### PR TITLE
feat: 增加合成和 Spine 元素接口

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -108,7 +108,7 @@ export class Composition implements Disposable, LostHandler {
   keepResource: boolean;
   /**
    * 合成内的元素否允许点击、拖拽交互
-   * @since 1.5.2
+   * @since 1.6.0
    */
   interactive: boolean;
   /**
@@ -127,7 +127,7 @@ export class Composition implements Disposable, LostHandler {
   /**
    * 合成中元素点击时触发的回调
    * 不推荐使用
-   * @since 1.5.2
+   * @since 1.6.0
    * @ignore
    */
   onItemClicked?: (data: CompItemClickedData) => void;

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -1,5 +1,5 @@
 import * as spec from '@galacean/effects-specification';
-import type { Ray } from '@galacean/effects-math/es/core/index';
+import type { Ray } from '@galacean/effects-math/es/core/ray';
 import type { Vector3 } from '@galacean/effects-math/es/core/vector3';
 import type { SceneType } from './asset-manager';
 import type { Scene } from './scene';
@@ -126,9 +126,10 @@ export class Composition implements Disposable, LostHandler {
   onMessageItem?: (item: MessageItem) => void;
   /**
    * 合成中元素点击时触发的回调
-   * 不推荐使用
+   * 注意：此接口随时可能下线，请务使用！
    * @since 1.6.0
    * @ignore
+   * @deprecated
    */
   onItemClicked?: (data: CompItemClickedData) => void;
   /**

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -1,22 +1,23 @@
-import type { Ray } from '@galacean/effects-math/es/core/index';
 import * as spec from '@galacean/effects-specification';
+import type { Ray } from '@galacean/effects-math/es/core/index';
 import type { SceneType } from './asset-manager';
-import { Camera } from './camera';
-import type { ItemNode } from './comp-vfx-item';
-import { CompVFXItem } from './comp-vfx-item';
-import { CompositionSourceManager } from './composition-source-manager';
-import { setRayFromCamera } from './math';
-import type { PluginSystem } from './plugin-system';
-import type { EventSystem, InteractVFXItem, Plugin, Region } from './plugins';
-import type { GlobalVolume, MeshRendererOptions, Renderer } from './render';
-import { RenderFrame } from './render';
 import type { Scene } from './scene';
-import type { Texture } from './texture';
-import { TextureSourceType } from './texture';
-import { Transform } from './transform';
 import type { Disposable, LostHandler } from './utils';
 import { assertExist, logger, noop } from './utils';
+import { Transform } from './transform';
 import type { VFXItem, VFXItemContent, VFXItemProps } from './vfx-item';
+import type { ItemNode } from './comp-vfx-item';
+import { CompVFXItem } from './comp-vfx-item';
+import type { InteractVFXItem, Plugin, EventSystem } from './plugins';
+import type { PluginSystem } from './plugin-system';
+import type { MeshRendererOptions, Renderer, GlobalVolume } from './render';
+import type { Texture } from './texture';
+import { TextureSourceType } from './texture';
+import { RenderFrame } from './render';
+import { Camera } from './camera';
+import { setRayFromCamera } from './math';
+import type { Region } from './plugins';
+import { CompositionSourceManager } from './composition-source-manager';
 
 export interface CompositionStatistic {
   loadTime: number,

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -1,5 +1,6 @@
 import * as spec from '@galacean/effects-specification';
 import type { Ray } from '@galacean/effects-math/es/core/index';
+import type { Vector3 } from '@galacean/effects-math/es/core/vector3';
 import type { SceneType } from './asset-manager';
 import type { Scene } from './scene';
 import type { Disposable, LostHandler } from './utils';
@@ -32,6 +33,13 @@ export interface MessageItem {
   compositionId: number,
 }
 
+export interface CompItemClickedData {
+  name: string,
+  id: string,
+  hitPositions: Vector3[],
+  position: Vector3,
+}
+
 /**
  *
  */
@@ -46,6 +54,7 @@ export interface CompositionProps {
   baseRenderOrder?: number,
   renderer: Renderer,
   onPlayerPause?: (item: VFXItem<any>) => void,
+  onItemClicked?: (item: VFXItem<any>) => void,
   onMessageItem?: (item: MessageItem) => void,
   onEnd?: (composition: Composition) => void,
   event?: EventSystem,
@@ -115,6 +124,13 @@ export class Composition implements Disposable, LostHandler {
    * 合成中消息元素创建/销毁时触发的回调
    */
   onMessageItem?: (item: MessageItem) => void;
+  /**
+   * 合成中元素点击时触发的回调
+   * 不推荐使用
+   * @since 1.5.2
+   * @ignore
+   */
+  onItemClicked?: (data: CompItemClickedData) => void;
   /**
    * 合成id
    */

--- a/packages/effects-core/src/plugins/interact/click-handler.ts
+++ b/packages/effects-core/src/plugins/interact/click-handler.ts
@@ -61,7 +61,7 @@ export type Region = {
   position: Vector3,
   behavior?: spec.InteractBehavior,
   parentId?: string,
-  hitPositions?: Vector3[],
+  hitPositions: Vector3[],
 };
 
 export type HitTestParams = {

--- a/packages/effects-core/src/plugins/interact/event-system.ts
+++ b/packages/effects-core/src/plugins/interact/event-system.ts
@@ -1,6 +1,6 @@
 import * as spec from '@galacean/effects-specification';
 import type { Disposable } from '../../utils';
-import { addItem, removeItem, isSimulatorCellPhone } from '../../utils';
+import { addItem, isSimulatorCellPhone, logger, removeItem } from '../../utils';
 
 export const EVENT_TYPE_CLICK = 'click';
 export const EVENT_TYPE_TOUCH_START = 'touchstart';
@@ -51,10 +51,18 @@ export class EventSystem implements Disposable {
     let touchmove = 'mousemove';
     let touchend = 'mouseup';
     const getTouchEventValue = (event: Event, x: number, y: number, dx = 0, dy = 0): TouchEventType => {
-      const { width, height } = this.target!;
-      const ts = performance.now();
       let vx = 0;
       let vy = 0;
+      const ts = performance.now();
+
+      if (!this.target) {
+        logger.error('Trigger TouchEvent after EventSystem is disposed');
+
+        return {
+          x, y, vx: 0, vy, dx, dy, ts, width: 0, height: 0, origin: event,
+        };
+      }
+      const { width, height } = this.target;
 
       if (lastTouch) {
         const dt = ts - lastTouch.ts;

--- a/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
+++ b/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
@@ -1,18 +1,18 @@
+import { clamp, Vector3 } from '@galacean/effects-math/es/core/index';
 import type { vec3 } from '@galacean/effects-specification';
 import * as spec from '@galacean/effects-specification';
-import { Vector3, clamp } from '@galacean/effects-math/es/core/index';
+import type { Composition } from '../../composition';
 import { PLAYER_OPTIONS_ENV_EDITOR } from '../../constants';
-import type { EventSystem, TouchEventType } from './event-system';
+import type { Engine } from '../../engine';
+import { trianglesFromRect } from '../../math';
+import { assertExist } from '../../utils';
 import type { VFXItemProps } from '../../vfx-item';
 import { VFXItem } from '../../vfx-item';
-import type { HitTestTriangleParams, BoundingBoxTriangle } from './click-handler';
+import type { BoundingBoxTriangle, HitTestTriangleParams } from './click-handler';
 import { HitTestType } from './click-handler';
-import { trianglesFromRect } from '../../math';
-import type { Composition } from '../../composition';
-import { InteractMesh } from './interact-mesh';
+import type { EventSystem, TouchEventType } from './event-system';
 import type { InteractItem } from './interact-item';
-import type { Engine } from '../../engine';
-import { assertExist } from '../../utils';
+import { InteractMesh } from './interact-mesh';
 
 interface DragEventType extends TouchEventType {
   cameraParam?: {
@@ -28,6 +28,7 @@ export class InteractVFXItem extends VFXItem<InteractItem> {
   private clickable: boolean;
   private dragEvent: DragEventType | null;
   private bouncingArg: TouchEventType | null;
+
   engine?: Engine;
 
   constructor (props: VFXItemProps, composition: Composition) {
@@ -147,6 +148,9 @@ export class InteractVFXItem extends VFXItem<InteractItem> {
     let dragEvent: Partial<DragEventType> | null;
     const handlerMap: Record<string, (event: TouchEventType) => void> = {
       touchstart: (event: TouchEventType) => {
+        if (!this.composition?.interactive) {
+          return;
+        }
         this.dragEvent = null;
         this.bouncingArg = null;
         const camera = this.composition?.camera;
@@ -165,6 +169,9 @@ export class InteractVFXItem extends VFXItem<InteractItem> {
         this.bouncingArg = event;
       },
       touchend: (event: TouchEventType) => {
+        if (!this.composition?.interactive) {
+          return;
+        }
         const bouncingArg = this.bouncingArg as TouchEventType;
 
         if (!shouldIgnoreBouncing(bouncingArg, 3) && bouncingArg) {
@@ -195,7 +202,7 @@ export class InteractVFXItem extends VFXItem<InteractItem> {
   }
 
   private handleDragMove (evt: Partial<DragEventType>, event: TouchEventType) {
-    if (!(evt && evt.cameraParam) || !this.composition) {
+    if (!(evt && evt.cameraParam) || !this.composition || !this.composition.interactive) {
       return;
     }
 

--- a/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
+++ b/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
@@ -202,7 +202,7 @@ export class InteractVFXItem extends VFXItem<InteractItem> {
   }
 
   private handleDragMove (evt: Partial<DragEventType>, event: TouchEventType) {
-    if (!(evt && evt.cameraParam) || !this.composition || !this.composition.interactive) {
+    if (!(evt && evt.cameraParam) || !this.composition?.interactive) {
       return;
     }
 

--- a/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
+++ b/packages/effects-core/src/plugins/interact/interact-vfx-item.ts
@@ -1,5 +1,5 @@
-import { clamp, Vector3 } from '@galacean/effects-math/es/core/index';
-import type { vec3 } from '@galacean/effects-specification';
+import { clamp } from '@galacean/effects-math/es/core/utils';
+import { Vector3 } from '@galacean/effects-math/es/core/vector3';
 import * as spec from '@galacean/effects-specification';
 import type { Composition } from '../../composition';
 import { PLAYER_OPTIONS_ENV_EDITOR } from '../../constants';
@@ -16,7 +16,7 @@ import { InteractMesh } from './interact-mesh';
 
 interface DragEventType extends TouchEventType {
   cameraParam?: {
-    position: vec3,
+    position: spec.vec3,
     fov: number,
   },
 }

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -1,7 +1,7 @@
 import type {
   Disposable, GLType, LostHandler, MessageItem, RestoreHandler,
   SceneLoadOptions, Texture2DSourceOptionsVideo, TouchEventType, VFXItem, VFXItemContent,
-  SceneType, math, GPUCapability,
+  SceneType, GPUCapability, CompItemClickedData,
 } from '@galacean/effects-core';
 import {
   Ticker,
@@ -30,11 +30,9 @@ import { isDowngradeIOS } from './utils';
 /**
  * `onItemClicked` 点击回调函数的传入参数
  */
-export interface ItemClickedData {
-  name: string,
+export interface ItemClickedData extends CompItemClickedData {
   player: Player,
-  id: string,
-  hitPositions: math.Vector3[],
+  composition: string,
   compositionId: number,
 }
 
@@ -178,7 +176,7 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
   private readonly handleMessageItem?: (item: MessageItem) => void;
   private readonly handlePlayerPause?: (item: VFXItem<VFXItemContent>) => void;
   private readonly reportGPUTime?: (time: number) => void;
-  private readonly handleItemClicked?: (event: any) => void;
+  private readonly handleItemClicked?: (event: ItemClickedData) => void;
   private readonly handlePlayableUpdate?: (event: { playing: boolean, player: Player }) => void;
   private readonly handleRenderError?: (err: Error) => void;
   private displayAspect: number;
@@ -865,11 +863,19 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
           const behavior = regions[i].behavior || spec.InteractBehavior.NOTIFY;
 
           if (behavior === spec.InteractBehavior.NOTIFY) {
-            this.handleItemClicked?.({
-              ...regions[i],
-              composition: composition.name,
-              player: this,
-            });
+            if (composition.onItemClicked) {
+              composition.onItemClicked({
+                ...regions[i],
+              });
+            } else {
+              this.handleItemClicked?.({
+                ...regions[i],
+                compositionId: composition.id,
+                composition: composition.name,
+                player: this,
+              });
+            }
+
           } else if (behavior === spec.InteractBehavior.RESUME_PLAYER) {
             void this.resume();
           }

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -32,7 +32,11 @@ import { isDowngradeIOS } from './utils';
  */
 export interface ItemClickedData extends CompItemClickedData {
   player: Player,
+  /**
+   * @deprecated since 1.6.0 - use `compositionName` instead
+   */
   composition: string,
+  compositionName: string,
   compositionId: number,
 }
 
@@ -871,6 +875,7 @@ export class Player implements Disposable, LostHandler, RestoreHandler {
               this.handleItemClicked?.({
                 ...regions[i],
                 compositionId: composition.id,
+                compositionName: composition.name,
                 composition: composition.name,
                 player: this,
               });

--- a/plugin-packages/spine/src/spine-vfx-item.ts
+++ b/plugin-packages/spine/src/spine-vfx-item.ts
@@ -260,10 +260,10 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
    */
   setAnimation (animation: string, speed?: number) {
     if (!this.skeleton || !this.state) {
-      throw new Error('Set animation before skeleton create');
+      throw new Error('set animation before skeleton create.');
     }
     if (!this.animationList.length) {
-      throw new Error('animationList is empty, check your spine file');
+      throw new Error('animationList is empty, check your spine file.');
     }
     const loop = this.endBehavior === spec.ItemEndBehavior.loop;
     const listener = this.state.tracks[0]?.listener;
@@ -275,7 +275,7 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
     this.state.setEmptyAnimation(0);
 
     if (!this.animationList.includes(animation)) {
-      console.warn(`animation ${JSON.stringify(animation)} not exists in animationList: ${this.animationList}, set to ${this.animationList[0]}`);
+      console.warn(`animation ${JSON.stringify(animation)} not exists in animationList: ${this.animationList}, set to ${this.animationList[0]}.`);
 
       this.state.setAnimation(0, this.animationList[0], loop);
       this.activeAnimation = [this.animationList[0]];
@@ -284,8 +284,8 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
       this.activeAnimation = [animation];
     }
 
-    if (!isNaN(speed as number)) {
-      this.setSpeed(speed as number);
+    if (speed !== undefined && !isNaN(speed)) {
+      this.setSpeed(speed);
     }
   }
 
@@ -328,8 +328,8 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
       }
     }
     this.activeAnimation = animationList;
-    if (!isNaN(speed as number)) {
-      this.setSpeed(speed as number);
+    if (speed !== undefined && !isNaN(speed)) {
+      this.setSpeed(speed);
     }
   }
 
@@ -341,10 +341,10 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
    */
   setAnimationListLoopEnd (animationList: string[], speed?: number) {
     if (!this.skeleton || !this.state) {
-      throw new Error('Set animation before skeleton create');
+      throw new Error('set animation before skeleton create.');
     }
     if (!this.animationList.length) {
-      throw new Error('animationList is empty, please check your setting');
+      throw new Error('animationList is empty, please check your setting.');
     }
     if (animationList.length === 1) {
       this.setAnimation(animationList[0], speed);
@@ -354,12 +354,11 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
     const listener = this.state.tracks[0]?.listener;
 
     if (listener) {
-      listener.end = () => {};
+      listener.end = () => { };
     }
     this.state.setEmptyAnimation(0);
     for (let i = 0; i < animationList.length - 1; i++) {
       const animation = animationList[i];
-
       const trackEntry = this.state.setAnimation(0, animation, false);
 
       if (i === animationList.length - 2) {

--- a/plugin-packages/spine/src/spine-vfx-item.ts
+++ b/plugin-packages/spine/src/spine-vfx-item.ts
@@ -337,6 +337,7 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
    * 设置播放一组动画，循环播放最后一个
    * @param animationList - 动画名列表
    * @param speed - 播放速度
+   * @since 1.5.2
    */
   setAnimationListLoopEnd (animationList: string[], speed?: number) {
     if (!this.skeleton || !this.state) {
@@ -406,6 +407,7 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
   /**
    * 获取当前 Spine 中的 AnimationState
    * @returns
+   * @since 1.5.2
    */
   getAnimationState (): AnimationState {
     return this.state;

--- a/plugin-packages/spine/src/spine-vfx-item.ts
+++ b/plugin-packages/spine/src/spine-vfx-item.ts
@@ -337,7 +337,7 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
    * 设置播放一组动画，循环播放最后一个
    * @param animationList - 动画名列表
    * @param speed - 播放速度
-   * @since 1.5.2
+   * @since 1.6.0
    */
   setAnimationListLoopEnd (animationList: string[], speed?: number) {
     if (!this.skeleton || !this.state) {
@@ -407,7 +407,7 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
   /**
    * 获取当前 Spine 中的 AnimationState
    * @returns
-   * @since 1.5.2
+   * @since 1.6.0
    */
   getAnimationState (): AnimationState {
     return this.state;

--- a/plugin-packages/spine/src/spine-vfx-item.ts
+++ b/plugin-packages/spine/src/spine-vfx-item.ts
@@ -253,6 +253,11 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
     this.content?.update();
   }
 
+  /**
+   * 设置单个动画
+   * @param animation - 动画名
+   * @param speed - 播放速度
+   */
   setAnimation (animation: string, speed?: number) {
     if (!this.skeleton || !this.state) {
       throw new Error('Set animation before skeleton create');
@@ -284,6 +289,11 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
     }
   }
 
+  /**
+   * 设置播放一组动画
+   * @param animationList - 动画名列表
+   * @param speed - 播放速度
+   */
   setAnimationList (animationList: string[], speed?: number) {
     if (!this.skeleton || !this.state) {
       throw new Error('Set animation before skeleton create');
@@ -324,6 +334,48 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
   }
 
   /**
+   * 设置播放一组动画，循环播放最后一个
+   * @param animationList - 动画名列表
+   * @param speed - 播放速度
+   */
+  setAnimationListLoopEnd (animationList: string[], speed?: number) {
+    if (!this.skeleton || !this.state) {
+      throw new Error('Set animation before skeleton create');
+    }
+    if (!this.animationList.length) {
+      throw new Error('animationList is empty, please check your setting');
+    }
+    if (animationList.length === 1) {
+      this.setAnimation(animationList[0], speed);
+
+      return;
+    }
+    const listener = this.state.tracks[0]?.listener;
+
+    if (listener) {
+      listener.end = () => {};
+    }
+    this.state.setEmptyAnimation(0);
+    for (let i = 0; i < animationList.length - 1; i++) {
+      const animation = animationList[i];
+
+      const trackEntry = this.state.setAnimation(0, animation, false);
+
+      if (i === animationList.length - 2) {
+        trackEntry.listener = {
+          complete: () => {
+            this.state.setAnimation(0, animationList[animationList.length - 1], true);
+          },
+        };
+      }
+
+    }
+    if (!isNaN(speed as number)) {
+      this.setSpeed(speed as number);
+    }
+  }
+
+  /**
    * 设置 Spine 播放的速度
    * @param speed - 速度
    */
@@ -349,6 +401,14 @@ export class SpineVFXItem extends VFXItem<SpineContent> {
    */
   getActiveAnimation (): string[] {
     return this.activeAnimation;
+  }
+
+  /**
+   * 获取当前 Spine 中的 AnimationState
+   * @returns
+   */
+  getAnimationState (): AnimationState {
+    return this.state;
   }
 
   /**

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -1,4 +1,5 @@
 import { Player } from '@galacean/effects';
+import '@galacean/effects-plugin-spine';
 import inspireList from './assets/inspire-list';
 
 const json = inspireList.turnplate.url;
@@ -6,9 +7,7 @@ const json = inspireList.turnplate.url;
 (async () => {
   try {
     const player = createPlayer();
-
-    await player.loadScene(json);
-
+    const comp = await player.loadScene(json);
   } catch (e) {
     console.error('biz', e);
   }

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -7,7 +7,8 @@ const json = inspireList.turnplate.url;
 (async () => {
   try {
     const player = createPlayer();
-    const comp = await player.loadScene(json);
+
+    await player.loadScene(json);
   } catch (e) {
     console.error('biz', e);
   }
@@ -21,7 +22,7 @@ function createPlayer () {
     },
     // manualRender: true,
     renderFramework: 'webgl',
-    // env: 'editor',
+    env: 'editor',
     notifyTouch: true,
     onPausedByItem: data => {
       console.info('onPausedByItem', data);


### PR DESCRIPTION
1.  增加 Spine 动画播放接口 setAnimationListLoopEnd
2.  增加 Composition 上交互响应属性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `interactive` property to control interactivity within compositions.
  - Introduced methods in `SpineVFXItem` for setting animations, handling animation lists, and accessing the current animation state.

- **Bug Fixes**
  - Improved error handling in event systems to manage null targets effectively.
  - Made `hitPositions` a required field in the `Region` type to ensure consistency.

- **Improvements**
  - Enhanced the `ItemClickedData` interface and adjusted the `handleItemClicked` method for better type safety and functionality.
  - Improved scene loading in the demo player with new variable assignments for loaded scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->