### PR TITLE
refactor: 修改 version 导出位置

### DIFF
--- a/packages/effects-core/src/index.ts
+++ b/packages/effects-core/src/index.ts
@@ -3,6 +3,7 @@ import type { CameraController, InteractComponent, ParticleSystem, SpriteCompone
 import {
   CalculateLoader, CameraVFXItemLoader, InteractLoader, ParticleLoader, SpriteLoader, TextLoader,
 } from './plugins';
+import { logger } from './utils';
 import { VFXItem } from './vfx-item';
 
 export * as math from '@galacean/effects-math/es/core/index';
@@ -48,3 +49,7 @@ registerPlugin<SpriteComponent>('sprite', SpriteLoader, VFXItem, true);
 registerPlugin<ParticleSystem>('particle', ParticleLoader, VFXItem, true);
 registerPlugin('cal', CalculateLoader, VFXItem, true);
 registerPlugin<InteractComponent>('interact', InteractLoader, VFXItem, true);
+
+export const version = __VERSION__;
+
+logger.info('player version: ' + version);

--- a/packages/effects/src/index.ts
+++ b/packages/effects/src/index.ts
@@ -4,7 +4,7 @@ import type {
 } from '@galacean/effects-core';
 import {
   Framebuffer, Geometry, glContext, imageDataFromColor, Material, Mesh, Renderbuffer,
-  Renderer, Texture, TextureSourceType, Engine, logger,
+  Renderer, Texture, TextureSourceType, Engine,
 } from '@galacean/effects-core';
 import {
   GLFramebuffer, GLGeometry, GLMaterial, GLRenderbuffer, GLRenderer, GLTexture, GLEngine,
@@ -82,7 +82,3 @@ Renderer.create = (
 Engine.create = (gl: WebGLRenderingContext | WebGL2RenderingContext) => {
   return new GLEngine(gl);
 };
-
-export const version = __VERSION__;
-
-logger.info('player version: ' + version);


### PR DESCRIPTION
三方引擎使用 spine 插件的时候，由于 spine 导入了 version，导致没办法修改 effects 为 effects-core 包

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version logging for the player using a new `version` constant.

- **Refactor**
  - Removed player version logging from `Engine` for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->