### PR TITLE
fix: stats should dispose when player is dispose

### DIFF
--- a/plugin-packages/stats/src/monitor.ts
+++ b/plugin-packages/stats/src/monitor.ts
@@ -1,3 +1,4 @@
+import type { Disposable } from '@galacean/effects';
 import type { PerformanceData } from './core';
 import { Core } from './core';
 
@@ -56,7 +57,7 @@ const css = `
   }
 `;
 
-export class Monitor {
+export class Monitor implements Disposable {
   private core: Core;
   private doms: HTMLElement[];
   private container: HTMLElement;
@@ -105,7 +106,7 @@ export class Monitor {
   /**
    * Update per frame
    */
-  public update (dt: number): void {
+  update (dt: number): void {
     const data = this.core.update(dt);
 
     if (!data || data.drawCall === 0 || data.triangles === 0) {
@@ -127,7 +128,7 @@ export class Monitor {
   /**
    * reset all hooks
    */
-  public reset (): void {
+  reset (): void {
     this.core.reset();
 
     for (let i = 0, l = this.items.length; i < l; i++) {
@@ -145,14 +146,14 @@ export class Monitor {
   /**
    * release all hooks
    */
-  public release (): void {
+  release (): void {
     this.core.release();
   }
 
   /**
-   * destroy the instance
+   * dispose the instance
    */
-  public destroy (): void {
+  dispose (): void {
     this.release();
     document.body.removeChild(this.container);
   }

--- a/plugin-packages/stats/src/stats-component.ts
+++ b/plugin-packages/stats/src/stats-component.ts
@@ -17,4 +17,9 @@ export class StatsComponent extends Behaviour {
   override update (dt: number): void {
     this.monitor.update(dt);
   }
+
+  override dispose (): void {
+    super.dispose();
+    this.monitor.dispose();
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,12 @@ importers:
       '@galacean/effects-plugin-orientation-transformer':
         specifier: workspace:*
         version: link:../../plugin-packages/orientation-transformer
+      '@galacean/effects-plugin-spine':
+        specifier: workspace:*
+        version: link:../../plugin-packages/spine
+      '@galacean/effects-plugin-stats':
+        specifier: workspace:*
+        version: link:../../plugin-packages/stats
       '@galacean/effects-threejs':
         specifier: workspace:*
         version: link:../../packages/effects-threejs

--- a/web-packages/demo/package.json
+++ b/web-packages/demo/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "@galacean/effects": "workspace:*",
     "@galacean/effects-threejs": "workspace:*",
+    "@galacean/effects-plugin-stats": "workspace:*",
+    "@galacean/effects-plugin-spine": "workspace:*",
     "@galacean/effects-plugin-orientation-transformer": "workspace:*",
     "three": "^0.149.0"
   },

--- a/web-packages/demo/src/render-level.ts
+++ b/web-packages/demo/src/render-level.ts
@@ -1,5 +1,6 @@
 import type { SceneRenderLevel } from '@galacean/effects';
 import { Player, spec } from '@galacean/effects';
+import { Stats } from '@galacean/effects-plugin-stats';
 
 const json = 'https://mdn.alipayobjects.com/mars/afts/file/A*GC99RbcyZiMAAAAAAAAAAAAADlB4AQ';
 const container = document.getElementById('J-container');
@@ -7,9 +8,11 @@ const selectEle = document.getElementById('J-select') as HTMLSelectElement;
 
 (async () => {
   try {
-    const player = new Player({
+    let player = new Player({
       container,
     });
+
+    new Stats(player);
 
     await player.loadScene(json, {
       renderLevel: spec.RenderLevel.B,
@@ -19,7 +22,11 @@ const selectEle = document.getElementById('J-select') as HTMLSelectElement;
     selectEle?.addEventListener('change', async () => {
       const renderLevel = selectEle.value as SceneRenderLevel;
 
-      player.getCompositions().forEach(composition => composition.dispose());
+      player.dispose();
+      player = new Player({
+        container,
+      });
+      new Stats(player);
       await player.loadScene(json, {
         renderLevel,
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `dispose` method in the `StatsComponent` to enhance resource management.
	- Added two new dependencies for improved effects functionality in the application.
  
- **Improvements**
	- Enhanced the `Monitor` class for better resource management and lifecycle event handling.
	- Improved instantiation and disposal of the `Player` instance for better performance monitoring and debugging capabilities.

- **Bug Fixes**
	- Ensured proper disposal of previous player instances to prevent resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->