### PR TITLE
refactor: opt shader variant create logic

### DIFF
--- a/packages/effects-core/src/material/material.ts
+++ b/packages/effects-core/src/material/material.ts
@@ -62,7 +62,6 @@ let seed = 1;
  * Material 抽象类
  */
 export abstract class Material extends EffectsObject implements Disposable {
-  shader: Shader;
   shaderVariant: ShaderVariant;
 
   // TODO: 待移除
@@ -76,6 +75,9 @@ export abstract class Material extends EffectsObject implements Disposable {
 
   protected destroyed = false;
   protected initialized = false;
+  protected shaderDirty = true;
+
+  private _shader: Shader;
 
   /**
    *
@@ -104,6 +106,15 @@ export abstract class Material extends EffectsObject implements Disposable {
       this.name = 'Material' + seed++;
       this.renderType = MaterialRenderType.normal;
     }
+  }
+
+  get shader () {
+    return this._shader;
+  }
+
+  set shader (value: Shader) {
+    this._shader = value;
+    this.shaderDirty = true;
   }
 
   /******** effects-core 中会调用 引擎必须实现 ***********************/

--- a/packages/effects-core/src/material/material.ts
+++ b/packages/effects-core/src/material/material.ts
@@ -113,6 +113,9 @@ export abstract class Material extends EffectsObject implements Disposable {
   }
 
   set shader (value: Shader) {
+    if (this._shader === value) {
+      return;
+    }
     this._shader = value;
     this.shaderDirty = true;
   }


### PR DESCRIPTION
- optimize judgment logic to avoid repeated creation of shader variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced encapsulation for the shader property in the Material class, allowing controlled access through a getter and setter.
	- Introduced a new boolean flag, `shaderDirty`, to track changes to the shader state.

- **Chores**
	- Streamlined naming conventions for internal flags in the GLMaterial class, improving clarity without altering functionality.
	- Updated internal logic to reflect new naming conventions for state management flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->