### PR TITLE
fix: fix vfxItem priority setting

### DIFF
--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -530,6 +530,7 @@ export class VFXItem extends EffectsObject implements Disposable {
         }
       }
     }
+    // renderOrder 在 component 初始化后设置。确保能拿到 rendererComponent。
     this.renderOrder = listIndex;
   }
 

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -507,7 +507,6 @@ export class VFXItem extends EffectsObject implements Disposable {
     this.parentId = parentId;
     this.duration = duration;
     this.endBehavior = endBehavior;
-    this.renderOrder = listIndex;
     //@ts-expect-error
     this.oldId = data.oldId;
 
@@ -531,6 +530,7 @@ export class VFXItem extends EffectsObject implements Disposable {
         }
       }
     }
+    this.renderOrder = listIndex;
   }
 
   override toData (): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the initialization process of visual effects by moving the `renderOrder` assignment from the constructor to the `initialize` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->