### PR TITLE
build: 统一 glsl 导入方式为 include，优化部分 glsl

### DIFF
--- a/packages/effects-core/src/material/utils.ts
+++ b/packages/effects-core/src/material/utils.ts
@@ -1,6 +1,6 @@
 import * as spec from '@galacean/effects-specification';
 import { glContext } from '../gl';
-import type { ShaderMarcos } from '../render';
+import type { ShaderMacros } from '../render';
 import type { Material } from './material';
 import { ShaderType } from './types';
 
@@ -47,19 +47,19 @@ const downgradeKeywords: Record<string, Record<string, string>> = {
 
 /**
  * 生成 shader，检测到 WebGL1 上下文会降级
- * @param marcos - 宏定义数组
+ * @param macros - 宏定义数组
  * @param shader - 原始 shader 文本
  * @param shaderType - shader 类型
  * @return 去除版本号的 shader 文本
  */
-export function createShaderWithMarcos (marcos: ShaderMarcos, shader: string, shaderType: ShaderType, level: number): string {
+export function createShaderWithMacros (macros: ShaderMacros, shader: string, shaderType: ShaderType, level: number): string {
   const ret: string[] = [];
   let header = '';
 
   // shader 标志宏，没有其他含义，方便不支持完全的自定义 shader 的三方引擎接入使用
   ret.push('#define GE_RUNTIME');
-  if (marcos) {
-    marcos.forEach(([key, value]) => {
+  if (macros) {
+    macros.forEach(([key, value]) => {
       if (value === true) {
         ret.push(`#define ${key}`);
       } else if (Number.isFinite(value)) {

--- a/packages/effects-core/src/plugins/interact/interact-mesh.ts
+++ b/packages/effects-core/src/plugins/interact/interact-mesh.ts
@@ -6,7 +6,7 @@ import { glContext } from '../../gl';
 import type { MaterialProps } from '../../material';
 import { Material } from '../../material';
 import { createValueGetter } from '../../math';
-import type { MeshRendererOptions } from '../../render';
+import type { MeshRendererOptions, ShaderMarcos } from '../../render';
 import { GLSLVersion, Geometry, Mesh } from '../../render';
 import type { Transform } from '../../transform';
 
@@ -100,7 +100,7 @@ export class InteractMesh {
   }
 
   private createMaterial (rendererOptions: MeshRendererOptions): Material {
-    const marcos: [key: string, value: boolean | number][] = [
+    const marcos: ShaderMarcos = [
       ['ENV_EDITOR', this.engine.renderer?.env === PLAYER_OPTIONS_ENV_EDITOR],
     ];
     const color = createValueGetter(this.color).getValue(0);

--- a/packages/effects-core/src/plugins/interact/interact-mesh.ts
+++ b/packages/effects-core/src/plugins/interact/interact-mesh.ts
@@ -6,7 +6,7 @@ import { glContext } from '../../gl';
 import type { MaterialProps } from '../../material';
 import { Material } from '../../material';
 import { createValueGetter } from '../../math';
-import type { MeshRendererOptions, ShaderMarcos } from '../../render';
+import type { MeshRendererOptions, ShaderMacros } from '../../render';
 import { GLSLVersion, Geometry, Mesh } from '../../render';
 import type { Transform } from '../../transform';
 
@@ -100,7 +100,7 @@ export class InteractMesh {
   }
 
   private createMaterial (rendererOptions: MeshRendererOptions): Material {
-    const marcos: ShaderMarcos = [
+    const macros: ShaderMacros = [
       ['ENV_EDITOR', this.engine.renderer?.env === PLAYER_OPTIONS_ENV_EDITOR],
     ];
     const color = createValueGetter(this.color).getValue(0);
@@ -110,7 +110,7 @@ export class InteractMesh {
         fragment,
         glslVersion: GLSLVersion.GLSL1,
         cacheId: `${rendererOptions.cachePrefix}_effects_interact`,
-        marcos,
+        macros,
       },
       uniformSemantics: {
         effects_MatrixVP: 'VIEWPROJECTION',

--- a/packages/effects-core/src/plugins/particle/particle-loader.ts
+++ b/packages/effects-core/src/plugins/particle/particle-loader.ts
@@ -1,6 +1,6 @@
 import type * as spec from '@galacean/effects-specification';
 import type { Engine } from '../../engine';
-import { createShaderWithMarcos, ShaderType } from '../../material';
+import { createShaderWithMacros, ShaderType } from '../../material';
 import type { Renderer, SharedShaderWithSource } from '../../render';
 import { GLSLVersion } from '../../render';
 import { Item } from '../../vfx-item';
@@ -32,7 +32,7 @@ export class ParticleLoader extends AbstractPlugin {
     });
 
     items.forEach(item => {
-      const { shader, fragment, vertex } = getParticleMeshShader(item, env, gpuCapability);
+      const { shader, fragment, vertex } = getParticleMeshShader(item, gpuCapability, env);
 
       shaders.push(shader);
       maxFragmentCount = Math.max(maxFragmentCount, fragment);
@@ -40,10 +40,10 @@ export class ParticleLoader extends AbstractPlugin {
 
       // TODO 此处add是否有意义？shader变量似乎没有加到this.shaders数组。
       if (item.content.trails) {
-        const shader = getTrailMeshShader(item.content.trails, item.content.options.maxCount, item.name, env, gpuCapability);
+        const shader = getTrailMeshShader(item.content.trails, item.content.options.maxCount, item.name, gpuCapability, env);
 
-        shader.vertex = createShaderWithMarcos(shader.marcos ?? [], shader.vertex, ShaderType.vertex, level);
-        shader.fragment = createShaderWithMarcos(shader.marcos ?? [], shader.fragment, ShaderType.fragment, level);
+        shader.vertex = createShaderWithMacros(shader.macros ?? [], shader.vertex, ShaderType.vertex, level);
+        shader.fragment = createShaderWithMacros(shader.macros ?? [], shader.fragment, ShaderType.fragment, level);
         shader.glslVersion = level === 2 ? GLSLVersion.GLSL3 : GLSLVersion.GLSL1;
         shaderLibrary.addShader(shader);
       }
@@ -55,8 +55,8 @@ export class ParticleLoader extends AbstractPlugin {
       } else {
         shader.glslVersion = GLSLVersion.GLSL1;
       }
-      shader.vertex = createShaderWithMarcos(shader.marcos ?? [], shader.vertex, ShaderType.vertex, level);
-      shader.fragment = createShaderWithMarcos(shader.marcos ?? [], shader.fragment, ShaderType.fragment, level);
+      shader.vertex = createShaderWithMacros(shader.macros ?? [], shader.vertex, ShaderType.vertex, level);
+      shader.fragment = createShaderWithMacros(shader.macros ?? [], shader.fragment, ShaderType.fragment, level);
       shaderLibrary.addShader(shader);
     });
     if (level === 2) {

--- a/packages/effects-core/src/plugins/particle/particle-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/particle-mesh.ts
@@ -148,8 +148,8 @@ export class ParticleMesh implements ParticleMeshData {
     const { detail } = engine.gpuCapability;
     const { halfFloatTexture, maxVertexUniforms } = detail;
     const marcos: ShaderMarcos = [
+      // spec.RenderMode
       ['RENDER_MODE', +renderMode],
-      ['PRE_MULTIPLY_ALPHA', false],
       ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
     ];
     const { level } = engine.gpuCapability;
@@ -647,9 +647,8 @@ function generateGeometryProps (
 export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCapability: GPUCapability) {
   const props = item.content;
   const renderMode = +(props.renderer?.renderMode || 0);
-  const marcos: [key: string, value: boolean | number][] = [
+  const marcos: ShaderMarcos = [
     ['RENDER_MODE', renderMode],
-    ['PRE_MULTIPLY_ALPHA', false],
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
   ];
   const { level, detail } = gpuCapability;

--- a/packages/effects-core/src/plugins/particle/particle-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/particle-mesh.ts
@@ -16,7 +16,7 @@ import {
   calculateTranslation, createKeyFrameMeta, createValueGetter, ValueGetter, getKeyFrameMetaByRawValue,
 } from '../../math';
 import type {
-  Attribute, GPUCapability, GeometryProps, ShaderMarcos, SharedShaderWithSource,
+  Attribute, GPUCapability, GeometryProps, ShaderMacros, SharedShaderWithSource,
 } from '../../render';
 import { GLSLVersion, Geometry, Mesh } from '../../render';
 import { particleFrag, particleVert } from '../../shader';
@@ -147,7 +147,7 @@ export class ParticleMesh implements ParticleMeshData {
     } = props;
     const { detail } = engine.gpuCapability;
     const { halfFloatTexture, maxVertexUniforms } = detail;
-    const marcos: ShaderMarcos = [
+    const macros: ShaderMacros = [
       // spec.RenderMode
       ['RENDER_MODE', +renderMode],
       ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
@@ -163,21 +163,21 @@ export class ParticleMesh implements ParticleMeshData {
 
     this.useSprite = useSprite;
     if (enableVertexTexture) {
-      marcos.push(['ENABLE_VERTEX_TEXTURE', true]);
+      macros.push(['ENABLE_VERTEX_TEXTURE', true]);
     }
     if (speedOverLifetime) {
-      marcos.push(['SPEED_OVER_LIFETIME', true]);
+      macros.push(['SPEED_OVER_LIFETIME', true]);
       shaderCacheId |= 1 << 1;
       uniformValues.uSpeedLifetimeValue = speedOverLifetime.toUniform(vertexKeyFrameMeta);
     }
     if (sprite?.animate) {
-      marcos.push(['USE_SPRITE', true]);
+      macros.push(['USE_SPRITE', true]);
       shaderCacheId |= 1 << 2;
       uniformValues.uFSprite = uniformValues.uSprite = new Float32Array([sprite.col, sprite.row, sprite.total, sprite.blend ? 1 : 0]);
       this.useSprite = true;
     }
     if (colorOverLifetime?.color) {
-      marcos.push(['COLOR_OVER_LIFETIME', true]);
+      macros.push(['COLOR_OVER_LIFETIME', true]);
       shaderCacheId |= 1 << 4;
       uniformValues.uColorOverLifetime = colorOverLifetime.color instanceof Texture ? colorOverLifetime.color : Texture.createWithData(engine, imageDataFromGradient(colorOverLifetime.color));
     }
@@ -197,7 +197,7 @@ export class ParticleMesh implements ParticleMeshData {
         shaderCacheId |= 1 << (7 + i);
         linearVelOverLifetime.enabled = true;
       }
-      marcos.push([`LINEAR_VEL_${pro.toUpperCase()}`, defL]);
+      macros.push([`LINEAR_VEL_${pro.toUpperCase()}`, defL]);
       if (orbitalVelOverLifetime?.[pro]) {
         uniformValues[`uOrb${pro.toUpperCase()}ByLifetimeValue`] = orbitalVelOverLifetime[pro].toUniform(vertexKeyFrameMeta);
         defO = 1;
@@ -205,16 +205,16 @@ export class ParticleMesh implements ParticleMeshData {
         useOrbitalVel = true;
         orbitalVelOverLifetime.enabled = true;
       }
-      marcos.push([`ORB_VEL_${pro.toUpperCase()}`, defO]);
+      macros.push([`ORB_VEL_${pro.toUpperCase()}`, defO]);
     });
     if (linearVelOverLifetime?.asMovement) {
-      marcos.push(['AS_LINEAR_MOVEMENT', true]);
+      macros.push(['AS_LINEAR_MOVEMENT', true]);
       shaderCacheId |= 1 << 5;
     }
 
     if (useOrbitalVel) {
       if (orbitalVelOverLifetime?.asRotation) {
-        marcos.push(['AS_ORBITAL_MOVEMENT', true]);
+        macros.push(['AS_ORBITAL_MOVEMENT', true]);
         shaderCacheId |= 1 << 6;
       }
       uniformValues.uOrbCenter = new Float32Array(orbitalVelOverLifetime?.center || [0, 0, 0]);
@@ -222,33 +222,33 @@ export class ParticleMesh implements ParticleMeshData {
 
     uniformValues.uSizeByLifetimeValue = sizeOverLifetime?.x.toUniform(vertexKeyFrameMeta);
     if (sizeOverLifetime?.separateAxes) {
-      marcos.push(['SIZE_Y_BY_LIFE', 1]);
+      macros.push(['SIZE_Y_BY_LIFE', 1]);
       shaderCacheId |= 1 << 14;
       uniformValues.uSizeYByLifetimeValue = sizeOverLifetime?.y?.toUniform(vertexKeyFrameMeta);
     }
     if (rotationOverLifetime?.z) {
       uniformValues.uRZByLifeTimeValue = rotationOverLifetime.z.toUniform(vertexKeyFrameMeta);
       shaderCacheId |= 1 << 15;
-      marcos.push(['ROT_Z_LIFETIME', 1]);
+      macros.push(['ROT_Z_LIFETIME', 1]);
     }
     if (rotationOverLifetime?.x) {
       uniformValues.uRXByLifeTimeValue = rotationOverLifetime.x.toUniform(vertexKeyFrameMeta);
       shaderCacheId |= 1 << 16;
-      marcos.push(['ROT_X_LIFETIME', 1]);
+      macros.push(['ROT_X_LIFETIME', 1]);
     }
     if (rotationOverLifetime?.y) {
       uniformValues.uRYByLifeTimeValue = rotationOverLifetime.y.toUniform(vertexKeyFrameMeta);
       shaderCacheId |= 1 << 17;
-      marcos.push(['ROT_Y_LIFETIME', 1]);
+      macros.push(['ROT_Y_LIFETIME', 1]);
     }
     if (rotationOverLifetime?.asRotation) {
-      marcos.push(['ROT_LIFETIME_AS_MOVEMENT', 1]);
+      macros.push(['ROT_LIFETIME_AS_MOVEMENT', 1]);
       shaderCacheId |= 1 << 18;
     }
     uniformValues.uGravityModifierValue = gravityModifier.toUniform(vertexKeyFrameMeta);
 
     if (forceTarget) {
-      marcos.push(['FINAL_TARGET', true]);
+      macros.push(['FINAL_TARGET', true]);
       shaderCacheId |= 1 << 19;
       uniformValues.uFinalTarget = new Float32Array(forceTarget.target || [0, 0, 0]);
       uniformValues.uForceCurve = forceTarget.curve.toUniform(vertexKeyFrameMeta);
@@ -283,7 +283,7 @@ export class ParticleMesh implements ParticleMeshData {
     }
     const shaderCache = ['-p:', renderMode, shaderCacheId, vertexKeyFrameMeta.index, vertexKeyFrameMeta.max, fragmentKeyFrameMeta.index, fragmentKeyFrameMeta.max].join('+');
 
-    marcos.push(
+    macros.push(
       ['VERT_CURVE_VALUE_COUNT', vertexKeyFrameMeta.index],
       ['FRAG_CURVE_VALUE_COUNT', fragmentKeyFrameMeta.index],
       ['VERT_MAX_KEY_FRAME_COUNT', vertexKeyFrameMeta.max],
@@ -300,7 +300,7 @@ export class ParticleMesh implements ParticleMeshData {
       glslVersion: level === 1 ? GLSLVersion.GLSL1 : GLSLVersion.GLSL3,
       shared: true,
       cacheId: shaderCache,
-      marcos,
+      macros,
       name: `particle#${name}`,
     };
     const mtlOptions: MaterialProps = {
@@ -644,10 +644,14 @@ function generateGeometryProps (
   return { attributes, indices: { data: new Uint16Array(0) }, name, maxVertex };
 }
 
-export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCapability: GPUCapability) {
+export function getParticleMeshShader (
+  item: spec.ParticleItem,
+  gpuCapability: GPUCapability,
+  env = '',
+) {
   const props = item.content;
   const renderMode = +(props.renderer?.renderMode || 0);
-  const marcos: ShaderMarcos = [
+  const macros: ShaderMacros = [
     ['RENDER_MODE', renderMode],
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
   ];
@@ -660,25 +664,25 @@ export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCap
   let shaderCacheId = 0;
 
   if (enableVertexTexture) {
-    marcos.push(['ENABLE_VERTEX_TEXTURE', true]);
+    macros.push(['ENABLE_VERTEX_TEXTURE', true]);
   }
 
   if (speedOverLifetime) {
-    marcos.push(['SPEED_OVER_LIFETIME', true]);
+    macros.push(['SPEED_OVER_LIFETIME', true]);
     shaderCacheId |= 1 << 1;
     getKeyFrameMetaByRawValue(vertexKeyFrameMeta, speedOverLifetime);
   }
   const sprite = props.textureSheetAnimation;
 
   if (sprite && sprite.animate) {
-    marcos.push(['USE_SPRITE', true]);
+    macros.push(['USE_SPRITE', true]);
     shaderCacheId |= 1 << 2;
   }
 
   const colorOverLifetime = props.colorOverLifetime;
 
   if (colorOverLifetime && colorOverLifetime.color) {
-    marcos.push(['COLOR_OVER_LIFETIME', true]);
+    macros.push(['COLOR_OVER_LIFETIME', true]);
     shaderCacheId |= 1 << 4;
   }
 
@@ -700,7 +704,7 @@ export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCap
       defL = 1;
       shaderCacheId |= 1 << (7 + i);
     }
-    marcos.push([`LINEAR_VEL_${pro.toUpperCase()}`, defL]);
+    macros.push([`LINEAR_VEL_${pro.toUpperCase()}`, defL]);
     let defO = 0;
 
     if (positionOverLifetime?.[orbitalPro as keyof spec.ParticlePositionOverLifetime]) {
@@ -709,15 +713,15 @@ export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCap
       shaderCacheId |= 1 << (10 + i);
       useOrbitalVel = true;
     }
-    marcos.push([`ORB_VEL_${pro.toUpperCase()}`, defO]);
+    macros.push([`ORB_VEL_${pro.toUpperCase()}`, defO]);
   });
   if (positionOverLifetime?.asMovement) {
-    marcos.push(['AS_LINEAR_MOVEMENT', true]);
+    macros.push(['AS_LINEAR_MOVEMENT', true]);
     shaderCacheId |= 1 << 5;
   }
   if (useOrbitalVel) {
     if (positionOverLifetime?.asRotation) {
-      marcos.push(['AS_ORBITAL_MOVEMENT', true]);
+      macros.push(['AS_ORBITAL_MOVEMENT', true]);
       shaderCacheId |= 1 << 6;
     }
   }
@@ -728,7 +732,7 @@ export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCap
 
     if (separateAxes) {
       getKeyFrameMetaByRawValue(vertexKeyFrameMeta, sizeOverLifetime.x);
-      marcos.push(['SIZE_Y_BY_LIFE', 1]);
+      macros.push(['SIZE_Y_BY_LIFE', 1]);
       shaderCacheId |= 1 << 14;
       getKeyFrameMetaByRawValue(vertexKeyFrameMeta, sizeOverLifetime.y);
     } else {
@@ -742,22 +746,22 @@ export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCap
     if (rot.z) {
       getKeyFrameMetaByRawValue(vertexKeyFrameMeta, rot?.z);
       shaderCacheId |= 1 << 15;
-      marcos.push(['ROT_Z_LIFETIME', 1]);
+      macros.push(['ROT_Z_LIFETIME', 1]);
     }
     if (rot.separateAxes) {
       if (rot.x) {
         getKeyFrameMetaByRawValue(vertexKeyFrameMeta, rot.x);
         shaderCacheId |= 1 << 16;
-        marcos.push(['ROT_X_LIFETIME', 1]);
+        macros.push(['ROT_X_LIFETIME', 1]);
       }
       if (rot.y) {
         getKeyFrameMetaByRawValue(vertexKeyFrameMeta, rot.y);
         shaderCacheId |= 1 << 17;
-        marcos.push(['ROT_Y_LIFETIME', 1]);
+        macros.push(['ROT_Y_LIFETIME', 1]);
       }
     }
     if (rot?.asRotation) {
-      marcos.push(['ROT_LIFETIME_AS_MOVEMENT', 1]);
+      macros.push(['ROT_LIFETIME_AS_MOVEMENT', 1]);
       shaderCacheId |= 1 << 18;
     }
   }
@@ -766,7 +770,7 @@ export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCap
   const forceOpt = positionOverLifetime?.forceTarget;
 
   if (forceOpt) {
-    marcos.push(['FINAL_TARGET', true]);
+    macros.push(['FINAL_TARGET', true]);
     shaderCacheId |= 1 << 19;
     getKeyFrameMetaByRawValue(vertexKeyFrameMeta, positionOverLifetime.forceCurve);
   }
@@ -798,11 +802,11 @@ export function getParticleMeshShader (item: spec.ParticleItem, env = '', gpuCap
     vertex: `#define LOOKUP_TEXTURE_CURVE ${vertex_lookup_texture}\n${particleVert}`,
     shared: true,
     cacheId: shaderCache,
-    marcos,
+    macros,
     name: `particle#${item.name}`,
   };
 
-  marcos.push(
+  macros.push(
     ['VERT_CURVE_VALUE_COUNT', vertexKeyFrameMeta.index],
     ['FRAG_CURVE_VALUE_COUNT', fragmentKeyFrameMeta.index],
     ['VERT_MAX_KEY_FRAME_COUNT', vertexKeyFrameMeta.max],
@@ -819,12 +823,12 @@ export function modifyMaxKeyframeShader (shader: SharedShaderWithSource, maxVert
   shaderIds[5] = maxFrag;
   shader.cacheId = shaderIds.join('+');
 
-  if (!shader.marcos) {
+  if (!shader.macros) {
     return;
   }
 
-  for (let i = 0; i < shader.marcos.length; i++) {
-    const marco = shader.marcos[i];
+  for (let i = 0; i < shader.macros.length; i++) {
+    const marco = shader.macros[i];
 
     if (marco[0] === 'VERT_CURVE_VALUE_COUNT') {
       marco[1] = maxVertex;

--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -142,6 +142,7 @@ export interface ParticleTrailProps extends Omit<spec.ParticleTrail, 'texture'> 
 
 // 粒子节点包含的数据
 export type ParticleContent = [number, number, number, Point]; // delay + lifetime, particleIndex, delay, pointData
+
 @effectsClass(spec.DataType.ParticleSystem)
 export class ParticleSystem extends Component {
   renderer: ParticleSystemRenderer;

--- a/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
@@ -1,7 +1,7 @@
 import type { Vector3 } from '@galacean/effects-math/es/core/vector3';
 import type * as spec from '@galacean/effects-specification';
 import { PLAYER_OPTIONS_ENV_EDITOR } from '../../constants';
-import type { GPUCapabilityDetail, ShaderMarcos, SharedShaderWithSource } from '../../render';
+import type { GPUCapabilityDetail, ShaderMacros, SharedShaderWithSource } from '../../render';
 import { GLSLVersion } from '../../render';
 import { itemFrag, itemFrameFrag, itemVert } from '../../shader';
 import type { Transform } from '../../transform';
@@ -57,7 +57,7 @@ export function spriteMeshShaderFromFilter (
   options?: { wireframe?: boolean, env?: string },
 ): SharedShaderWithSource {
   const { env = '', wireframe } = options ?? {};
-  const marcos: ShaderMarcos = [
+  const macros: ShaderMacros = [
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
   ];
   const fragment = wireframe ? itemFrameFrag : itemFrag;
@@ -67,7 +67,7 @@ export function spriteMeshShaderFromFilter (
     fragment,
     vertex,
     glslVersion: level === 1 ? GLSLVersion.GLSL1 : GLSLVersion.GLSL3,
-    marcos,
+    macros,
     shared: true,
   };
 }

--- a/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
@@ -1,7 +1,7 @@
 import type { Vector3 } from '@galacean/effects-math/es/core/vector3';
 import type * as spec from '@galacean/effects-specification';
 import { PLAYER_OPTIONS_ENV_EDITOR } from '../../constants';
-import type { GPUCapabilityDetail, SharedShaderWithSource } from '../../render';
+import type { GPUCapabilityDetail, ShaderMarcos, SharedShaderWithSource } from '../../render';
 import { GLSLVersion } from '../../render';
 import { itemFrag, itemFrameFrag, itemVert } from '../../shader';
 import type { Transform } from '../../transform';
@@ -56,13 +56,13 @@ export function getImageItemRenderInfo (item: SpriteComponent): SpriteItemRender
   };
 }
 
-export function spriteMeshShaderFromFilter (level: number, options?: { count?: number, ignoreBlend?: boolean, wireframe?: boolean, env?: string }): SharedShaderWithSource {
-  const { count = 2, env = '', ignoreBlend, wireframe } = options ?? {};
-  const marcos: [key: string, val: boolean | number][] = [
-    ['MAX_ITEM_COUNT', count],
-    ['PRE_MULTIPLY_ALPHA', false],
+export function spriteMeshShaderFromFilter (
+  level: number,
+  options?: { wireframe?: boolean, env?: string },
+): SharedShaderWithSource {
+  const { env = '', wireframe } = options ?? {};
+  const marcos: ShaderMarcos = [
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
-    ['USE_BLEND', !ignoreBlend],
     ['MAX_FRAG_TEX', maxSpriteTextureCount >= 16 ? 16 : 8],
   ];
   const fragment = wireframe ? itemFrameFrag : itemFrag;
@@ -84,7 +84,6 @@ export function spriteMeshShaderIdFromRenderInfo (renderInfo: SpriteItemRenderIn
 export function spriteMeshShaderFromRenderInfo (renderInfo: SpriteItemRenderInfo, count: number, level: number, env?: string): SharedShaderWithSource {
   const { wireframe } = renderInfo;
   const shader = spriteMeshShaderFromFilter(level, {
-    count,
     wireframe,
     env,
   });

--- a/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
@@ -26,17 +26,13 @@ export type SpriteRegionData = {
 };
 
 export let maxSpriteMeshItemCount = 8;
-export let maxSpriteTextureCount = 8;
 
 export function setSpriteMeshMaxItemCountByGPU (gpuCapability: GPUCapabilityDetail) {
-  // 8 or 16
-  maxSpriteTextureCount = Math.min(gpuCapability.maxFragmentTextures, 16);
   if (gpuCapability.maxVertexUniforms >= 256) {
     return maxSpriteMeshItemCount = 32;
   } else if (gpuCapability.maxVertexUniforms >= 128) {
     return maxSpriteMeshItemCount = 16;
   }
-  maxSpriteTextureCount = 8;
 }
 
 export function getImageItemRenderInfo (item: SpriteComponent): SpriteItemRenderInfo {
@@ -63,7 +59,6 @@ export function spriteMeshShaderFromFilter (
   const { env = '', wireframe } = options ?? {};
   const marcos: ShaderMarcos = [
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
-    ['MAX_FRAG_TEX', maxSpriteTextureCount >= 16 ? 16 : 8],
   ];
   const fragment = wireframe ? itemFrameFrag : itemFrag;
   const vertex = itemVert;
@@ -99,8 +94,4 @@ export function spriteMeshShaderFromRenderInfo (renderInfo: SpriteItemRenderInfo
 // TODO: 只有单测用
 export function setMaxSpriteMeshItemCount (count: number) {
   maxSpriteMeshItemCount = count;
-}
-
-export function setSpriteMeshMaxFragmentTextures (count: number) {
-  maxSpriteTextureCount = count;
 }

--- a/packages/effects-core/src/render/create-copy-shader.ts
+++ b/packages/effects-core/src/render/create-copy-shader.ts
@@ -58,7 +58,7 @@ export function createCopyShader (level: number, writeDepth?: boolean): SharedSh
     vertex: version + '\n' + COPY_VERTEX_SHADER,
     fragment: version + '\n' + COPY_FRAGMENT_SHADER,
     glslVersion: webgl2 ? GLSLVersion.GLSL3 : GLSLVersion.GLSL1,
-    marcos: [
+    macros: [
       ['WEBGL2', !!webgl2],
       ['DEPTH_TEXTURE', !!writeDepth],
     ],

--- a/packages/effects-core/src/render/shader.ts
+++ b/packages/effects-core/src/render/shader.ts
@@ -3,7 +3,7 @@ import { effectsClass } from '../decorators';
 import { EffectsObject } from '../effects-object';
 import type { Engine } from '../engine';
 
-export type ShaderMarcos = [key: string, value: string | number | boolean][];
+export type ShaderMacros = [key: string, value: string | number | boolean][];
 
 export enum ShaderCompileResultStatus {
   noShader = 0,
@@ -44,7 +44,7 @@ export interface InstancedShaderWithSource {
   /**
    * shader的宏定义
    */
-  marcos?: ShaderMarcos,
+  macros?: ShaderMacros,
   /**
    * shader是否共享
    */
@@ -71,7 +71,7 @@ export interface SharedShaderWithSource {
   /**
    * shader的宏定义
    */
-  marcos?: ShaderMarcos,
+  macros?: ShaderMacros,
   /**
    * 是否共用GLProgram
    * shared为true时，
@@ -102,7 +102,7 @@ export class Shader extends EffectsObject {
   shaderData: spec.ShaderData;
 
   createVariant (macros?: Record<string, number | boolean>) {
-    const shaderMacros: ShaderMarcos = [];
+    const shaderMacros: ShaderMacros = [];
 
     if (macros) {
       for (const key of Object.keys(macros)) {
@@ -128,7 +128,7 @@ export interface ShaderLibrary {
 
   addShader (shader: ShaderWithSource): void,
 
-  createShader (shaderSource: ShaderWithSource, macros?: ShaderMarcos): ShaderVariant,
+  createShader (shaderSource: ShaderWithSource, macros?: ShaderMacros): ShaderVariant,
 
   /**
    * @param cacheId

--- a/packages/effects-core/src/shader/blend.glsl
+++ b/packages/effects-core/src/shader/blend.glsl
@@ -1,10 +1,7 @@
 vec4 blendColor(vec4 color, vec4 vc, float mode) {
   vec4 ret = color * vc;
-    #ifdef PRE_MULTIPLY_ALPHA
-  float alpha = vc.a;
-    #else
   float alpha = ret.a;
-    #endif
+
   if(mode == 1.) {
     ret.rgb *= alpha;
   } else if(mode == 2.) {

--- a/packages/effects-core/src/shader/item-frame.frag.glsl
+++ b/packages/effects-core/src/shader/item-frame.frag.glsl
@@ -1,7 +1,7 @@
 #version 300 es
 precision highp float;
-#pragma "./compatible.frag.glsl";
-#import "./blend.glsl";
+#include "./compatible.frag.glsl";
+#include "./blend.glsl";
 
 in vec4 vColor;
 in vec4 vTexCoord;//x y transparentOcclusion

--- a/packages/effects-core/src/shader/item.frag.glsl
+++ b/packages/effects-core/src/shader/item.frag.glsl
@@ -8,11 +8,8 @@ uniform sampler2D uSampler0;
 
 vec4 blendColor(vec4 color, vec4 vc, float mode) {
   vec4 ret = color * vc;
-#ifdef PRE_MULTIPLY_ALPHA
-  float alpha = vc.a;
-#else
   float alpha = ret.a;
-#endif
+
   if(mode == 1.) {
     ret.rgb *= alpha;
   } else if(mode == 2.) {

--- a/packages/effects-core/src/shader/particle.frag.glsl
+++ b/packages/effects-core/src/shader/particle.frag.glsl
@@ -1,7 +1,7 @@
 #version 300 es
 precision mediump float;
-#pragma "./compatible.frag.glsl";
-#import "./blend.glsl";
+#include "./compatible.frag.glsl";
+#include "./blend.glsl";
 #define PATICLE_SHADER 1
 in float vLife;
 in vec2 vTexCoord;

--- a/packages/effects-core/src/shader/particle.vert.glsl
+++ b/packages/effects-core/src/shader/particle.vert.glsl
@@ -3,9 +3,9 @@ precision mediump float;
 #define SHADER_VERTEX 1
 #define PATICLE_SHADER 1
 
-#import "./compatible.vert.glsl";
-#import "./value.glsl";
-#import "./integrate.glsl";
+#include "./compatible.vert.glsl";
+#include "./value.glsl";
+#include "./integrate.glsl";
 
 const float d2r = 3.141592653589793 / 180.;
 
@@ -27,8 +27,6 @@ struct UVDetail {
 UVDetail getSpriteUV(vec2 uv, float lifeTime);
 out vec4 vTexCoordBlend;
 #endif
-
-//#pragma EDITOR_VERT_DEFINE
 
 #ifdef FINAL_TARGET
 uniform vec3 uFinalTarget;

--- a/packages/effects-core/src/shader/trail.vert.glsl
+++ b/packages/effects-core/src/shader/trail.vert.glsl
@@ -1,8 +1,8 @@
 #version 300 es
 precision mediump float;
 #define SHADER_VERTEX 1
-#import "./compatible.vert.glsl";
-#import "./value.glsl";
+#include "./compatible.vert.glsl";
+#include "./value.glsl";
 in vec4 aPos;
 in vec3 aDir;
 in vec3 aInfo;//lifetime section side

--- a/packages/effects-core/src/shader/value.glsl
+++ b/packages/effects-core/src/shader/value.glsl
@@ -1,4 +1,4 @@
-#pragma "./value-define.glsl"
+#include "./value-define.glsl"
 
 #define NONE_CONST_INDEX 1
 #ifdef SHADER_VERTEX

--- a/packages/effects-threejs/src/material/three-material.ts
+++ b/packages/effects-threejs/src/material/three-material.ts
@@ -1,8 +1,8 @@
 import type {
   MaterialProps, Texture, UniformValue, MaterialDestroyOptions, UndefinedAble, Engine, math,
-  GlobalUniforms, Renderer, ShaderMarcos,
+  GlobalUniforms, Renderer, ShaderMacros,
 } from '@galacean/effects-core';
-import { Material, ShaderType, createShaderWithMarcos, maxSpriteMeshItemCount, spec } from '@galacean/effects-core';
+import { Material, ShaderType, createShaderWithMacros, maxSpriteMeshItemCount, spec } from '@galacean/effects-core';
 import * as THREE from 'three';
 import type { ThreeTexture } from '../three-texture';
 import {
@@ -59,8 +59,8 @@ export class ThreeMaterial extends Material {
     this.uniforms['effects_MatrixV'] = new THREE.Uniform([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 8, 1]);
 
     this.material = new THREE.RawShaderMaterial({
-      vertexShader: createShaderWithMarcos(shader!.marcos as ShaderMarcos, shader!.vertex, ShaderType.vertex, this.engine.gpuCapability.level),
-      fragmentShader: createShaderWithMarcos(shader!.marcos as ShaderMarcos, shader!.fragment, ShaderType.fragment, this.engine.gpuCapability.level),
+      vertexShader: createShaderWithMacros(shader!.macros as ShaderMacros, shader!.vertex, ShaderType.vertex, this.engine.gpuCapability.level),
+      fragmentShader: createShaderWithMacros(shader!.macros as ShaderMacros, shader!.fragment, ShaderType.fragment, this.engine.gpuCapability.level),
       alphaToCoverage: false,
       depthFunc: THREE.LessDepth,
       polygonOffsetFactor: THREE.ZeroFactor,

--- a/packages/effects-webgl/src/gl-shader-library.ts
+++ b/packages/effects-webgl/src/gl-shader-library.ts
@@ -1,9 +1,9 @@
 import stringHash from 'string-hash';
 import type {
-  Disposable, RestoreHandler, ShaderCompileResult, ShaderLibrary, ShaderMarcos, ShaderWithSource,
+  Disposable, RestoreHandler, ShaderCompileResult, ShaderLibrary, ShaderMacros, ShaderWithSource,
   SharedShaderWithSource,
 } from '@galacean/effects-core';
-import { ShaderCompileResultStatus, GLSLVersion, ShaderType, createShaderWithMarcos } from '@galacean/effects-core';
+import { ShaderCompileResultStatus, GLSLVersion, ShaderType, createShaderWithMacros } from '@galacean/effects-core';
 import { GLProgram } from './gl-program';
 import { GLShaderVariant } from './gl-shader';
 import { assignInspectorName } from './gl-renderer-internal';
@@ -63,19 +63,19 @@ export class GLShaderLibrary implements ShaderLibrary, Disposable, RestoreHandle
   }
 
   // TODO 创建shader的ShaderWithSource和shader的source类型一样，待优化。
-  addShader (shaderSource: ShaderWithSource, macros?: ShaderMarcos): string {
-    const mergedMacros: ShaderMarcos = [];
+  addShader (shaderSource: ShaderWithSource, macros?: ShaderMacros): string {
+    const mergedMacros: ShaderMacros = [];
 
-    if (shaderSource.marcos) {
-      mergedMacros.push(...shaderSource.marcos);
+    if (shaderSource.macros) {
+      mergedMacros.push(...shaderSource.macros);
     }
     if (macros) {
       mergedMacros.push(...macros);
     }
     const shaderWithMacros = {
       ...shaderSource,
-      vertex: createShaderWithMarcos(mergedMacros, shaderSource.vertex, ShaderType.vertex, this.engine.gpuCapability.level),
-      fragment: createShaderWithMarcos(mergedMacros, shaderSource.fragment, ShaderType.fragment, this.engine.gpuCapability.level),
+      vertex: createShaderWithMacros(mergedMacros, shaderSource.vertex, ShaderType.vertex, this.engine.gpuCapability.level),
+      fragment: createShaderWithMacros(mergedMacros, shaderSource.fragment, ShaderType.fragment, this.engine.gpuCapability.level),
     };
     const shaderCacheId = this.computeShaderCacheId(shaderWithMacros);
 
@@ -105,7 +105,7 @@ export class GLShaderLibrary implements ShaderLibrary, Disposable, RestoreHandle
     return shaderCacheId;
   }
 
-  createShader (shaderSource: ShaderWithSource, macros?: ShaderMarcos) {
+  createShader (shaderSource: ShaderWithSource, macros?: ShaderMacros) {
     const shaderCacheId = this.addShader(shaderSource, macros);
 
     return this.cachedShaders[shaderCacheId];

--- a/plugin-packages/editor-gizmo/src/wireframe.ts
+++ b/plugin-packages/editor-gizmo/src/wireframe.ts
@@ -254,7 +254,12 @@ export class SharedGeometry extends GLGeometry {
   }
 }
 
-function createGizmoShader (marcos: ShaderMarcos, shader: string, shaderType: ShaderType, level: number) {
+function createGizmoShader (
+  marcos: ShaderMarcos,
+  shader: string,
+  shaderType: ShaderType,
+  level: number,
+) {
   const versionTag = /#version\s+\b\d{3}\b\s*(es)?/;
   const shaderMatch = shader.match(versionTag);
   const newShader = shaderMatch ? shader.substring(shaderMatch[0].length) : shader;

--- a/plugin-packages/editor-gizmo/src/wireframe.ts
+++ b/plugin-packages/editor-gizmo/src/wireframe.ts
@@ -1,5 +1,5 @@
-import type { ShaderMarcos, Geometry, GeometryDrawMode, Engine, GLEngine, spec } from '@galacean/effects';
-import { GLSLVersion, glContext, GLGeometry, DestroyOptions, Material, Mesh, createShaderWithMarcos, ShaderType, math } from '@galacean/effects';
+import type { ShaderMacros, Geometry, GeometryDrawMode, Engine, GLEngine, spec } from '@galacean/effects';
+import { GLSLVersion, glContext, GLGeometry, DestroyOptions, Material, Mesh, createShaderWithMacros, ShaderType, math } from '@galacean/effects';
 
 const { Vector4 } = math;
 
@@ -15,14 +15,14 @@ export function createParticleWireframe (engine: Engine, mesh: Mesh, color: spec
       name: 'testtest',
     });
 
-  const { vertex, fragment, marcos, name } = mesh.material.props.shader;
+  const { vertex, fragment, macros, name } = mesh.material.props.shader;
   const materialOptions = { ...mesh.material.props };
-  const newMarcos = [...(marcos || [] as ShaderMarcos), ['PREVIEW_BORDER', 1]] as ShaderMarcos;
+  const newMacros = [...(macros || [] as ShaderMacros), ['PREVIEW_BORDER', 1]] as ShaderMacros;
   const level = engine.gpuCapability.level;
 
   materialOptions.shader = {
-    vertex: createGizmoShader(newMarcos, vertex, ShaderType.vertex, level),
-    fragment: createGizmoShader(newMarcos, fragment, ShaderType.fragment, level),
+    vertex: createGizmoShader(newMacros, vertex, ShaderType.vertex, level),
+    fragment: createGizmoShader(newMacros, fragment, ShaderType.fragment, level),
     shared: true,
     name: name + '_wireframe',
     glslVersion: engine.gpuCapability.level === 2 ? GLSLVersion.GLSL3 : GLSLVersion.GLSL1,
@@ -114,14 +114,14 @@ export function createModeWireframe (engine: Engine, mesh: Mesh, color: spec.vec
         data: new Uint32Array(0),
       },
     });
-  const { vertex, fragment, marcos } = mesh.material.props.shader;
+  const { vertex, fragment, macros } = mesh.material.props.shader;
   const materialOptions = { ...mesh.material.props };
 
-  const newMarcos = [...(marcos || [] as ShaderMarcos), ['PREVIEW_BORDER', 1]] as ShaderMarcos;
+  const newMacros = [...(macros || [] as ShaderMacros), ['PREVIEW_BORDER', 1]] as ShaderMacros;
 
   materialOptions.shader = {
-    vertex: createGizmoShader(newMarcos, vertex, ShaderType.vertex, level),
-    fragment: createGizmoShader(newMarcos, fragment, ShaderType.fragment, level),
+    vertex: createGizmoShader(newMacros, vertex, ShaderType.vertex, level),
+    fragment: createGizmoShader(newMacros, fragment, ShaderType.fragment, level),
     shared: true,
     name: (mesh.name ?? 'unamedmesh') + '_wireframe',
     glslVersion: engine.gpuCapability.level === 2 ? GLSLVersion.GLSL3 : GLSLVersion.GLSL1,
@@ -255,7 +255,7 @@ export class SharedGeometry extends GLGeometry {
 }
 
 function createGizmoShader (
-  marcos: ShaderMarcos,
+  macros: ShaderMacros,
   shader: string,
   shaderType: ShaderType,
   level: number,
@@ -264,5 +264,5 @@ function createGizmoShader (
   const shaderMatch = shader.match(versionTag);
   const newShader = shaderMatch ? shader.substring(shaderMatch[0].length) : shader;
 
-  return createShaderWithMarcos(marcos, newShader, shaderType, level);
+  return createShaderWithMacros(macros, newShader, shaderType, level);
 }

--- a/plugin-packages/model/src/runtime/shader-libs/standard-shader-source.ts
+++ b/plugin-packages/model/src/runtime/shader-libs/standard-shader-source.ts
@@ -39,7 +39,11 @@ export namespace StandardShaderSource {
     source = source.replace(/#define FEATURES/,
       features.map(value => `#define ${value}`).join('\n'));
 
-    if (isWebGL2) { return '#version 300 es\n' + source; } else { return '#version 100\n' + source; }
+    if (isWebGL2) {
+      return '#version 300 es\n' + source;
+    } else {
+      return '#version 100\n' + source;
+    }
   }
 
   export function getSourceCode (source: string, isWebGL2?: boolean): string {

--- a/plugin-packages/model/src/runtime/shader-libs/standard-shader-source.ts
+++ b/plugin-packages/model/src/runtime/shader-libs/standard-shader-source.ts
@@ -55,8 +55,8 @@ export namespace StandardShaderSource {
 
     if (isWebGL2) {
       return '#version 300 es\n' + source;
-    } else {
-      return '#version 100\n' + source;
     }
+
+    return '#version 100\n' + source;
   }
 }

--- a/plugin-packages/spine/src/spine-mesh.ts
+++ b/plugin-packages/spine/src/spine-mesh.ts
@@ -1,6 +1,6 @@
 import type { BlendMode } from '@esotericsoftware/spine-core';
 import type {
-  Attribute, Disposable, Engine, ShaderMarcos, SharedShaderWithSource, Texture,
+  Attribute, Disposable, Engine, ShaderMacros, SharedShaderWithSource, Texture,
 } from '@galacean/effects';
 import {
   GLSLVersion, Geometry, Material, Mesh, PLAYER_OPTIONS_ENV_EDITOR, glContext, math, setMaskMode,
@@ -166,7 +166,7 @@ export class SpineMesh implements Disposable {
 
 export function createShader (engine: Engine): SharedShaderWithSource {
   const env = engine.renderer.env;
-  const marcos: ShaderMarcos = [
+  const macros: ShaderMacros = [
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
   ];
 
@@ -174,7 +174,7 @@ export function createShader (engine: Engine): SharedShaderWithSource {
     fragment: fs,
     vertex: vs,
     glslVersion: GLSLVersion.GLSL1,
-    marcos,
+    macros,
     shared: true,
   };
 }

--- a/plugin-packages/spine/src/spine-mesh.ts
+++ b/plugin-packages/spine/src/spine-mesh.ts
@@ -1,5 +1,7 @@
 import type { BlendMode } from '@esotericsoftware/spine-core';
-import type { Attribute, Disposable, Engine, SharedShaderWithSource, Texture } from '@galacean/effects';
+import type {
+  Attribute, Disposable, Engine, ShaderMarcos, SharedShaderWithSource, Texture,
+} from '@galacean/effects';
 import {
   GLSLVersion, Geometry, Material, Mesh, PLAYER_OPTIONS_ENV_EDITOR, glContext, math, setMaskMode,
 } from '@galacean/effects';
@@ -164,7 +166,7 @@ export class SpineMesh implements Disposable {
 
 export function createShader (engine: Engine): SharedShaderWithSource {
   const env = engine.renderer.env;
-  const marcos: [key: string, val: boolean][] = [
+  const marcos: ShaderMarcos = [
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
   ];
 

--- a/scripts/rollup-plugin-glsl-inner.js
+++ b/scripts/rollup-plugin-glsl-inner.js
@@ -10,18 +10,17 @@ export default function glslInner() {
       }
       const dirPath = path.dirname(id);
       // proceed with the transformation...
-      const assembleImportContent = processContent(code, dirPath);
-      const assemblePragmaContent = processContent(assembleImportContent, dirPath, 'pragma');
+      const assembleIncludeContent = processContent(code, dirPath);
 
       return {
-        code: `export default ${JSON.stringify(compressShader(assemblePragmaContent))}`,
+        code: `export default ${JSON.stringify(compressShader(assembleIncludeContent))}`,
         map: { mappings: '' }
       };
     },
   };
 }
 
-function processContent(content, dirPath, keyword = 'import') {
+function processContent(content, dirPath, keyword = 'include') {
   const reg = new RegExp(`#${keyword}[\\s\\t]+('|")(.*?)\\1;?`);
   let ret;
 

--- a/web-packages/test/unit/src/effects-core/plugins/particle/particle.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/particle/particle.spec.ts
@@ -91,27 +91,27 @@ describe('effects-core/plugins/particle-test', function () {
     const billItem = comp.getItemByName('billboard');
     const billMaterial = billItem.content.renderer.particleMesh.mesh.material;
 
-    expect(getMarcosValue(billMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.BILLBOARD);
+    expect(getMacrosValue(billMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.BILLBOARD);
 
     const defaultItem = comp.getItemByName('default');
     const defaultMaterial = defaultItem.content.renderer.particleMesh.mesh.material;
 
-    expect(getMarcosValue(defaultMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.BILLBOARD);
+    expect(getMacrosValue(defaultMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.BILLBOARD);
 
     const meshItem = comp.getItemByName('mesh');
     const meshMaterial = meshItem.content.renderer.particleMesh.mesh.material;
 
-    expect(getMarcosValue(meshMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.MESH);
+    expect(getMacrosValue(meshMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.MESH);
 
     const verticalItem = comp.getItemByName('vertical_billboard');
     const verticalMaterial = verticalItem.content.renderer.particleMesh.mesh.material;
 
-    expect(getMarcosValue(verticalMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.VERTICAL_BILLBOARD);
+    expect(getMacrosValue(verticalMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.VERTICAL_BILLBOARD);
 
     const horizonItem = comp.getItemByName('horizon_billboard');
     const horizonMaterial = horizonItem.content.renderer.particleMesh.mesh.material;
 
-    expect(getMarcosValue(horizonMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.HORIZONTAL_BILLBOARD);
+    expect(getMacrosValue(horizonMaterial, 'RENDER_MODE')).to.eql(spec.RenderMode.HORIZONTAL_BILLBOARD);
   });
 
   it('particle mask mode', async () => {
@@ -406,11 +406,11 @@ function translatePoint (x, y) {
   return origin;
 }
 
-function getMarcosValue (material, name) {
-  const marcos = material.shaderSource.marcos;
+function getMacrosValue (material, name) {
+  const macros = material.shaderSource.macros;
 
-  if (marcos) {
-    const ret = marcos.find(m => m[0] === name);
+  if (macros) {
+    const ret = macros.find(m => m[0] === name);
 
     return ret && ret[1];
   }

--- a/web-packages/test/unit/src/effects-webgl/gl-material.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-material.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createShaderWithMarcos, RenderFrame, RenderPass, glContext, DestroyOptions, TextureLoadAction, ShaderType, Texture, Camera, Mesh, math } from '@galacean/effects-core';
+import { createShaderWithMacros, RenderFrame, RenderPass, glContext, DestroyOptions, TextureLoadAction, ShaderType, Texture, Camera, Mesh, math } from '@galacean/effects-core';
 import { GLMaterial, GLGeometry, GLRenderer } from '@galacean/effects-webgl';
 
 const { Vector4 } = math;
@@ -1534,7 +1534,7 @@ describe('gl-material', () => {
   //   });
 });
 
-function generateMesh (engine, meshName, vs, fs, marcos = [], shared = true) {
+function generateMesh (engine, meshName, vs, fs, macros = [], shared = true) {
   return new Mesh(
     engine,
     {
@@ -1543,9 +1543,9 @@ function generateMesh (engine, meshName, vs, fs, marcos = [], shared = true) {
         engine,
         {
           shader: {
-            vertex: createShaderWithMarcos(marcos, vs, ShaderType.vertex),
-            fragment: createShaderWithMarcos(marcos, fs, ShaderType.fragment),
-            marcos: marcos,
+            vertex: createShaderWithMacros(macros, vs, ShaderType.vertex),
+            fragment: createShaderWithMacros(macros, fs, ShaderType.fragment),
+            macros,
             shared,
           },
           states: {},

--- a/web-packages/test/unit/src/effects-webgl/gl-shader-library.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-shader-library.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { GPUCapability, ShaderCompileResultStatus, GLSLVersion, ShaderType, createShaderWithMarcos } from '@galacean/effects-core';
+import { GPUCapability, ShaderCompileResultStatus, GLSLVersion, ShaderType, createShaderWithMacros } from '@galacean/effects-core';
 import { GLMaterial, GLRenderer } from '@galacean/effects-webgl';
 
 const { expect } = chai;
@@ -53,7 +53,7 @@ describe('webgl/GLShaderLibrary', () => {
     const shader = shaderLib.createShader({
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 1.0]],
+      macros: [['HAS_TEXTURE', 1.0]],
     });
 
     rendererGL2.pipelineContext.shaderLibrary.compileShader(shader);
@@ -85,7 +85,7 @@ describe('webgl/GLShaderLibrary', () => {
     const sameShader = {
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 1.0]],
+      macros: [['HAS_TEXTURE', 1.0]],
     };
     const cacheId = shaderLib.addShader(sameShader);
 
@@ -101,7 +101,7 @@ describe('webgl/GLShaderLibrary', () => {
     // const shaderId = shaderLib.addShader({
     //   vertex: vs,
     //   fragment: fs,
-    //   marcos: [['HAS_TEXTURE', 1.0]],
+    //   macros: [['HAS_TEXTURE', 1.0]],
     // });
 
     // renderer.pipelineContext.shaderLibrary.compileShader(shaderId);
@@ -147,8 +147,8 @@ describe('webgl/GLShaderLibrary', () => {
     `;
     const lib = pipelineContext.shaderLibrary;
     const shader = lib.createShader({
-      fragment: createShaderWithMarcos([], fragShader, ShaderType.fragment, 1),
-      vertex: createShaderWithMarcos([], vertexShader, ShaderType.vertex, 1),
+      fragment: createShaderWithMacros([], fragShader, ShaderType.fragment, 1),
+      vertex: createShaderWithMacros([], vertexShader, ShaderType.vertex, 1),
       glslVersion: GLSLVersion.GLSL1,
     });
     const source = shader.source;
@@ -167,7 +167,7 @@ describe('webgl/GLShaderLibrary', () => {
     const shader = shaderLib.createShader({
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 122.0]],
+      macros: [['HAS_TEXTURE', 122.0]],
     });
     const callback = chai.spy(result => {
       expect(result).to.eql(shader.compileResult);
@@ -189,7 +189,7 @@ describe('webgl/GLShaderLibrary', () => {
     const shader = shaderLib.createShader({
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 152.0]],
+      macros: [['HAS_TEXTURE', 152.0]],
     });
 
     //@ts-expect-error
@@ -214,12 +214,12 @@ describe('webgl/GLShaderLibrary', () => {
     shaderLib.addShader({
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 12.0]],
+      macros: [['HAS_TEXTURE', 12.0]],
     });
     shaderLib.addShader({
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 33.0]],
+      macros: [['HAS_TEXTURE', 33.0]],
     });
     shaderLib.compileAllShaders(function (results) {
       expect(results.length).to.eql(2);
@@ -237,12 +237,12 @@ describe('webgl/GLShaderLibrary', () => {
     shaderLib.addShader({
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 12.0]],
+      macros: [['HAS_TEXTURE', 12.0]],
     });
     shaderLib.addShader({
       vertex: vs,
       fragment: fs,
-      marcos: [['HAS_TEXTURE', 33.0]],
+      macros: [['HAS_TEXTURE', 33.0]],
     });
     //@ts-expect-error
     shaderLib._glAsyncCompileExt = null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized the inclusion of shader files across various shader scripts by replacing `#pragma` and `#import` directives with `#include`.
  - Updated shader macros handling, including removal and adjustment of specific macros (`PRE_MULTIPLY_ALPHA` and `RENDER_MODE`).

- **New Features**
  - Enhanced `createGizmoShader` function to accept an additional `level` parameter.

- **Bug Fixes**
  - Refined alpha value calculation logic within shader functions for improved rendering accuracy.
  - Improved WebGL version detection logic in shader source retrieval for more robust compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->