### PR TITLE
fix: runtime 2.0 component export

### DIFF
--- a/packages/effects-core/src/plugins/cal/calculate-item.ts
+++ b/packages/effects-core/src/plugins/cal/calculate-item.ts
@@ -27,7 +27,6 @@ export type ItemLinearVelOverLifetime = {
 
 /**
  * @since 2.0.0
- * @internal
  */
 @effectsClass('ObjectBindingTrack')
 export class ObjectBindingTrack extends TrackAsset {

--- a/packages/effects-core/src/plugins/cal/calculate-vfx-item.ts
+++ b/packages/effects-core/src/plugins/cal/calculate-vfx-item.ts
@@ -18,7 +18,6 @@ const tempPos = new Vector3();
 
 /**
  * @since 2.0.0
- * @internal
  */
 export class TransformAnimationPlayable extends AnimationPlayable {
   originalTransform: ItemBasicTransform;
@@ -238,7 +237,6 @@ export interface TransformPlayableAssetData extends spec.EffectsObjectData {
 
 /**
  * @since 2.0.0
- * @internal
  */
 export class ActivationPlayable extends Playable {
 

--- a/packages/effects-core/src/plugins/cal/playable-graph.ts
+++ b/packages/effects-core/src/plugins/cal/playable-graph.ts
@@ -4,7 +4,6 @@ import type { Disposable } from '../../utils';
 /**
  * 动画图，负责更新所有的动画节点
  * @since 2.0.0
- * @internal
  */
 export class PlayableGraph {
   private playableOutputs: PlayableOutput[] = [];
@@ -67,7 +66,6 @@ export class PlayableGraph {
 /**
  * 动画图可播放节点对象
  * @since 2.0.0
- * @internal
  */
 export class Playable implements Disposable {
   onPlayablePlayFlag = true;
@@ -331,7 +329,6 @@ export class Playable implements Disposable {
 /**
  * 动画图输出节点对象，将动画数据采样到绑定的元素属性上
  * @since 2.0.0
- * @internal
  */
 export class PlayableOutput {
   /**

--- a/packages/effects-core/src/plugins/particle/particle-vfx-item.ts
+++ b/packages/effects-core/src/plugins/particle/particle-vfx-item.ts
@@ -5,7 +5,6 @@ import { ParticleSystem } from './particle-system';
 
 /**
  * @since 2.0.0
- * @internal
  */
 export class ParticleBehaviourPlayable extends Playable {
   lastTime = 0;

--- a/packages/effects-core/src/plugins/timeline/track.ts
+++ b/packages/effects-core/src/plugins/timeline/track.ts
@@ -8,7 +8,6 @@ import type { Constructor } from '../../utils';
 
 /**
  * @since 2.0.0
- * @internal
  */
 export class TimelineClip {
   id: string;
@@ -39,7 +38,6 @@ export class TimelineClip {
 
 /**
  * @since 2.0.0
- * @internal
  */
 @effectsClass('TrackAsset')
 export class TrackAsset extends PlayableAsset {
@@ -239,7 +237,6 @@ export class RuntimeClip {
 
 /**
  * @since 2.0.0
- * @internal
  */
 export interface TimelineClipData {
   asset: PlayableAsset,

--- a/packages/effects-core/src/render/create-copy-shader.ts
+++ b/packages/effects-core/src/render/create-copy-shader.ts
@@ -23,7 +23,7 @@ uniform sampler2D uDepth;
 void main(){
     #ifdef DEPTH_TEXTURE
     gl_FragDepthEXT = texture2D(uDepth,vTex).r;
-    #endifc
+    #endif
 }
 `;
 

--- a/packages/effects-core/src/render/create-copy-shader.ts
+++ b/packages/effects-core/src/render/create-copy-shader.ts
@@ -23,7 +23,7 @@ uniform sampler2D uDepth;
 void main(){
     #ifdef DEPTH_TEXTURE
     gl_FragDepthEXT = texture2D(uDepth,vTex).r;
-    #endif
+    #endifc
 }
 `;
 

--- a/packages/effects-threejs/src/three-text-component.ts
+++ b/packages/effects-threejs/src/three-text-component.ts
@@ -7,7 +7,6 @@ export interface ThreeTextComponent extends TextComponentBase { }
 
 /**
  * @since 2.0.0
- * @internal
  */
 @effectsClass(spec.DataType.TextComponent)
 export class ThreeTextComponent extends ThreeSpriteComponent {

--- a/plugin-packages/model/src/plugin/model-item.ts
+++ b/plugin-packages/model/src/plugin/model-item.ts
@@ -19,7 +19,6 @@ import { getSceneManager } from './model-plugin';
 /**
  * 插件 Mesh 组件类，支持 3D Mesh 渲染能力
  * @since 2.0.0
- * @internal
  */
 @effectsClass(spec.DataType.MeshComponent)
 export class ModelMeshComponent extends RendererComponent {
@@ -241,7 +240,6 @@ export class ModelMeshComponent extends RendererComponent {
 /**
  * 插件天空盒组件类，支持 3D 天空盒渲染能力
  * @since 2.0.0
- * @internal
  */
 @effectsClass(spec.DataType.SkyboxComponent)
 export class ModelSkyboxComponent extends RendererComponent {
@@ -343,7 +341,6 @@ export class ModelSkyboxComponent extends RendererComponent {
 /**
  * 插件灯光组件类，支持 3D 灯光能力
  * @since 2.0.0
- * @internal
  */
 @effectsClass(spec.DataType.LightComponent)
 export class ModelLightComponent extends Behaviour {
@@ -435,7 +432,6 @@ export class ModelLightComponent extends Behaviour {
 /**
  * 插件相机组件类，支持 3D 相机能力
  * @since 2.0.0
- * @internal
  */
 @effectsClass(spec.DataType.CameraComponent)
 export class ModelCameraComponent extends Behaviour {
@@ -546,7 +542,6 @@ export class ModelCameraComponent extends Behaviour {
 /**
  * 插件动画组件类，支持 3D 动画能力
  * @since 2.0.0
- * @internal
  */
 @effectsClass(spec.DataType.AnimationComponent)
 export class AnimationComponent extends Behaviour {

--- a/plugin-packages/model/src/plugin/model-tree-item.ts
+++ b/plugin-packages/model/src/plugin/model-tree-item.ts
@@ -174,7 +174,6 @@ export class ModelTreeItem {
 /**
  * 插件场景树组件类，实现 3D 场景树功能
  * @since 2.0.0
- * @internal
  */
 @effectsClass(spec.DataType.TreeComponent)
 export class ModelTreeComponent extends Behaviour {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility of multiple classes and components by removing the `@internal` annotation, allowing for broader access and potential use in external applications.
	- Classes such as `ObjectBindingTrack`, `TransformAnimationPlayable`, `PlayableGraph`, and others are now part of the public API.

- **Documentation**
	- Updated documentation comments across various classes to reflect their new public status, improving clarity for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->