### PR TITLE
fix: subcomposition end behavior not rendering as expected

### DIFF
--- a/packages/effects-core/src/comp-vfx-item.ts
+++ b/packages/effects-core/src/comp-vfx-item.ts
@@ -148,6 +148,18 @@ export class CompositionComponent extends Behaviour {
     }
   }
 
+  showItems () {
+    for (const item of this.items) {
+      item.setVisible(true);
+    }
+  }
+
+  hideItems () {
+    for (const item of this.items) {
+      item.setVisible(false);
+    }
+  }
+
   override onDestroy (): void {
     if (this.item.composition) {
       if (this.items) {

--- a/packages/effects-core/src/plugins/timeline/playables/sub-composition-mixer-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/sub-composition-mixer-playable.ts
@@ -1,0 +1,31 @@
+import { CompositionComponent } from '../../../comp-vfx-item';
+import type { FrameContext } from '../../cal/playable-graph';
+import { Playable } from '../../cal/playable-graph';
+
+export class SubCompositionMixerPlayable extends Playable {
+  override processFrame (context: FrameContext): void {
+    const boundObject = context.output.getUserData();
+
+    if (!(boundObject instanceof CompositionComponent)) {
+      return;
+    }
+
+    const compositionComponent = boundObject;
+
+    let hasInput = false;
+
+    for (let i = 0; i < this.getInputCount(); i++) {
+      if (this.getInputWeight(i) > 0) {
+        hasInput = true;
+
+        break;
+      }
+    }
+
+    if (hasInput) {
+      compositionComponent.showItems();
+    } else {
+      compositionComponent.hideItems();
+    }
+  }
+}

--- a/packages/effects-core/src/plugins/timeline/tracks/sub-composition-track.ts
+++ b/packages/effects-core/src/plugins/timeline/tracks/sub-composition-track.ts
@@ -2,6 +2,8 @@ import { VFXItem } from '../../../vfx-item';
 import { CompositionComponent } from '../../../comp-vfx-item';
 import { TrackAsset } from '../track';
 import { effectsClass } from '../../../decorators';
+import type { PlayableGraph, Playable } from '../../cal/playable-graph';
+import { SubCompositionMixerPlayable } from '../playables/sub-composition-mixer-playable';
 
 @effectsClass('SubCompositionTrack')
 export class SubCompositionTrack extends TrackAsset {
@@ -12,5 +14,9 @@ export class SubCompositionTrack extends TrackAsset {
     }
 
     return parentBinding.getComponent(CompositionComponent);
+  }
+
+  override createTrackMixer (graph: PlayableGraph): Playable {
+    return new SubCompositionMixerPlayable(graph);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods to control item visibility (`showItems` and `hideItems`) in the Composition component.
	- Added a new class (`SubCompositionMixerPlayable`) for enhanced frame processing and dynamic item visibility management based on input weights.
	- Implemented a new track mixer method in the SubCompositionTrack class to improve track mixing capabilities.

- **Bug Fixes**
	- Enhanced validation checks to ensure only valid components are processed in the new SubCompositionMixerPlayable class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->