### PR TITLE
feat: property clip use normalized time

### DIFF
--- a/packages/effects-core/src/plugins/cal/playable-graph.ts
+++ b/packages/effects-core/src/plugins/cal/playable-graph.ts
@@ -67,6 +67,7 @@ export class Playable implements Disposable {
   onPlayablePlayFlag = true;
   onPlayablePauseFlag = false;
 
+  private duration = 0;
   private destroyed = false;
   private inputs: Playable[] = [];
   private inputOuputPorts: number[] = [];
@@ -183,6 +184,14 @@ export class Playable implements Disposable {
 
   getTime () {
     return this.time;
+  }
+
+  setDuration (duration: number) {
+    this.duration = duration;
+  }
+
+  getDuration () {
+    return this.duration;
   }
 
   getPlayState () {

--- a/packages/effects-core/src/plugins/timeline/playables/property-clip-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/property-clip-playable.ts
@@ -7,6 +7,6 @@ export class PropertyClipPlayable<T> extends Playable {
   curve: ValueGetter<T>;
 
   override processFrame (context: FrameContext): void {
-    this.value = this.curve.getValue(this.time);
+    this.value = this.curve.getValue(this.time / this.getDuration());
   }
 }

--- a/packages/effects-core/src/plugins/timeline/track.ts
+++ b/packages/effects-core/src/plugins/timeline/track.ts
@@ -99,6 +99,8 @@ export class TrackAsset extends PlayableAsset {
     for (const timelineClip of timelineClips) {
       const clipPlayable = this.createClipPlayable(graph, timelineClip);
 
+      clipPlayable.setDuration(timelineClip.duration);
+
       const clip = new RuntimeClip(timelineClip, clipPlayable, mixer, this);
 
       runtimeClips.push(clip);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced duration management for playable instances in the `Playable` class.
	- Enhanced clip handling by explicitly defining durations during compilation.

- **Bug Fixes**
	- Improved value calculation in `PropertyClipPlayable` to account for duration.

- **Documentation**
	- Updated method signatures to reflect new functionality related to duration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->