### PR TITLE
fix: timeline clip end judgment

### DIFF
--- a/packages/effects-core/src/plugins/timeline/track.ts
+++ b/packages/effects-core/src/plugins/timeline/track.ts
@@ -24,7 +24,7 @@ export class TimelineClip {
     let localTime = time - this.start;
     const duration = this.duration;
 
-    if (localTime - duration > 0.001) {
+    if (localTime - duration > 0) {
       if (this.endBehavior === EndBehavior.restart) {
         localTime = localTime % duration;
       } else if (this.endBehavior === EndBehavior.freeze) {
@@ -196,7 +196,7 @@ export class RuntimeClip {
     let started = false;
     const boundObject = this.track.binding;
 
-    if (localTime > clip.start + clip.duration + 0.001 && clip.endBehavior === EndBehavior.destroy) {
+    if (localTime >= clip.start + clip.duration && clip.endBehavior === EndBehavior.destroy) {
       if (boundObject instanceof VFXItem && VFXItem.isParticle(boundObject) && this.particleSystem && !this.particleSystem.destroyed) {
         weight = 1.0;
       } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced timing logic for clips, allowing for more precise behavior at the boundaries of clip durations.
- **Bug Fixes**
	- Adjusted conditions to ensure correct destruction of clips when local time matches their end points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->