### PR TITLE
fix: support max bone count for skin

### DIFF
--- a/plugin-packages/model/src/plugin/model-item.ts
+++ b/plugin-packages/model/src/plugin/model-item.ts
@@ -67,10 +67,10 @@ export class ModelMeshComponent extends RendererComponent {
    * 组件开始，需要创建内部对象，更新父元素信息和添加到场景管理器中
    */
   override start (): void {
+    this.sceneManager = getSceneManager(this);
     this.createContent();
     this.item.type = VFX_ITEM_TYPE_3D;
     this.priority = this.item.renderOrder;
-    this.sceneManager = getSceneManager(this);
     this.sceneManager?.addItem(this.content);
     if (this.item.parentId && this.item.parent) {
       this.content.updateParentInfo(this.item.parentId, this.item.parent);

--- a/plugin-packages/model/src/plugin/model-plugin.ts
+++ b/plugin-packages/model/src/plugin/model-plugin.ts
@@ -16,13 +16,14 @@ import {
   PLAYER_OPTIONS_ENV_EDITOR,
   effectsClass,
   GLSLVersion,
+  Geometry,
 } from '@galacean/effects';
 import { CompositionCache } from '../runtime/cache';
 import { PluginHelper } from '../utility/plugin-helper';
 import { PTransform, PSceneManager, PCoordinate, PBRShaderGUID, UnlitShaderGUID } from '../runtime';
 import { DEG2RAD, Matrix4, Vector3 } from '../runtime/math';
 import { VFX_ITEM_TYPE_3D } from './const';
-import { ModelCameraComponent, ModelLightComponent } from './model-item';
+import { ModelCameraComponent, ModelLightComponent, ModelMeshComponent } from './model-item';
 import { fetchPBRShaderCode, fetchUnlitShaderCode } from '../utility';
 
 /**
@@ -310,6 +311,7 @@ export class ModelPluginComponent extends ItemBehaviour {
       renderMode3DUVGridSize: this.renderMode3DUVGridSize,
       renderSkybox: this.renderSkybox,
       lightItemCount: this.getLightItemCount(),
+      maxJointCount: this.getMaxJointCount(),
     });
     this.updateSceneCamera(component);
   }
@@ -335,6 +337,29 @@ export class ModelPluginComponent extends ItemBehaviour {
     });
 
     return lightItemCount;
+  }
+
+  private getMaxJointCount (): number {
+    let maxJointCount = 0;
+    const items = this.item.composition?.items ?? [];
+
+    items.forEach(item => {
+      const meshComp = item.getComponent(ModelMeshComponent);
+
+      if (meshComp && meshComp.data) {
+        const geometry = meshComp.data.geometry;
+
+        if (geometry instanceof Geometry) {
+          const skin = geometry.getSkinProps();
+
+          if (skin.boneNames) {
+            maxJointCount = Math.max(skin.boneNames.length, maxJointCount);
+          }
+        }
+      }
+    });
+
+    return maxJointCount;
   }
 }
 

--- a/plugin-packages/model/src/runtime/animation.ts
+++ b/plugin-packages/model/src/runtime/animation.ts
@@ -76,7 +76,7 @@ export class PSkin extends PObject {
     //
     this.inverseBindMatrices = [];
     //
-    this.textureDataMode = this.getTextureDataMode(maxJointCount, engine);
+    this.textureDataMode = this.getTextureDataMode(this.maxJointCount, engine);
     const matList = props.inverseBindMatrices;
 
     if (matList !== undefined && matList.length > 0) {

--- a/plugin-packages/model/src/runtime/animation.ts
+++ b/plugin-packages/model/src/runtime/animation.ts
@@ -53,6 +53,10 @@ export class PSkin extends PObject {
    * 纹理数据模式
    */
   textureDataMode = TextureDataMode.none;
+  /**
+   * 最大骨骼数目
+   */
+  maxJointCount = 0;
 
   /**
    * 创建蒙皮对象
@@ -60,18 +64,19 @@ export class PSkin extends PObject {
    * @param engine - 引擎对象
    * @param rootBoneItem - 场景树父元素
    */
-  create (props: SkinProps, engine: Engine, rootBoneItem: VFXItem) {
+  create (props: SkinProps, engine: Engine, rootBoneItem: VFXItem, maxJointCount: number) {
     this.name = props.rootBoneName ?? 'Unnamed skin';
     this.type = PObjectType.skin;
     //
     this.rootBoneItem = rootBoneItem;
     this.skeleton = -1;
     this.jointItem = this.getJointItems(props, rootBoneItem);
+    this.maxJointCount = Math.max(maxJointCount, this.jointItem.length);
     this.animationMatrices = [];
     //
     this.inverseBindMatrices = [];
     //
-    this.textureDataMode = this.getTextureDataMode(this.getJointCount(), engine);
+    this.textureDataMode = this.getTextureDataMode(maxJointCount, engine);
     const matList = props.inverseBindMatrices;
 
     if (matList !== undefined && matList.length > 0) {

--- a/plugin-packages/model/src/runtime/mesh.ts
+++ b/plugin-packages/model/src/runtime/mesh.ts
@@ -93,12 +93,12 @@ export class PMesh extends PEntity {
     private engine: Engine,
     name: string,
     meshData: ModelMeshComponentData,
-    owner?: ModelMeshComponent,
+    owner: ModelMeshComponent,
     parentId?: string,
     parent?: VFXItem,
   ) {
     super();
-    const proxy = new EffectsMeshProxy(meshData, parent);
+    const proxy = new EffectsMeshProxy(meshData, owner, parent);
 
     this.name = name;
     this.type = PObjectType.mesh;
@@ -454,7 +454,7 @@ export class PSubMesh {
     this.geometry.setHide(parent.hide);
 
     if (this.skin !== undefined) {
-      const jointCount = this.skin.getJointCount();
+      const jointCount = this.skin.maxJointCount;
 
       this.jointMatrixList = new Float32Array(jointCount * 16);
       this.jointNormalMatList = new Float32Array(jointCount * 16);
@@ -636,7 +636,7 @@ export class PSubMesh {
 
     if (this.skin !== undefined) {
       macroList.push({ name: 'USE_SKINNING' });
-      macroList.push({ name: 'JOINT_COUNT', value: this.skin.getJointCount() });
+      macroList.push({ name: 'JOINT_COUNT', value: this.skin.maxJointCount });
       macroList.push({ name: 'HAS_JOINT_SET1' });
       macroList.push({ name: 'HAS_WEIGHT_SET1' });
       if (this.skin.textureDataMode) {
@@ -1140,6 +1140,7 @@ class EffectsMeshProxy {
 
   constructor (
     public itemData: ModelMeshComponentData,
+    public parentComponent: ModelMeshComponent,
     public parentItem?: VFXItem,
   ) {
     this.data = itemData;
@@ -1222,8 +1223,9 @@ class EffectsMeshProxy {
 
     if (skin.rootBoneName && skin.boneNames && skin.inverseBindMatrices && this.rootBoneItem) {
       const skinObj = new PSkin();
+      const maxJointCount = this.parentComponent.sceneManager?.maxJointCount ?? 0;
 
-      skinObj.create(skin, engine, this.rootBoneItem);
+      skinObj.create(skin, engine, this.rootBoneItem, maxJointCount);
 
       return skinObj;
     }

--- a/plugin-packages/model/src/runtime/scene.ts
+++ b/plugin-packages/model/src/runtime/scene.ts
@@ -69,6 +69,10 @@ export interface PSceneOptions {
    * 灯光元素数目
    */
   lightItemCount: number,
+  /**
+   * 最大骨骼数目
+   */
+  maxJointCount: number,
 }
 
 /**
@@ -120,6 +124,10 @@ export interface PSceneStates {
    * 最大灯光数目
    */
   maxLightCount: number,
+  /**
+   * 最大骨骼数目
+   */
+  maxJointCount: number,
   /**
    * 天空盒对象
    */
@@ -184,6 +192,10 @@ export class PSceneManager {
    */
   maxLightCount = 16;
   /**
+   * 最大骨骼数目
+   */
+  maxJointCount = 0;
+  /**
    * 场景状态
    */
   sceneStates: PSceneStates;
@@ -225,6 +237,7 @@ export class PSceneManager {
     this.enableDynamicSort = opts.enableDynamicSort === true;
     this.renderSkybox = opts.renderSkybox;
     this.maxLightCount = opts.lightItemCount;
+    this.maxJointCount = opts.maxJointCount;
     this.cameraManager.initial(this.renderer.getWidth(), this.renderer.getHeight());
     this.brdfLUT = this.sceneCache.getBrdfLutTexture();
     this.initGlobalState(opts);
@@ -397,6 +410,7 @@ export class PSceneManager {
       //
       lightList: this.lightManager.lightList,
       maxLightCount: this.maxLightCount,
+      maxJointCount: this.maxJointCount,
       skybox: this.skybox,
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for calculating the maximum number of joints in the model plugin component, enhancing mesh functionality.
	- Added a `maxJointCount` property to scene options and states, improving scene configuration capabilities.

- **Improvements**
	- Rearranged initialization logic in the `ModelMeshComponent` for enhanced reliability during startup.
	- Updated the handling of joint counts in various components for better performance and clarity. 

These changes collectively enhance the overall functionality and user experience in managing 3D models and animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->