### PR TITLE
faet: add Texture class fromImage options

### DIFF
--- a/packages/effects-core/src/texture/texture.ts
+++ b/packages/effects-core/src/texture/texture.ts
@@ -1,5 +1,5 @@
 import { TextureSourceType } from './types';
-import type { TextureFactorySourceFrom, TextureSourceOptions, TextureDataType } from './types';
+import type { TextureFactorySourceFrom, TextureSourceOptions, TextureDataType, Texture2DSourceOptionsImage } from './types';
 import { glContext } from '../gl';
 import type { Engine } from '../engine';
 import { EffectsObject } from '../effects-object';
@@ -46,10 +46,11 @@ export abstract class Texture extends EffectsObject {
    * @param url - 要创建的 Texture URL
    * @since 2.0.0
    */
-  static async fromImage (url: string, engine: Engine): Promise<Texture> {
+  static async fromImage (url: string, engine: Engine, options?: Texture2DSourceOptionsImage): Promise<Texture> {
     const image = await loadImage(url);
 
     const texture = Texture.create(engine, {
+      ...options,
       sourceType: TextureSourceType.image,
       image,
       id: generateGUID(),

--- a/packages/effects-core/src/texture/texture.ts
+++ b/packages/effects-core/src/texture/texture.ts
@@ -1,5 +1,5 @@
 import { TextureSourceType } from './types';
-import type { TextureFactorySourceFrom, TextureSourceOptions, TextureDataType, Texture2DSourceOptionsImage } from './types';
+import type { TextureFactorySourceFrom, TextureSourceOptions, TextureDataType, TextureOptionsBase } from './types';
 import { glContext } from '../gl';
 import type { Engine } from '../engine';
 import { EffectsObject } from '../effects-object';
@@ -46,15 +46,16 @@ export abstract class Texture extends EffectsObject {
    * @param url - 要创建的 Texture URL
    * @since 2.0.0
    */
-  static async fromImage (url: string, engine: Engine, options?: Texture2DSourceOptionsImage): Promise<Texture> {
+  static async fromImage (url: string, engine: Engine, options?: TextureOptionsBase): Promise<Texture> {
     const image = await loadImage(url);
 
     const texture = Texture.create(engine, {
-      ...options,
       sourceType: TextureSourceType.image,
       image,
+      target: glContext.TEXTURE_2D,
       id: generateGUID(),
       flipY: true,
+      ...options,
     });
 
     texture.initialize();

--- a/web-packages/test/unit/src/effects-core/texture.spec.ts
+++ b/web-packages/test/unit/src/effects-core/texture.spec.ts
@@ -1,4 +1,4 @@
-import { Texture, Player } from '@galacean/effects';
+import { Texture, Player, glContext } from '@galacean/effects';
 
 const { expect } = chai;
 
@@ -25,6 +25,28 @@ describe('core/texture', () => {
   it('texture from image', async () => {
     const testTexture = await Texture.fromImage('https://gw.alipayobjects.com/mdn/rms_2e421e/afts/img/A*fRtNTKrsq3YAAAAAAAAAAAAAARQnAQ', player.renderer.engine);
 
+    expect(testTexture).to.be.an.instanceOf(Texture);
+    expect(testTexture.width).to.be.a('number');
+    expect(testTexture.height).to.be.a('number');
+    expect(testTexture.id).to.be.a('string');
+  });
+
+  it('texture from image with options', async () => {
+    const testTexture = await Texture.fromImage('https://gw.alipayobjects.com/mdn/rms_2e421e/afts/img/A*fRtNTKrsq3YAAAAAAAAAAAAAARQnAQ', player.renderer.engine,
+      {
+        minFilter: glContext.LINEAR_MIPMAP_LINEAR,
+        magFilter: glContext.LINEAR,
+        wrapS: glContext.REPEAT,
+        wrapT: glContext.MIRRORED_REPEAT,
+      }
+    );
+    const textureSource = testTexture.source;
+
+    expect(textureSource.minFilter).to.equal(glContext.LINEAR_MIPMAP_LINEAR);
+    expect(textureSource.magFilter).to.equal(glContext.LINEAR);
+    expect(textureSource.wrapS).to.equal(glContext.REPEAT);
+    expect(textureSource.wrapT).to.equal(glContext.MIRRORED_REPEAT);
+    expect(textureSource.flipY).to.be.true;
     expect(testTexture).to.be.an.instanceOf(Texture);
     expect(testTexture.width).to.be.a('number');
     expect(testTexture.height).to.be.a('number');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced texture creation with customizable options when using the `fromImage` method.
  
- **Bug Fixes**
  - Improved handling of texture properties to ensure correct behavior when specific options are provided.

- **Tests**
  - Added new test cases to validate the functionality of the `fromImage` method with various texture options, ensuring expected behavior and properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->