### PR TITLE
feat: add support for shape property in item renderer

### DIFF
--- a/packages/effects-core/src/plugins/sprite/sprite-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-item.ts
@@ -11,7 +11,6 @@ import type { PlayableGraph, Playable } from '../cal/playable-graph';
 import { PlayableAsset } from '../cal/playable-graph';
 import type { ColorPlayableAssetData } from '../../animation';
 import { ColorPlayable } from '../../animation';
-import type { ItemRenderer } from '../../components';
 import { BaseRenderComponent, getImageItemRenderInfo } from '../../components/base-render-component';
 
 /**
@@ -33,13 +32,6 @@ export type SpriteItemOptions = {
   startColor: spec.vec4,
   renderLevel?: spec.RenderLevel,
 };
-
-/**
- * 图层元素渲染属性, 经过处理后的 spec.SpriteContent.renderer
- */
-export interface SpriteItemRenderer extends ItemRenderer {
-  shape?: GeometryFromShape,
-}
 
 export type splitsDataType = [r: number, x: number, y: number, w: number, h: number | undefined][];
 
@@ -197,7 +189,7 @@ export class SpriteComponent extends BaseRenderComponent {
   override getItemGeometryData () {
     const { splits, textureSheetAnimation } = this;
     const sx = 1, sy = 1;
-    const renderer = this.renderer as SpriteItemRenderer;
+    const renderer = this.renderer;
 
     if (renderer.shape) {
       const { index = [], aPoint = [] } = renderer.shape;
@@ -295,7 +287,7 @@ export class SpriteComponent extends BaseRenderComponent {
       mask: renderer.mask ?? 0,
       maskMode: renderer.maskMode ?? spec.MaskMode.NONE,
       order: listIndex,
-    } as SpriteItemRenderer;
+    };
 
     this.emptyTexture = this.engine.emptyTexture;
     this.splits = data.splits || singleSplits;

--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -1,5 +1,6 @@
 import type {
   Texture, Engine, Texture2DSourceOptionsVideo, Asset, SpriteItemProps,
+  GeometryFromShape,
 } from '@galacean/effects';
 import { spec, math, BaseRenderComponent, effectsClass, glContext } from '@galacean/effects';
 
@@ -10,6 +11,7 @@ export interface VideoItemProps extends Omit<spec.VideoComponentData, 'renderer'
   listIndex?: number,
   renderer: {
     mask: number,
+    shape?: GeometryFromShape,
     texture: Texture,
   } & Omit<spec.RendererOptions, 'texture'>,
 }
@@ -86,6 +88,7 @@ export class VideoComponent extends BaseRenderComponent {
       mask: renderer.mask ?? 0,
       maskMode: renderer.maskMode ?? spec.MaskMode.NONE,
       order: listIndex,
+      shape: renderer.shape,
     };
 
     this.interaction = interaction;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional `shape` property to the `ItemRenderer` interface, enhancing geometry flexibility.
	- Integrated `shape` property into the `VideoItemProps` interface for video components.

- **Bug Fixes**
	- Updated handling of geometry in `BaseRenderComponent` to ensure compatibility with new shape data.

- **Refactor**
	- Removed the `SpriteItemRenderer` interface for a more streamlined renderer structure in the `SpriteComponent`.
	- Simplified type handling for the `renderer` property in the `SpriteComponent`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->