### PR TITLE
fix: 修复当 variable 为 number 时文本设置失效问题

### DIFF
--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -62,7 +62,7 @@ export class TextItem extends SpriteItem {
     this.textStyle = new TextStyle(options);
     this.textLayout = new TextLayout(options);
 
-    this.text = options.text;
+    this.text = options.text.toString();
 
     this.lineCount = this.getLineCount(options.text, true);
     // Text
@@ -149,7 +149,7 @@ export class TextItem extends SpriteItem {
     if (this.text === value) {
       return;
     }
-    this.text = value;
+    this.text = value.toString();
     this.lineCount = this.getLineCount(value, false);
     this.isDirty = true;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where non-string values for text properties could lead to errors by ensuring all text inputs are converted to strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->