### PR TITLE
refactor: handleEnd 改为 onEnd 并注释

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -48,7 +48,7 @@ export interface CompositionProps {
   renderer: Renderer,
   onPlayerPause?: (item: VFXItem<any>) => void,
   onMessageItem?: (item: MessageItem) => void,
-  handleEnd?: (composition: Composition) => void,
+  onEnd?: (composition: Composition) => void,
   event?: EventSystem,
   width: number,
   height: number,
@@ -207,7 +207,7 @@ export class Composition implements Disposable, LostHandler {
       reusable = false,
       speed = 1,
       baseRenderOrder = 0, renderer,
-      onPlayerPause, onMessageItem, handleEnd,
+      onPlayerPause, onMessageItem, onEnd,
       event, width, height,
     } = props;
 
@@ -257,7 +257,7 @@ export class Composition implements Disposable, LostHandler {
     this.assigned = true;
     this.onPlayerPause = onPlayerPause;
     this.onMessageItem = onMessageItem;
-    this.onEnd = handleEnd;
+    this.onEnd = onEnd;
     this.createRenderFrame();
     this.reset();
   }

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -268,6 +268,7 @@ export class Composition implements Disposable, LostHandler {
    * @deprecated since 2.0 - use `onEnd` instead
    */
   set handleEnd (func: (composition: Composition) => void) {
+    console.warn('The handleEnd property is deprecated. Use onEnd instead.');
     this.onEnd = func;
   }
 

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -105,7 +105,7 @@ export class Composition implements Disposable, LostHandler {
   /**
    * 单个合成结束时的回调
    */
-  handleEnd?: (composition: Composition) => void;
+  onEnd?: (composition: Composition) => void;
   /**
    * 合成id
    */
@@ -253,9 +253,18 @@ export class Composition implements Disposable, LostHandler {
     this.assigned = true;
     this.handlePlayerPause = handlePlayerPause;
     this.handleMessageItem = handleMessageItem;
-    this.handleEnd = handleEnd;
+    this.onEnd = handleEnd;
     this.createRenderFrame();
     this.reset();
+  }
+
+  /**
+   * 合成结束回调
+   * @param {(composition: Composition) => void} func
+   * @deprecated since 2.0 - use `onEnd` instead
+   */
+  set handleEnd (func: (composition: Composition) => void) {
+    this.onEnd = func;
   }
 
   /**
@@ -435,7 +444,7 @@ export class Composition implements Disposable, LostHandler {
     this.content.createContent();
     this.content.onEnd = () => {
       window.setTimeout(() => {
-        this.handleEnd?.(this);
+        this.onEnd?.(this);
       }, 0);
     };
     this.pluginSystem.resetComposition(this, this.renderFrame);

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -383,7 +383,7 @@ export abstract class VFXItem<T extends VFXItemContent> implements Disposable {
               this.endBehavior === spec.END_BEHAVIOR_PAUSE ||
               this.endBehavior === spec.END_BEHAVIOR_PAUSE_AND_DESTROY
             ) {
-              this.composition.handlePlayerPause?.(this);
+              this.composition.onPlayerPause?.(this);
             } else if (this.endBehavior === spec.END_BEHAVIOR_FREEZE) {
               this.transform.setValid(true);
               shouldUpdate = true;
@@ -571,7 +571,7 @@ export abstract class VFXItem<T extends VFXItemContent> implements Disposable {
   }
 
   /**
-   * 设置元素的在画布上的像素位置
+   * 设置元素的在画布上的像素位置, 坐标原点在 canvas 中心，x 正方向水平向右， y 正方向垂直向下
    */
   setPositionByPixel (x: number, y: number) {
     if (this.composition) {

--- a/packages/effects-threejs/src/three-composition.ts
+++ b/packages/effects-threejs/src/three-composition.ts
@@ -37,21 +37,21 @@ export interface CompositionBaseProps {
    * @param composition - composition 对象
    * @returns
    */
-  handleEnd?: (composition: Composition) => void,
+  onEnd?: (composition: Composition) => void,
   /**
    * 交互元素监听函数
    *
    * @param item
    * @returns
    */
-  handleMessageItem?: (item: MessageItem) => void,
+  onMessageItem?: (item: MessageItem) => void,
   /**
    * player 暂停监听函授
    *
    * @param item
    * @returns
    */
-  handlePlayerPause?: (item: VFXItem<VFXItemContent>) => void,
+  onPlayerPause?: (item: VFXItem<VFXItemContent>) => void,
 }
 
 export interface ThreeCompositionProps extends CompositionBaseProps {

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -176,8 +176,8 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
   private readonly event: EventSystem;
   private readonly handleWebGLContextLost?: (event: Event) => void;
   private readonly handleWebGLContextRestored?: () => void;
-  private readonly handleMessageItem?: (item: MessageItem) => void;
-  private readonly handlePlayerPause?: (item: VFXItem<VFXItemContent>) => void;
+  private readonly onMessageItem?: (item: MessageItem) => void;
+  private readonly onPlayerPause?: (item: VFXItem<VFXItemContent>) => void;
   private readonly reportGPUTime?: (time: number) => void;
   private readonly handleItemClicked?: (event: any) => void;
   private readonly handlePlayableUpdate?: (event: { playing: boolean, player: Player }) => void;
@@ -229,10 +229,10 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
     this.handleWebGLContextRestored = onWebGLContextRestored;
     this.reportGPUTime = reportGPUTime;
     this.handleItemClicked = onItemClicked;
-    this.handleMessageItem = onMessageItem;
+    this.onMessageItem = onMessageItem;
     this.handlePlayableUpdate = onPlayableUpdate;
     this.handleRenderError = onRenderError;
-    this.handlePlayerPause = (item: VFXItem<VFXItemContent>) => {
+    this.onPlayerPause = (item: VFXItem<VFXItemContent>) => {
       this.pause();
       onPausedByItem?.({
         name: item.name,
@@ -439,8 +439,8 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
       width: renderer.getWidth(),
       height: renderer.getHeight(),
       event: this.event,
-      handlePlayerPause: this.handlePlayerPause,
-      handleMessageItem: this.handleMessageItem,
+      onPlayerPause: this.onPlayerPause,
+      onMessageItem: this.onMessageItem,
     }, scene);
 
     if (this.ticker) {

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -176,8 +176,8 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
   private readonly event: EventSystem;
   private readonly handleWebGLContextLost?: (event: Event) => void;
   private readonly handleWebGLContextRestored?: () => void;
-  private readonly onMessageItem?: (item: MessageItem) => void;
-  private readonly onPlayerPause?: (item: VFXItem<VFXItemContent>) => void;
+  private readonly handleMessageItem?: (item: MessageItem) => void;
+  private readonly handlePlayerPause?: (item: VFXItem<VFXItemContent>) => void;
   private readonly reportGPUTime?: (time: number) => void;
   private readonly handleItemClicked?: (event: any) => void;
   private readonly handlePlayableUpdate?: (event: { playing: boolean, player: Player }) => void;
@@ -229,10 +229,10 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
     this.handleWebGLContextRestored = onWebGLContextRestored;
     this.reportGPUTime = reportGPUTime;
     this.handleItemClicked = onItemClicked;
-    this.onMessageItem = onMessageItem;
+    this.handleMessageItem = onMessageItem;
     this.handlePlayableUpdate = onPlayableUpdate;
     this.handleRenderError = onRenderError;
-    this.onPlayerPause = (item: VFXItem<VFXItemContent>) => {
+    this.handlePlayerPause = (item: VFXItem<VFXItemContent>) => {
       this.pause();
       onPausedByItem?.({
         name: item.name,
@@ -439,8 +439,8 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
       width: renderer.getWidth(),
       height: renderer.getHeight(),
       event: this.event,
-      onPlayerPause: this.onPlayerPause,
-      onMessageItem: this.onMessageItem,
+      onPlayerPause: this.handlePlayerPause,
+      onMessageItem: this.handleMessageItem,
     }, scene);
 
     if (this.ticker) {
@@ -539,9 +539,9 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
   playSequence (compositions: Composition[]): void {
     for (let i = 0; i < compositions.length - 1; i++) {
       const composition = compositions[i];
-      const preEndHandler = composition.handleEnd;
+      const preEndHandler = composition.onEnd;
 
-      composition.handleEnd = () => {
+      composition.onEnd = () => {
         preEndHandler?.call(composition, composition);
         compositions[i + 1].play();
       };

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -3,14 +3,18 @@ import '@galacean/effects-plugin-spine';
 import '@galacean/effects-plugin-model';
 import inspireList from './assets/inspire-list';
 
-const json = 'https://mdn.alipayobjects.com/mars/afts/file/A*3mT3SJ4KGKYAAAAAAAAAAAAADlB4AQ';
+const json = 'https://mdn.alipayobjects.com/mars/afts/file/A*88uxRq5GA4sAAAAAAAAAAAAADlB4AQ';
 const container = document.getElementById('J-container');
 
 (async () => {
   try {
     const player = createPlayer();
 
-    await player.loadScene(json);
+    const comp = await player.loadScene(json, {
+      autoplay: false,
+    });
+
+    player.play();
   } catch (e) {
     console.error('biz', e);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed event handler properties in the composition logic for clarity and consistency.

- **New Features**
  - Added additional control over scene playback with a new configuration option to disable autoplay.

- **Documentation**
  - Marked the `handleEnd` method as deprecated; users should transition to using `onEnd`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->