### PR TITLE
fix: GLTFTexture clone problem

### DIFF
--- a/packages/effects-core/package.json
+++ b/packages/effects-core/package.json
@@ -50,7 +50,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@galacean/effects-specification": "2.0.0-alpha.19",
+    "@galacean/effects-specification": "2.0.0-alpha.20",
     "@galacean/effects-math": "1.1.0",
     "uuid": "9.0.1"
   }

--- a/plugin-packages/model/demo/src/hit-test.ts
+++ b/plugin-packages/model/demo/src/hit-test.ts
@@ -16,8 +16,9 @@ let composition;
 
 let playScene;
 
-const url = 'https://gw.alipayobjects.com/os/bmw-prod/2b867bc4-0e13-44b8-8d92-eb2db3dfeb03.glb';
+let url;
 
+url = 'https://gw.alipayobjects.com/os/bmw-prod/2b867bc4-0e13-44b8-8d92-eb2db3dfeb03.glb';
 url = 'https://gw.alipayobjects.com/os/gltf-asset/89748482160728/DamagedHelmet.glb';
 
 const compatibleMode = 'tiny3d';

--- a/plugin-packages/model/package.json
+++ b/plugin-packages/model/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@galacean/effects": "workspace:*",
     "@galacean/effects-plugin-editor-gizmo": "workspace:*",
-    "@vvfx/resource-detection": "0.6.0-alpha.9",
+    "@vvfx/resource-detection": "0.6.0-alpha.11",
     "@types/hammerjs": "^2.0.45",
     "fpsmeter": "^0.3.1",
     "hammerjs": "^2.0.8"

--- a/plugin-packages/model/src/gltf/loader-impl.ts
+++ b/plugin-packages/model/src/gltf/loader-impl.ts
@@ -235,15 +235,9 @@ export class LoaderImpl implements Loader {
 
         if (texData) {
           const newId = generateGUID();
-          // @ts-expect-error
-          const newTexData: GLTFTexture = {
-            ...texData,
-          };
+          const newTexData = texData.clone();
 
-          newTexData.textureOptions = {
-            ...texData.textureOptions,
-            id: newId,
-          };
+          newTexData.textureOptions.id = newId;
           textures.push(newTexData);
           textureDataMap[newId] = newTexData.textureOptions;
           textureIdMap[baseColorId] = newId;

--- a/web-packages/test/package.json
+++ b/web-packages/test/package.json
@@ -9,6 +9,6 @@
     "@galacean/effects": "workspace:*",
     "@galacean/effects-helper": "workspace:*",
     "@galacean/effects-threejs": "workspace:*",
-    "@vvfx/resource-detection": "0.6.0-alpha.9"
+    "@vvfx/resource-detection": "0.6.0-alpha.11"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
  - Updated `@galacean/effects-specification` to `2.0.0-alpha.20` in `effects-core`.
  - Updated `@vvfx/resource-detection` to `0.6.0-alpha.11` in `plugin-packages/model` and `web-packages/test`.

- **Improvements**
  - Optimized URL initialization in hit-test functionality.
  - Enhanced GLTF texture handling by using `clone()` method, improving performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->