### PR TITLE
fix: 修复 reusable 时消息元素结束无法触发的问题

### DIFF
--- a/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
+++ b/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
@@ -77,8 +77,13 @@ export class InteractVFXItem extends VFXItem<InteractItem> {
     }
   }
 
-  override onItemRemoved (composition: Composition) {
-    composition.removeInteractiveItem(this, this.ui.options.type);
+  override onEnd () {
+    if (this.composition) {
+      this.composition.removeInteractiveItem(this, this.ui.options.type);
+    }
+  }
+
+  override onItemRemoved () {
     this.clickable = false;
     this.previewContent?.mesh.dispose();
     this.endDragTarget();

--- a/web-packages/test/unit/src/effects-core/interact/interact.spec.ts
+++ b/web-packages/test/unit/src/effects-core/interact/interact.spec.ts
@@ -477,7 +477,38 @@ describe('interact item', () => {
       },
     ];
 
-    const scene = await generateScene(items, player);
+    await generateScene(items, player);
+
+    player.gotoAndPlay(0.1);
+    expect(messagePhrase).to.eql(spec.MESSAGE_ITEM_PHRASE_BEGIN, 'MESSAGE_ITEM_PHRASE_BEGIN');
+    player.gotoAndPlay(1.1);
+
+    expect(messagePhrase).to.eql(spec.MESSAGE_ITEM_PHRASE_END, 'MESSAGE_ITEM_PHRASE_END');
+
+  });
+
+  it('message item with reusable', async () => {
+    messagePhrase = undefined;
+    const items = [
+      {
+        'name': 'ui_11',
+        'delay': 0,
+        'id': 12,
+        'ui': {
+          'options': {
+            'duration': 1,
+            'type': 'message',
+            'width': 0.6,
+            'height': 0.4,
+            'showPreview': true,
+          },
+        },
+      },
+    ];
+
+    await generateScene(items, player, {
+      reusable: true,
+    });
 
     player.gotoAndPlay(0.1);
     expect(messagePhrase).to.eql(spec.MESSAGE_ITEM_PHRASE_BEGIN, 'MESSAGE_ITEM_PHRASE_BEGIN');
@@ -540,7 +571,7 @@ describe('interact item', () => {
   });
 });
 
-function generateScene (items, player) {
+function generateScene (items, player, options?) {
   const json = {
     'compositionId': 5,
     'requires': [],
@@ -584,7 +615,7 @@ function generateScene (items, player) {
     ],
   };
 
-  return player.createComposition(json);
+  return player.createComposition(json, options);
 }
 
 async function generateComposition (items, player, playerOptions) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of interactive items' lifecycle, including their removal and cleanup process.
- **Tests**
	- Enhanced testing for message item behaviors at specific playback times and their reusability in scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->