### PR TITLE
chore: add dependabot ignore for three and spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     directory: "/packages/effects-core"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@galacean/effects-specification"
 
   - package-ecosystem: "npm"
     directory: "/packages/effects-helper"
@@ -24,6 +26,9 @@ updates:
     directory: "/packages/effects-threejs"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "three"
+      - dependency-name: "@types/three"
 
   - package-ecosystem: "npm"
     directory: "/packages/effects-webgl"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management configuration to include ignore rules for specific npm packages, ensuring smoother updates and reduced notifications for certain dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->