### PR TITLE
fix: 修复更新顺序导致的图层大小继承问题

### DIFF
--- a/packages/effects-core/src/plugins/sprite/sprite-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-item.ts
@@ -136,7 +136,6 @@ export class SpriteItem extends CalculateItem {
       this.basicTransform.position.add([-realAnchor[0] * scale.x, -realAnchor[1] * scale.y, 0]);
     }
     this.transform.setAnchor(realAnchor[0] * scale.x, realAnchor[1] * scale.y, 0);
-
     const colorOverLifetime = props.colorOverLifetime;
 
     if (colorOverLifetime) {
@@ -290,7 +289,6 @@ export class SpriteItem extends CalculateItem {
       ret.texOffset = [0, 0, 1, 1];
     }
     ret.visible = this.vfxItem.contentVisible;
-    // 图层元素作为父节点时，除了k的大小变换，自身的尺寸也需要传递给子元素，子元素可以通过startSize读取
     ret.startSize = this.startSize;
 
     return ret;

--- a/packages/effects-core/src/plugins/sprite/sprite-vfx-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-vfx-item.ts
@@ -109,8 +109,11 @@ export class SpriteVFXItem extends VFXItem<SpriteItem> {
 
   protected override doCreateContent (composition: Composition) {
     const { emptyTexture } = composition.getRendererOptions();
+    const content = new SpriteItem(this.sprite as SpriteItemProps, { emptyTexture }, this);
 
-    return new SpriteItem(this.sprite as SpriteItemProps, { emptyTexture }, this);
+    content.getRenderData(0, true);
+
+    return content;
   }
 
   createWireframeMesh (item: SpriteItem, color: spec.vec4): SpriteMesh {

--- a/web-packages/demo/src/assets/inspire-list.ts
+++ b/web-packages/demo/src/assets/inspire-list.ts
@@ -712,6 +712,11 @@ export default {
     name: '直接认父——图层',
     pass: true,
   },
+  parentSprite2: {
+    url: 'https://mdn.alipayobjects.com/mars/afts/file/A*enfjQrKbio8AAAAAAAAAAAAADlB4AQ',
+    name: '直接认父——图层2',
+    pass: true,
+  },
   parentParticle: {
     url: 'https://gw.alipayobjects.com/os/gltf-asset/92178974741421/particle.json',
     name: '直接认父——粒子',

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -3,14 +3,19 @@ import '@galacean/effects-plugin-spine';
 import '@galacean/effects-plugin-model';
 import inspireList from './assets/inspire-list';
 
-const json = inspireList.spring.url;
+const json = 'https://mdn.alipayobjects.com/mars/afts/file/A*enfjQrKbio8AAAAAAAAAAAAADlB4AQ';
+// inspireList.spring.url;
 const container = document.getElementById('J-container');
 
 (async () => {
   try {
     const player = createPlayer();
 
-    await player.loadScene(json);
+    const comp = await player.loadScene(json);
+
+    player.gotoAndStop(0.5);
+    const item = comp.getItemByName('盖子');
+
   } catch (e) {
     console.error('biz', e);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new sprite layer `parentSprite2` to the asset list in the demo.
	- Updated scene loading with new operations, including stopping at a specific frame and item retrieval by name.

- **Refactor**
	- Enhanced sprite item creation in `SpriteVFXItem` with additional rendering data processing.

- **Chores**
	- Removed unused code related to size information passing in sprite items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->