### PR TITLE
fix: errors about visible and transform when setting 

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -860,7 +860,7 @@ export class Composition implements Disposable, LostHandler {
   }
 
   /**
-   * 设置合成在 3D 坐标轴上的位移
+   * 设置合成在 3D 坐标轴上相对原点的位移
    */
   setPosition (x: number, y: number, z: number) {
     this.content.setPosition(x, y, z);
@@ -874,7 +874,7 @@ export class Composition implements Disposable, LostHandler {
   }
 
   /**
-   * 设置合成在 3D 坐标轴上的旋转（角度）
+   * 设置合成在 3D 坐标轴上的相对原点的旋转（角度）
    */
   setRotation (x: number, y: number, z: number) {
     this.content.setRotation(x, y, z);

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -15,7 +15,7 @@ import type { Texture } from './texture';
 import { TextureSourceType } from './texture';
 import { RenderFrame } from './render';
 import { Camera } from './camera';
-import { setRayFromCamera, intersectRayTriangle, intersectRayBox, intersectRaySphere, quatFromRotation } from './math';
+import { setRayFromCamera, intersectRayTriangle, intersectRayBox, intersectRaySphere } from './math';
 import { HitTestType } from './plugins';
 import type { Region } from './plugins';
 import { CompositionSourceManager } from './composition-source-manager';

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -853,22 +853,44 @@ export class Composition implements Disposable, LostHandler {
   }
 
   /**
-   * 设置合成在 3D 坐标轴上相对移动
+   * 设置合成在 3D 坐标轴上相对当前的位移
    */
   translate (x: number, y: number, z: number) {
     this.content.translate(x, y, z);
   }
+
   /**
-   * 设置合成在 3D 坐标轴上相对旋转（角度）
+   * 设置合成在 3D 坐标轴上的位移
+   */
+  setPosition (x: number, y: number, z: number) {
+    this.content.setPosition(x, y, z);
+  }
+
+  /**
+   * 设置合成在 3D 坐标轴上相对当前的旋转（角度）
    */
   rotate (x: number, y: number, z: number) {
     this.content.rotate(x, y, z);
   }
+
   /**
-   * 设置合成在 3D 坐标轴上相对缩放
+   * 设置合成在 3D 坐标轴上的旋转（角度）
+   */
+  setRotation (x: number, y: number, z: number) {
+    this.content.setRotation(x, y, z);
+  }
+  /**
+   * 设置合成在 3D 坐标轴上相对当前的缩放
    */
   scale (x: number, y: number, z: number) {
     this.content.scale(x, y, z);
+  }
+
+  /**
+   * 设置合成在 3D 坐标轴上的缩放
+   */
+  setScale (x: number, y: number, z: number) {
+    this.content.setScale(x, y, z);
   }
 
   /**

--- a/packages/effects-core/src/plugins/cal/calculate-item.ts
+++ b/packages/effects-core/src/plugins/cal/calculate-item.ts
@@ -94,7 +94,7 @@ export class CalculateItem {
   private _velocity: spec.vec3;
   constructor (
     props: spec.NullContent,
-    vfxItem: VFXItem<VFXItemContent>,
+    protected vfxItem: VFXItem<VFXItemContent>,
   ) {
     this.transform = vfxItem.transform;
     const scale = this.transform.scale;

--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -476,7 +476,7 @@ export class ParticleSystem {
     }
     this.meshes = meshes;
     this.reusable = vfxItem.reusable;
-    this.setVisible(vfxItem.getVisible());
+    this.setVisible(vfxItem.contentVisible);
     const interaction = props.interaction;
 
     if (interaction) {

--- a/packages/effects-core/src/plugins/particle/particle-vfx-item.ts
+++ b/packages/effects-core/src/plugins/particle/particle-vfx-item.ts
@@ -55,9 +55,9 @@ export class ParticleVFXItem extends VFXItem<ParticleSystem> {
         }
       }
       if (hide) {
-        this.content.setVisible(true);
-      } else {
         this.content.setVisible(false);
+      } else {
+        this.content.setVisible(true);
         this.content.onUpdate(dt);
       }
 

--- a/packages/effects-core/src/plugins/sprite/sprite-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-item.ts
@@ -294,7 +294,7 @@ export class SpriteItem extends CalculateItem {
     } else if (init) {
       ret.texOffset = [0, 0, 1, 1];
     }
-    ret.visible = this.visible;
+    ret.visible = this.vfxItem.contentVisible;
     // 图层元素作为父节点时，除了k的大小变换，自身的尺寸也需要传递给子元素，子元素可以通过startSize读取
     ret.startSize = this.startSize;
 

--- a/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
@@ -91,7 +91,7 @@ export class SpriteMesh {
     let pointCount = 0;
 
     if (!items.length) {
-      this.mesh.setVisible(true);
+      this.mesh.setVisible(false);
 
       return true;
     }
@@ -157,7 +157,7 @@ export class SpriteMesh {
     geometry.setIndexData(indexData);
     geometry.setAttributeData('aPoint', bundle.aPoint);
     geometry.setDrawCount(indexLen);
-    this.mesh.setVisible(!geometry.getDrawCount());
+    this.mesh.setVisible(!!geometry.getDrawCount());
     this.mesh.priority = items[0].listIndex;
     for (let i = 0; i < textures.length; i++) {
       const texture = textures[i];

--- a/packages/effects-core/src/plugins/sprite/sprite-vfx-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-vfx-item.ts
@@ -25,21 +25,13 @@ export class SpriteVFXItem extends VFXItem<SpriteItem> {
   }
 
   override onLifetimeBegin (composition: Composition, content: SpriteItem) {
-    this._contentVisible = true;
     content.active = true;
   }
 
   override onItemRemoved (composition: Composition, content?: SpriteItem) {
-    this._contentVisible = false;
     if (content) {
       delete content.mesh;
       composition.destroyTextures(content.getTextures());
-    }
-  }
-
-  override handleVisibleChanged (visible: boolean) {
-    if (this.content) {
-      this.content.visible = visible;
     }
   }
 

--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -1,5 +1,4 @@
 import * as spec from '@galacean/effects-specification';
-import type { TextureDataType } from '../../texture';
 import { Texture } from '../../texture';
 import { TextMesh } from './text-mesh';
 import type { TextVFXItem } from './text-vfx-item';
@@ -68,7 +67,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置字号大小
-   * @param value 字号
+   * @param value - 字号
    * @returns
    */
   setFontSize (value: number): void {
@@ -84,7 +83,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置字重
-   * @param value 字重类型
+   * @param value - 字重类型
    * @returns
    */
   setFontWeight (value: spec.TextWeight): void {
@@ -110,7 +109,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置文本
-   * @param value 文本内容
+   * @param value - 文本内容
    * @returns
    */
   setText (value: string): void {
@@ -123,7 +122,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置文本水平布局
-   * @param value 布局选项
+   * @param value - 布局选项
    * @returns
    */
   setTextAlign (value: spec.TextAlignment): void {
@@ -136,7 +135,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置文本垂直布局
-   * @param value 布局选项
+   * @param value - 布局选项
    * @returns
    */
   setTextBaseline (value: spec.TextBaseline): void {
@@ -149,7 +148,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置文本颜色
-   * @param value 颜色内容
+   * @param value - 颜色内容
    * @returns
    */
   setTextColor (value: spec.RGBAColorValue): void {
@@ -162,7 +161,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置文本字体
-   * @param value 文本字体
+   * @param value - 文本字体
    * @returns
    */
   setFontFamily (value: string): void {
@@ -175,7 +174,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置外描边文本颜色
-   * @param value 颜色内容
+   * @param value - 颜色内容
    * @returns
    */
   setOutlineColor (value: spec.RGBAColorValue): void {
@@ -188,7 +187,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置外描边文本宽度
-   * @param value 外描边宽度
+   * @param value - 外描边宽度
    * @returns
    */
   setOutlineWidth (value: number): void {
@@ -201,7 +200,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置阴影模糊
-   * @param value 阴影模糊强度
+   * @param value - 阴影模糊强度
    * @returns
    */
   setShadowBlur (value: number): void {
@@ -214,7 +213,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置阴影颜色
-   * @param value 阴影颜色
+   * @param value - 阴影颜色
    * @returns
    */
   setShadowColor (value: spec.RGBAColorValue): void {
@@ -227,7 +226,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置阴影水平偏移距离
-   * @param value 水平偏移距离
+   * @param value - 水平偏移距离
    * @returns
    */
   setShadowOffsetX (value: number): void {
@@ -240,7 +239,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置阴影水平偏移距离
-   * @param value 水平偏移距离
+   * @param value - 水平偏移距离
    * @returns
    */
   setShadowOffsetY (value: number): void {
@@ -253,7 +252,7 @@ export class TextItem extends SpriteItem {
 
   /**
    * 设置字体清晰度
-   * @param value 字体清晰度
+   * @param value - 字体清晰度
    * @returns
    */
   setFontScale (value: number): void {
@@ -434,5 +433,4 @@ export class TextItem extends SpriteItem {
     context!.shadowOffsetX = style.shadowOffsetX ;
     context!.shadowOffsetY = -style.shadowOffsetY ;
   }
-
 }

--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -64,8 +64,6 @@ export class TextItem extends SpriteItem {
 
     // Text
     this.mesh = new TextMesh(this.engine, this.renderInfo, vfxItem.composition) as unknown as SpriteMesh;
-    this.mesh.setItems([this]);
-    this.updateTexture();
   }
 
   /**
@@ -286,7 +284,7 @@ export class TextItem extends SpriteItem {
     const fontSize = style.fontSize * fontScale;
     const lineHeight = layout.lineHeight * fontScale;
 
-    this.char = this.text.split('');
+    this.char = (this.text || '').split('');
 
     this.canvas.width = width ;
     this.canvas.height = height;

--- a/packages/effects-core/src/plugins/text/text-loader.ts
+++ b/packages/effects-core/src/plugins/text/text-loader.ts
@@ -10,7 +10,7 @@ export class TextLoader extends AbstractPlugin {
   override name = 'text';
   addItems: TextVFXItem[] = [];
   removeItems: TextVFXItem[] = [];
-  public readonly meshes: Mesh[] = []; // meshSplits对应的mesh数组 每次diff后更新
+  public readonly meshes: Mesh[] = [];
 
   override onCompositionDestroyed (composition: Composition) {
     if (composition.reusable) {
@@ -26,11 +26,18 @@ export class TextLoader extends AbstractPlugin {
 
   override onCompositionUpdate (composition: Composition, dt: number): void {
     this.addItems.forEach(item => {
+      if (!item.contentVisible) {
+        item.content.mesh?.mesh.setVisible(false);
+
+        return;
+      } else {
+        item.content.mesh?.mesh.setVisible(true);
+      }
       item.content.updateTexture();
       if (!item.content.ended && item.content.mesh) {
         item.content.mesh.updateItem(item.content);
+        item.content.mesh?.applyChange();
       }
-      item.content.mesh?.applyChange();
     });
   }
 

--- a/packages/effects-core/src/plugins/text/text-loader.ts
+++ b/packages/effects-core/src/plugins/text/text-loader.ts
@@ -57,6 +57,7 @@ export class TextLoader extends AbstractPlugin {
   }
 
   override onCompositionItemRemoved (composition: Composition, item: VFXItem<TextItem>) {
+    // FIXME: 此处判断有问题，item 应该先判断
     if (item instanceof TextVFXItem && item) {
       addItem(this.removeItems, item);
       if (this.addItems.includes(item)) {
@@ -76,7 +77,6 @@ export class TextLoader extends AbstractPlugin {
         removeItem(this.addItems, item);
         item.content.mesh.mesh.dispose({ material: { textures: DestroyOptions.keep } });
         item.dispose();
-
       }
     });
 

--- a/packages/effects-core/src/plugins/text/text-vfx-item.ts
+++ b/packages/effects-core/src/plugins/text/text-vfx-item.ts
@@ -23,27 +23,22 @@ export class TextVFXItem extends VFXItem<TextItem> {
   }
 
   override onLifetimeBegin (composition: Composition, content: TextItem) {
-    this._contentVisible = true;
     content.active = true;
-
+    this.content?.mesh!.setItems([this.content]);
+    this.content.updateTexture();
   }
 
   override onItemRemoved (composition: Composition, content?: TextItem) {
-    this._contentVisible = false;
-
     if (content) {
       delete content.mesh;
       composition.destroyTextures(content.getTextures());
     }
   }
 
-  override handleVisibleChanged (visible: boolean) {
-    if (this.content) {
-      this.content.visible = visible;
-    }
-  }
-
   override onItemUpdate (dt: number, lifetime: number) {
+    if (!this.content) {
+      return ;
+    }
     this.content?.updateTime(this.time);
   }
 
@@ -112,6 +107,7 @@ export class TextVFXItem extends VFXItem<TextItem> {
   createWireframeMesh (item: TextItem, color: spec.vec4): TextMesh {
     const spMesh = new TextMesh(this.composition.getEngine(), { wireframe: true, ...item.renderInfo }, this.composition);
 
+    spMesh.mesh.setVisible(true);
     spMesh.setItems([item]);
     spMesh.mesh.material.setVector3('uFrameColor', [color[0], color[1], color[2]]);
     spMesh.mesh.priority = 999;

--- a/packages/effects-core/src/render/mesh.ts
+++ b/packages/effects-core/src/render/mesh.ts
@@ -54,7 +54,7 @@ export class Mesh implements Disposable {
 
   // 各引擎独立实现 priority，重写 getter/setter
   private _priority: number;
-  private visible = false;
+  private visible = true;
 
   /**
    * 创建一个新的 Mesh 对象。

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -30,7 +30,7 @@ export type VFXItemProps =
   }
   ;
 
-/**
+/*
  * 所有元素的继承的抽象类
  */
 export abstract class VFXItem<T extends VFXItemContent> implements Disposable {
@@ -324,6 +324,7 @@ export abstract class VFXItem<T extends VFXItemContent> implements Disposable {
 
         this.transform.setValid(true);
         this.createContent();
+        this._contentVisible = true;
         this.onLifetimeBegin(this.composition, this.content);
         this.composition.itemLifetimeEvent(this, true);
       }
@@ -366,7 +367,7 @@ export abstract class VFXItem<T extends VFXItemContent> implements Disposable {
                 this.endBehavior = spec.END_BEHAVIOR_FORWARD;
               }
             } else if (this.endBehavior === spec.END_BEHAVIOR_DESTROY) {
-              this.setVisible(false);
+              this._contentVisible = false;
             }
             lifetime = Math.min(lifetime, 1);
           } else {
@@ -618,6 +619,7 @@ export abstract class VFXItem<T extends VFXItemContent> implements Disposable {
     if (this.composition) {
       this.onItemRemoved(this.composition, this._content);
       this._content = undefined;
+      this._contentVisible = false;
     }
     this.started = false;
   }

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -30,7 +30,7 @@ export type VFXItemProps =
   }
   ;
 
-/*
+/**
  * 所有元素的继承的抽象类
  */
 export abstract class VFXItem<T extends VFXItemContent> implements Disposable {

--- a/packages/effects-threejs/src/three-mesh.ts
+++ b/packages/effects-threejs/src/three-mesh.ts
@@ -70,7 +70,7 @@ export class ThreeMesh extends Mesh implements Sortable {
    * @param val - 可见性开关
    */
   override setVisible (val: boolean): void {
-    this.mesh.visible = !val;
+    this.mesh.visible = val;
   }
 
   /**
@@ -79,7 +79,7 @@ export class ThreeMesh extends Mesh implements Sortable {
    * @returns
    */
   override getVisible (): boolean {
-    return !this.mesh.visible;
+    return this.mesh.visible;
   }
 
   /**

--- a/packages/effects-webgl/src/gl-renderer.ts
+++ b/packages/effects-webgl/src/gl-renderer.ts
@@ -144,7 +144,7 @@ export class GLRenderer extends Renderer implements Disposable {
         // console.error(`mesh ${mesh.name} destroyed`, mesh);
         continue;
       }
-      if (mesh.getVisible()) {
+      if (!mesh.getVisible()) {
         continue;
       }
       if (!mesh.material) {

--- a/plugin-packages/spine/src/spine-loader.ts
+++ b/plugin-packages/spine/src/spine-loader.ts
@@ -189,7 +189,7 @@ export class SpineLoader extends AbstractPlugin {
     this.slotGroups.length && this.slotGroups.map(slotGroup => {
       if (slotGroup) {
         slotGroup.meshToAdd.forEach(mesh => {
-          renderFrame.addMeshToDefaultRenderPass(mesh);
+          mesh.getVisible() && renderFrame.addMeshToDefaultRenderPass(mesh);
         });
         slotGroup.resetMeshes();
       }

--- a/plugin-packages/spine/src/spine-vfx-item.ts
+++ b/plugin-packages/spine/src/spine-vfx-item.ts
@@ -146,19 +146,21 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
   }
 
   override onItemUpdate (dt: number, lifetime: number) {
-    if (lifetime < 0) {
-      // 还未开始 隐藏一下
-      this.setVisible(false);
-
-      return;
+    if (!this.content || !this.content.meshGroups.length) {
+      return ;
     }
-    this.setVisible(true);
-    this.updateState(dt / 1000);
+    const visible = this.contentVisible;
+
+    this.content.meshGroups.map((mesh: SpineMesh) => {
+      mesh.mesh.setVisible(visible);
+    });
+    if (visible) {
+      this.updateState(dt / 1000);
+    }
   }
 
   override onEnd () {
-    if (this.endBehavior === spec.END_BEHAVIOR_DESTROY) {
-      this.setVisible(false);
+    if (this.endBehavior === spec.END_BEHAVIOR_DESTROY && this.state) {
       this.state.clearListeners();
       this.state.clearTracks();
     }

--- a/plugin-packages/spine/src/spine-vfx-item.ts
+++ b/plugin-packages/spine/src/spine-vfx-item.ts
@@ -383,6 +383,12 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
     this.transform.setScale(this.startSize * scaleFactor, this.startSize * scaleFactor, scale[2]);
   }
 
+  override setScale (x: number, y: number, z: number) {
+    const [sx, sy, sz] = this.transform.scale;
+
+    this.transform.setScale(x * sx, y * sy, z * sz);
+  }
+
   getBounds (): BoundsData | undefined {
     if (!(this.state && this.skeleton && this.contentVisible)) {
       return;

--- a/plugin-packages/spine/src/spine-vfx-item.ts
+++ b/plugin-packages/spine/src/spine-vfx-item.ts
@@ -141,7 +141,6 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
     }
     this.state.apply(this.skeleton);
     this.resize();
-    this._contentVisible = true;
     this.updateState(0);
   }
 
@@ -385,7 +384,7 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
   }
 
   getBounds (): BoundsData | undefined {
-    if (!(this.state && this.skeleton)) {
+    if (!(this.state && this.skeleton && this.contentVisible)) {
       return;
     }
     this.skeleton.updateWorldTransform();

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -3,14 +3,14 @@ import '@galacean/effects-plugin-spine';
 import '@galacean/effects-plugin-model';
 import inspireList from './assets/inspire-list';
 
-const json = inspireList.turnplate.url;
+const json = 'https://mdn.alipayobjects.com/mars/afts/file/A*fTq-S4h_nYMAAAAAAAAAAAAADlB4AQ';
 const container = document.getElementById('J-container');
 
 (async () => {
   try {
     const player = createPlayer();
 
-    const comp = await player.loadScene(json);
+    const comp = await player.loadScene('https://mdn.alipayobjects.com/mars/afts/file/A*fTq-S4h_nYMAAAAAAAAAAAAADlB4AQ');
 
   } catch (e) {
     console.error('biz', e);

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -9,7 +9,7 @@ const container = document.getElementById('J-container');
   try {
     const player = createPlayer();
 
-    const comp = await player.loadScene(json);
+    await player.loadScene(json);
 
   } catch (e) {
     console.error('biz', e);
@@ -29,7 +29,6 @@ function createPlayer () {
     onItemClicked: () => {
 
     },
-    // reportGPUTime: console.debug,
   });
 
   return player;

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -11,6 +11,10 @@ const container = document.getElementById('J-container');
     const player = createPlayer();
 
     const comp = await player.loadScene(json);
+    const item = comp.getItemByName('spine_483');
+
+    setTimeout(() => {
+    }, 1000);
 
   } catch (e) {
     console.error('biz', e);

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -3,14 +3,14 @@ import '@galacean/effects-plugin-spine';
 import '@galacean/effects-plugin-model';
 import inspireList from './assets/inspire-list';
 
-const json = 'https://mdn.alipayobjects.com/mars/afts/file/A*fTq-S4h_nYMAAAAAAAAAAAAADlB4AQ';
+const json = 'https://mdn.alipayobjects.com/mars/afts/file/A*vKGhS7H1ei8AAAAAAAAAAAAADlB4AQ';
 const container = document.getElementById('J-container');
 
 (async () => {
   try {
     const player = createPlayer();
 
-    const comp = await player.loadScene('https://mdn.alipayobjects.com/mars/afts/file/A*fTq-S4h_nYMAAAAAAAAAAAAADlB4AQ');
+    const comp = await player.loadScene(json);
 
   } catch (e) {
     console.error('biz', e);
@@ -22,7 +22,7 @@ function createPlayer () {
     container,
     interactive: true,
     // renderFramework: 'webgl',
-    env: 'editor',
+    // env: 'editor',
     notifyTouch: true,
     onPausedByItem: data => {
       console.info('onPausedByItem', data);

--- a/web-packages/test/unit/src/effects-core/composition/plugin.spec.ts
+++ b/web-packages/test/unit/src/effects-core/composition/plugin.spec.ts
@@ -283,22 +283,20 @@ describe('plugin', () => {
       reusable: true,
     });
 
-    player.gotoAndStop(1.4);
-
     const item = comp.getItemByName('t2');
 
-    expect(item).to.exist;
-    expect(item.reusable).to.be.true;
-    expect(item.visible).to.be.false;
-    expect(remove).not.to.has.been.called;
+    comp.gotoAndStop(0.3);
+    expect(item.contentVisible).to.be.true;
+
+    item.setVisible(false);
     expect(hide).to.has.been.called.with(false);
     expect(hide).to.has.been.called.once;
-    const sp2 = item.handleVisibleChanged = chai.spy('hide2');
 
-    comp.gotoAndStop(0.3);
-    expect(item.visible).to.be.true;
-    expect(sp2).to.has.been.called.with(true);
-    expect(sp2).to.has.been.called.once;
+    comp.gotoAndStop(1.4);
+    expect(item).to.exist;
+    expect(item.reusable).to.be.true;
+    expect(item.contentVisible).to.be.false;
+    expect(remove).not.to.has.been.called;
     comp.dispose();
   });
 


### PR DESCRIPTION
- fix: correct the mean of visible
- feat: add setRotation、setScale and setPosition method in class Composition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new methods for more intuitive 3D transformations: `setPosition`, `setRotation`, and `setScale`.
  - Added conditional visibility control for meshes in various plugins, enhancing the rendering logic.

- **Bug Fixes**
  - Corrected the visibility logic in `ThreeMesh` to directly reflect the provided values.
  - Fixed the conditional rendering flow in `GLRenderer` to proceed only when meshes are not visible.

- **Refactor**
  - Improved visibility handling in `ParticleVFXItem` and `SpriteVFXItem` by removing direct manipulation of visibility properties.
  - Streamlined the initialization process in `TextItem` by removing redundant texture updates.
  - Enhanced the `SpineVFXItem` class with a new `setScale` method and refined visibility checks.

- **Documentation**
  - Updated comments to reflect changes in visibility handling across various classes.

- **Style**
  - Adjusted code style for consistency in visibility-related methods across the codebase.

- **Tests**
  - Modified unit tests to align with the new visibility control logic and 3D transformation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->