### PR TITLE
fix: revert busrt once and disabled property

### DIFF
--- a/packages/effects-core/src/plugins/particle/burst.ts
+++ b/packages/effects-core/src/plugins/particle/burst.ts
@@ -9,6 +9,9 @@ interface BurstOptions {
 }
 
 export class Burst {
+  once: boolean;
+  disabled: boolean;
+
   private now: number;
   private index: number;
   private internalCycles: number;

--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -405,12 +405,16 @@ export class ParticleSystem extends Component {
               break;
             }
             const burst = bursts[j];
-            const opts = burst.getGeneratorOptions(timePassed, lifetime);
+            const opts = !burst.disabled && burst.getGeneratorOptions(timePassed, lifetime);
 
             if (opts) {
               const originVec = [0, 0, 0];
               const offsets = emission.burstOffsets[j];
               const burstOffset = (offsets && offsets[opts.cycleIndex]) || originVec;
+
+              if (burst.once) {
+                this.removeBurst(j);
+              }
 
               for (let i = 0; i < opts.count && cursor < maxCount; i++) {
                 if (shouldSkipGenerate()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new properties `once` and `disabled` to the `Burst` class for improved execution control.
  - Enhanced the `ParticleSystem` to manage burst lifecycle more effectively, including checks for disabled bursts and handling single-trigger bursts.

- **Bug Fixes**
  - Improved performance by preventing unnecessary computations for disabled bursts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->