### PR TITLE
fix(video): 修复视频渲染与元素结束行为不符问题

### DIFF
--- a/packages/effects-core/src/plugins/sprite/sprite-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-item.ts
@@ -149,8 +149,12 @@ export class SpriteComponent extends BaseRenderComponent {
     }
     const { video } = this.renderer.texture.source as Texture2DSourceOptionsVideo;
 
-    if (video?.paused) {
-      video.play().catch(e => { this.engine.renderErrors.add(e); });
+    if (video) {
+      if (time === 0 || (time === this.item.duration)) {
+        video.pause();
+      } else {
+        video.play().catch(e => { this.engine.renderErrors.add(e); });
+      }
     }
   }
 

--- a/packages/effects-threejs/src/three-composition.ts
+++ b/packages/effects-threejs/src/three-composition.ts
@@ -61,13 +61,6 @@ export class ThreeComposition extends Composition {
     super(props, scene);
   }
 
-  /**
-   * 更新 video texture 数据
-   */
-  override updateVideo () {
-    void this.textures.map(tex => (tex as ThreeTexture).startVideo());
-  }
-
   override prepareRender (): void {
     const render = this.renderer;
     const frame = this.renderFrame;

--- a/packages/effects-threejs/src/three-texture.ts
+++ b/packages/effects-threejs/src/three-texture.ts
@@ -85,13 +85,7 @@ export class ThreeTexture extends Texture {
    *
    */
   async startVideo () {
-    if (this.sourceType === TextureSourceType.video) {
-      const video = (this.texture).source.data;
 
-      if (video.paused) {
-        await video.play();
-      }
-    }
   }
 
   /**
@@ -224,6 +218,7 @@ export class ThreeTexture extends Texture {
       texture.wrapT = THREE.MirroredRepeatWrapping;
       this.width = this.height = 1;
     }
+    this.source = options;
     if (texture) {
       texture.flipY = !!flipY;
 

--- a/packages/effects-threejs/src/three-texture.ts
+++ b/packages/effects-threejs/src/three-texture.ts
@@ -81,14 +81,6 @@ export class ThreeTexture extends Texture {
   }
 
   /**
-   * 开始更新视频数据
-   *
-   */
-  async startVideo () {
-
-  }
-
-  /**
    * 组装纹理选项
    * @param options - 纹理选项
    * @returns 组装后的纹理选项


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved video playback control in animations, ensuring videos pause at the start and end.
	- Retained reference to texture options during texture creation for better management.

- **Bug Fixes**
	- Removed automatic playback for video textures, enhancing user control over video playback.
	- Refined logic for updating video texture data, ensuring smoother playback management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->