### PR TITLE
build: add vite legacy polyfill

### DIFF
--- a/plugin-packages/alipay-downgrade/vite.config.js
+++ b/plugin-packages/alipay-downgrade/vite.config.js
@@ -36,6 +36,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       legacy({
         targets: ['iOS >= 9'],
+        modernPolyfills: ['es/global-this'],
       }),
       glslInner(),
       tsconfigPaths(),

--- a/plugin-packages/model/vite.config.js
+++ b/plugin-packages/model/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       legacy({
         targets: ['iOS >= 9'],
+        modernPolyfills: ['es/global-this'],
       }),
       glslInner(),
       tsconfigPaths(),

--- a/plugin-packages/orientation-transformer/vite.config.js
+++ b/plugin-packages/orientation-transformer/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       legacy({
         targets: ['iOS >= 9'],
+        modernPolyfills: ['es/global-this'],
       }),
       glslInner(),
       tsconfigPaths(),

--- a/plugin-packages/spine/vite.config.js
+++ b/plugin-packages/spine/vite.config.js
@@ -36,6 +36,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       legacy({
         targets: ['iOS >= 9'],
+        modernPolyfills: ['es/global-this'],
       }),
       glslInner(),
       tsconfigPaths(),


### PR DESCRIPTION
Where run the preview script for old device, vite will give the undefined of `globalThis` , so will include the polyfill when run `preview`.
More information: https://github.com/vitejs/vite/discussions/7915