### PR TITLE
fix: 去除多余的 WebGL 版本不一致警告

### DIFF
--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -261,13 +261,6 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
       container.appendChild(this.canvas);
     }
 
-    // 不允许同时存在WebGL和WebGL2的Player
-    playerMap.forEach(player => {
-      if (player.gpuCapability.type !== framework) {
-        throw new Error(`Initialize player with different webgl version: old=${player.gpuCapability.type}, new=${framework}`);
-      }
-    });
-
     this.renderer = Renderer.create(
       this.canvas,
       framework,


### PR DESCRIPTION
WebGL 版本不一致警告在 Renderer 创建后已经有检查，前置检查可以去除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the graphics rendering process by removing the restriction on WebGL version types for players.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->