### PR TITLE
fix(threejs/sprite): 修复 threejs 粒子渲染问题 & video 无法重播问题

### DIFF
--- a/packages/effects-core/src/plugins/sprite/sprite-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-item.ts
@@ -6,7 +6,7 @@ import { glContext } from '../../gl';
 import type { GeometryDrawMode } from '../../render';
 import { Geometry } from '../../render';
 import type { GeometryFromShape } from '../../shape';
-import type { Texture } from '../../texture';
+import type { Texture, Texture2DSourceOptionsVideo } from '../../texture';
 import type { PlayableGraph, Playable } from '../cal/playable-graph';
 import { PlayableAsset } from '../cal/playable-graph';
 import type { ColorPlayableAssetData } from '../../animation';
@@ -146,6 +146,11 @@ export class SpriteComponent extends BaseRenderComponent {
         texRectH + texRectY - texOffset[1],
         dx, dy,
       ]);
+    }
+    const { video } = this.renderer.texture.source as Texture2DSourceOptionsVideo;
+
+    if (video?.paused) {
+      video.play().catch(e => { this.engine.renderErrors.add(e); });
     }
   }
 

--- a/packages/effects-threejs/src/three-geometry.ts
+++ b/packages/effects-threejs/src/three-geometry.ts
@@ -172,7 +172,7 @@ export class ThreeGeometry extends Geometry {
       const buffer = new THREE.InterleavedBuffer(data, attributeBuffer.stride);
 
       attributeBuffer = this.attributes[name].attribute.data = buffer;
-
+      this.attributes[name].buffer = buffer;
       this.geometry.setAttribute(name, this.attributes[name].attribute);
     } else {
       attributeBuffer.set(data, 0);

--- a/packages/effects-threejs/src/three-texture.ts
+++ b/packages/effects-threejs/src/three-texture.ts
@@ -66,6 +66,7 @@ export class ThreeTexture extends Texture {
       this.texture = this.createTextureByType(options);
     }
     this.texture.needsUpdate = true;
+    this.source = {};
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced texture handling capabilities with support for video textures.
	- Introduced a new property, `source`, in the `ThreeTexture` class for improved texture management.

- **Bug Fixes**
	- Improved video playback control to ensure videos resume if paused during rendering.

- **Improvements**
	- Updated handling of attribute and index data in the `ThreeGeometry` class for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->