### PR TITLE
docs: changelog 1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 - Major version release is not included in this schedule for breaking change and new features.
 
 ---
+## 1.1.8
+
+`2024-01-26`
+
+- Fix: windows shader compile problem and update case test player version. [#141](https://github.com/galacean/effects-runtime/pull/141) @liuxi150
+- Fix: Fixed memory leak in Spine elements during composition replay. [#116](https://github.com/galacean/effects-runtime/pull/116) @RGCHN
+- Fix: Removed unnecessary WebGL version mismatch warning. [#115](https://github.com/galacean/effects-runtime/pull/115) @liuxi150
+- Test: Fixed pre-composition order unit test. [#140](https://github.com/galacean/effects-runtime/pull/140) @RGCHN
+- Style: Optimized error messages for image loading. [#143](https://github.com/galacean/effects-runtime/pull/143) @RGCHN
+
 ## 1.1.7
 
 `2024-01-22`

--- a/packages/effects-core/package.json
+++ b/packages/effects-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-core",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects runtime core for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/packages/effects-helper/package.json
+++ b/packages/effects-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-helper",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects runtime helper for the web",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/effects-threejs/package.json
+++ b/packages/effects-threejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-threejs",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects runtime threejs plugin for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/packages/effects-webgl/package.json
+++ b/packages/effects-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-webgl",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects runtime webgl for the web",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects runtime player for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/alipay-downgrade/package.json
+++ b/plugin-packages/alipay-downgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-alipay-downgrade",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects player downgrade plugin for Alipay",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/editor-gizmo/package.json
+++ b/plugin-packages/editor-gizmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-editor-gizmo",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects player editor gizmo plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/model/package.json
+++ b/plugin-packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-model",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects player model plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/orientation-transformer/package.json
+++ b/plugin-packages/orientation-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-orientation-transformer",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects player orientation transformer plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/spine/package.json
+++ b/plugin-packages/spine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-spine",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Galacean Effects player spine plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Addressed a Windows shader compilation issue.
	- Resolved a memory leak in Spine elements during composition replay.
	- Removed an unnecessary WebGL version mismatch warning.
	- Fixed a pre-composition order unit test.
- **Improvements**
	- Optimized error messages for image loading.
- **Version Updates**
	- Updated various `@galacean` packages and plugins from version 1.1.7 to 1.1.8, including core effects, helper utilities, Three.js integration, WebGL support, Alipay downgrade plugin, editor gizmo, model handling, orientation transformer, and Spine plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->