### PR TITLE
fix: materal uniform dirty flag setting when shader changed

### DIFF
--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -1,6 +1,6 @@
 import type {
   BaseContent, BinaryFile, CompositionData, Item, JSONScene, JSONSceneLegacy, SpineResource,
-  SpineContent,
+  SpineContent, TimelineAssetData,
 } from '@galacean/effects-specification';
 import {
   DataType, END_BEHAVIOR_FREEZE, END_BEHAVIOR_PAUSE, END_BEHAVIOR_PAUSE_AND_DESTROY,
@@ -8,7 +8,6 @@ import {
 } from '@galacean/effects-specification';
 import { generateGUID } from '../utils';
 import { convertAnchor, ensureFixedNumber, ensureFixedVec3 } from './utils';
-import type { spec } from '@galacean/effects-core';
 
 /**
  * 2.1 以下版本数据适配（mars-player@2.4.0 及以上版本支持 2.1 以下数据的适配）
@@ -411,7 +410,7 @@ function convertTimelineAsset (composition: CompositionData, guidToItemMap: Reco
   const sceneBindings = [];
   const trackDatas = [];
   const playableAssetDatas = [];
-  const timelineAssetData: spec.TimelineAssetData = {
+  const timelineAssetData: TimelineAssetData = {
     tracks: [],
     id: generateGUID(),
     //@ts-expect-error

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -6,9 +6,9 @@ import {
   DataType, END_BEHAVIOR_FREEZE, END_BEHAVIOR_PAUSE, END_BEHAVIOR_PAUSE_AND_DESTROY,
   EndBehavior, ItemType,
 } from '@galacean/effects-specification';
-import type { TimelineAssetData } from '../plugins/cal/timeline-asset';
 import { generateGUID } from '../utils';
 import { convertAnchor, ensureFixedNumber, ensureFixedVec3 } from './utils';
+import type { spec } from '@galacean/effects-core';
 
 /**
  * 2.1 以下版本数据适配（mars-player@2.4.0 及以上版本支持 2.1 以下数据的适配）
@@ -411,7 +411,7 @@ function convertTimelineAsset (composition: CompositionData, guidToItemMap: Reco
   const sceneBindings = [];
   const trackDatas = [];
   const playableAssetDatas = [];
-  const timelineAssetData: TimelineAssetData = {
+  const timelineAssetData: spec.TimelineAssetData = {
     tracks: [],
     id: generateGUID(),
     //@ts-expect-error

--- a/packages/effects-core/src/plugins/cal/playable-graph.ts
+++ b/packages/effects-core/src/plugins/cal/playable-graph.ts
@@ -10,11 +10,6 @@ export class PlayableGraph {
   private playables: Playable[] = [];
 
   evaluate (dt: number) {
-    // 初始化节点状态
-    for (const playable of this.playables) {
-      this.updatePlayableTime(playable, dt);
-    }
-
     // 初始化输出节点状态
     for (const playableOutput of this.playableOutputs) {
       playableOutput.context.deltaTime = dt;
@@ -26,6 +21,11 @@ export class PlayableGraph {
     }
     for (const playableOutput of this.playableOutputs) {
       this.processFrameWithRoot(playableOutput);
+    }
+
+    // 更新节点时间
+    for (const playable of this.playables) {
+      this.updatePlayableTime(playable, dt);
     }
   }
 
@@ -55,11 +55,7 @@ export class PlayableGraph {
     if (playable.getPlayState() !== PlayState.Playing) {
       return;
     }
-    if (playable.overrideTimeNextEvaluation) {
-      playable.overrideTimeNextEvaluation = false;
-    } else {
-      playable.setTime(playable.getTime() + deltaTime);
-    }
+    playable.setTime(playable.getTime() + deltaTime);
   }
 }
 
@@ -70,7 +66,6 @@ export class PlayableGraph {
 export class Playable implements Disposable {
   onPlayablePlayFlag = true;
   onPlayablePauseFlag = false;
-  overrideTimeNextEvaluation = false;
 
   private destroyed = false;
   private inputs: Playable[] = [];
@@ -184,7 +179,6 @@ export class Playable implements Disposable {
 
   setTime (time: number) {
     this.time = time;
-    this.overrideTimeNextEvaluation = true;
   }
 
   getTime () {

--- a/packages/effects-core/src/plugins/cal/timeline-asset.ts
+++ b/packages/effects-core/src/plugins/cal/timeline-asset.ts
@@ -1,3 +1,4 @@
+import type * as spec from '@galacean/effects-specification';
 import { effectsClass, serialize } from '../../decorators';
 import { VFXItem } from '../../vfx-item';
 import type { RuntimeClip, TrackAsset } from '../timeline/track';
@@ -5,7 +6,6 @@ import { ObjectBindingTrack } from './calculate-item';
 import type { FrameContext, PlayableGraph } from './playable-graph';
 import { Playable, PlayableAsset, PlayableTraversalMode } from './playable-graph';
 import type { Constructor } from '../../utils';
-import type { spec } from '@galacean/effects-core';
 
 @effectsClass('TimelineAsset')
 export class TimelineAsset extends PlayableAsset {

--- a/packages/effects-core/src/plugins/cal/timeline-asset.ts
+++ b/packages/effects-core/src/plugins/cal/timeline-asset.ts
@@ -1,4 +1,3 @@
-import type { DataPath, EffectsObjectData } from '@galacean/effects-specification';
 import { effectsClass, serialize } from '../../decorators';
 import { VFXItem } from '../../vfx-item';
 import type { RuntimeClip, TrackAsset } from '../timeline/track';
@@ -6,10 +5,7 @@ import { ObjectBindingTrack } from './calculate-item';
 import type { FrameContext, PlayableGraph } from './playable-graph';
 import { Playable, PlayableAsset, PlayableTraversalMode } from './playable-graph';
 import type { Constructor } from '../../utils';
-
-export interface TimelineAssetData extends EffectsObjectData {
-  tracks: DataPath[],
-}
+import type { spec } from '@galacean/effects-core';
 
 @effectsClass('TimelineAsset')
 export class TimelineAsset extends PlayableAsset {
@@ -39,7 +35,7 @@ export class TimelineAsset extends PlayableAsset {
     return newTrack;
   }
 
-  override fromData (data: TimelineAssetData): void {
+  override fromData (data: spec.TimelineAssetData): void {
   }
 }
 

--- a/packages/effects-webgl/src/gl-material.ts
+++ b/packages/effects-webgl/src/gl-material.ts
@@ -278,6 +278,7 @@ export class GLMaterial extends Material {
     if (!this.shaderVariant || this.shaderVariant.shader !== this.shader || this.macrosDirtyFlag) {
       this.shaderVariant = this.shader.createVariant(this.enabledMacros);
       this.macrosDirtyFlag = false;
+      this.uniformDirtyFlag = true;
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Centralized type definitions for TimelineAssetData to improve consistency and maintainability across the codebase.

- **Bug Fixes**
	- Streamlined time-setting process in the Playable class, simplifying time evaluations.

- **Chores**
	- Updated imports to utilize centralized specifications from the @galacean/effects-core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->