### PR TITLE
fix: composition time reset

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -506,6 +506,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   protected reset () {
     this.rendererOptions = null;
     this.rootItem.ended = false;
+    this.rootComposition.time = 0;
     this.pluginSystem.resetComposition(this, this.renderFrame);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that the `reset` method properly initializes the `time` property to `0`, enhancing the reliability of the composition behavior during resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->