### PR TITLE
docs: add Native link

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -8,7 +8,7 @@
 ![GitHub License](https://img.shields.io/github/license/galacean/effects-runtime)
 ![GitHub top language](https://img.shields.io/github/languages/top/galacean/effects-runtime)
 
-[更新日志](./CHANGELOG.md) · [报告问题][github-issues-url] · [特性需求][github-issues-url] · [English](./README.md) · 中文
+[客户端版](https://github.com/galacean/effects-native) · [更新日志](./CHANGELOG.md) · [报告问题][github-issues-url] · [特性需求][github-issues-url] · [English](./README.md) · 中文
 
 ![](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It can load and render cool animation effects, The APIs provided by effects-core
 ![GitHub License](https://img.shields.io/github/license/galacean/effects-runtime)
 ![GitHub top language](https://img.shields.io/github/languages/top/galacean/effects-runtime)
 
-[Changelog](./CHANGELOG.md) · [Report Bug][github-issues-url] · [Request Feature][github-issues-url] · English · [中文](./README-zh_CN.md)
+[Native](https://github.com/galacean/effects-native) · [Changelog](./CHANGELOG.md) · [Report Bug][github-issues-url] · [Request Feature][github-issues-url] · English · [中文](./README-zh_CN.md)
 
 ![](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Changelog" link in the README to redirect users to the "Native" repository for more relevant information.
	- Modified the client version link in the README-zh_CN to point to the effects-native repository, enhancing navigation for Chinese-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->