### PR TITLE
fix: 修复文本自动宽度支持

### DIFF
--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -11,6 +11,7 @@ import { effectsClass } from '../../decorators';
 import { canvasPool } from '../../canvas-pool';
 import { applyMixins, isValidFontFamily } from '../../utils';
 import type { Material } from '../../material';
+import type { VFXItem } from '../../vfx-item';
 
 export const DEFAULT_FONTS = [
   'serif',
@@ -102,6 +103,7 @@ export class TextComponentBase {
   engine: Engine;
   material: Material;
   lineCount: number;
+  item: VFXItem;
   /***** mix 类型兼容用 *****/
 
   private char: string[];
@@ -372,20 +374,17 @@ export class TextComponentBase {
     const fontScale = style.fontScale;
 
     const width = (layout.width + style.fontOffset) * fontScale;
-
     const finalHeight = layout.lineHeight * this.lineCount;
 
     const fontSize = style.fontSize * fontScale;
     const lineHeight = layout.lineHeight * fontScale;
 
     this.char = (this.text || '').split('');
-
     this.canvas.width = width;
+
     if (layout.autoWidth) {
       this.canvas.height = finalHeight * fontScale;
-      // @ts-expect-error transform 存在于 SpriteComponent
-      this.transform.size.set(1, finalHeight / layout.height);
-
+      this.item.transform.size.set(1, finalHeight / layout.height);
     } else {
       this.canvas.height = layout.height * fontScale;
     }

--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -345,8 +345,8 @@ export class TextComponentBase {
   }
 
   /**
-   * 设置自动宽度开关
-   * @param value - 是否开启自动宽度
+   * 设置自适应宽高开关
+   * @param value - 是否自适应宽高开关
    * @returns
    */
   setAutoWidth (value: boolean): void {

--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -345,6 +345,20 @@ export class TextComponentBase {
   }
 
   /**
+   * 设置自动宽度开关
+   * @param value - 是否开启自动宽度
+   * @returns
+   */
+  setAutoWidth (value: boolean): void {
+    if (this.textLayout.autoWidth === value) {
+      return;
+    }
+
+    this.textLayout.autoWidth = value;
+    this.isDirty = true;
+  }
+
+  /**
    * 更新文本
    * @returns
    */
@@ -358,7 +372,8 @@ export class TextComponentBase {
     const fontScale = style.fontScale;
 
     const width = (layout.width + style.fontOffset) * fontScale;
-    const height = layout.height * fontScale;
+
+    const finalHeight = layout.lineHeight * this.lineCount;
 
     const fontSize = style.fontSize * fontScale;
     const lineHeight = layout.lineHeight * fontScale;
@@ -366,9 +381,18 @@ export class TextComponentBase {
     this.char = (this.text || '').split('');
 
     this.canvas.width = width;
-    this.canvas.height = height;
+    if (layout.autoWidth) {
+      this.canvas.height = finalHeight * fontScale;
+      // @ts-expect-error transform 存在于 SpriteComponent
+      this.transform.size.set(1, finalHeight / layout.height);
 
-    context.clearRect(0, 0, width, this.canvas.height);
+    } else {
+      this.canvas.height = layout.height * fontScale;
+    }
+
+    const height = this.canvas.height;
+
+    context.clearRect(0, 0, width, height);
     // fix bug 1/255
     context.fillStyle = 'rgba(255, 255, 255, 0.0039)';
 
@@ -377,7 +401,7 @@ export class TextComponentBase {
       context.scale(1, -1);
     }
 
-    context.fillRect(0, 0, width, this.canvas.height);
+    context.fillRect(0, 0, width, height);
     style.fontDesc = this.getFontDesc();
     context.font = style.fontDesc;
 

--- a/packages/effects-core/src/plugins/text/text-layout.ts
+++ b/packages/effects-core/src/plugins/text/text-layout.ts
@@ -30,19 +30,6 @@ export class TextLayout {
     this.autoWidth = autoWidth;
     this.maxTextWidth = text.length * tempWidth;
 
-    // if (autoWidth) {
-    //   this.width = this.maxTextWidth + this.lineWidth;
-    //   this.height = fontSize + this.lineHeight;
-    // } else {
-    //   if (textWidth) {
-    //     this.maxCharCount = Math.floor((textWidth - this.lineWidth) / (tempWidth));
-    //     this.width = textWidth;
-    //   } else {
-    //     this.width = basicScale[0] * 100;
-    //   }
-    //   this.height = basicScale[1] * 100;
-    // }
-
     this.width = textWidth;
     this.height = textHeight;
 


### PR DESCRIPTION
- autoWidth 参数开关，默认为false
- 当 autoWidth 为 true 时，文本在设置后会自动根据布局换行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new method to toggle auto width in text components, improving control over text rendering.
- **Refactor**
  - Simplified logic for width and height calculations in text layout, ensuring more consistent and predictable text rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->