### PR TITLE
feat: item active setting

### DIFF
--- a/packages/effects-core/src/comp-vfx-item.ts
+++ b/packages/effects-core/src/comp-vfx-item.ts
@@ -105,15 +105,15 @@ export class CompositionComponent extends Behaviour {
     }
   }
 
-  showItems () {
+  override onEnable () {
     for (const item of this.items) {
-      item.setVisible(true);
+      item.setActive(true);
     }
   }
 
-  hideItems () {
+  override onDisable () {
     for (const item of this.items) {
-      item.setVisible(false);
+      item.setActive(false);
     }
   }
 
@@ -143,7 +143,7 @@ export class CompositionComponent extends Behaviour {
       const item = this.items[i];
 
       if (
-        item.getVisible()
+        item.isActive()
         && item.transform.getValid()
         && !VFXItem.isComposition(item)
         && !skip(item)

--- a/packages/effects-core/src/comp-vfx-item.ts
+++ b/packages/effects-core/src/comp-vfx-item.ts
@@ -143,7 +143,7 @@ export class CompositionComponent extends Behaviour {
       const item = this.items[i];
 
       if (
-        item.isActive()
+        item.isActive
         && item.transform.getValid()
         && !VFXItem.isComposition(item)
         && !skip(item)

--- a/packages/effects-core/src/components/component.ts
+++ b/packages/effects-core/src/components/component.ts
@@ -30,7 +30,7 @@ export abstract class Component extends EffectsObject {
    * 组件是否可以更新，true 更新，false 不更新
    */
   get isActiveAndEnabled () {
-    return this.item.isActive() && this.enabled;
+    return this.item.isActive && this.enabled;
   }
 
   get enabled () {
@@ -134,7 +134,7 @@ export abstract class Component extends EffectsObject {
         this.onAwake();
         this.isAwakeCalled = true;
       }
-      if (item.isActive() && this.enabled) {
+      if (item.isActive && this.enabled) {
         this.start();
         this.enable();
       }

--- a/packages/effects-core/src/components/component.ts
+++ b/packages/effects-core/src/components/component.ts
@@ -30,7 +30,7 @@ export abstract class Component extends EffectsObject {
    * 组件是否可以更新，true 更新，false 不更新
    */
   get isActiveAndEnabled () {
-    return this.item.getVisible() && this.enabled;
+    return this.item.isActive() && this.enabled;
   }
 
   get enabled () {
@@ -134,7 +134,7 @@ export abstract class Component extends EffectsObject {
         this.onAwake();
         this.isAwakeCalled = true;
       }
-      if (item.getVisible() && this.enabled) {
+      if (item.isActive() && this.enabled) {
         this.start();
         this.enable();
       }

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -388,7 +388,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
    */
   setVisible (visible: boolean) {
     this.items.forEach(item => {
-      item.setVisible(visible);
+      item.setActive(visible);
     });
   }
 

--- a/packages/effects-core/src/plugins/timeline/playables/activation-mixer-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/activation-mixer-playable.ts
@@ -25,26 +25,10 @@ export class ActivationMixerPlayable extends Playable {
 
     if (hasInput) {
       boundItem.transform.setValid(true);
-      this.showRendererComponents(boundItem);
+      boundItem.setActive(true);
     } else {
       boundItem.transform.setValid(false);
-      this.hideRendererComponents(boundItem);
-    }
-  }
-
-  private hideRendererComponents (item: VFXItem) {
-    for (const rendererComponent of item.rendererComponents) {
-      if (rendererComponent.enabled) {
-        rendererComponent.enabled = false;
-      }
-    }
-  }
-
-  private showRendererComponents (item: VFXItem) {
-    for (const rendererComponent of item.rendererComponents) {
-      if (!rendererComponent.enabled) {
-        rendererComponent.enabled = true;
-      }
+      boundItem.setActive(false);
     }
   }
 }

--- a/packages/effects-core/src/plugins/timeline/playables/sub-composition-mixer-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/sub-composition-mixer-playable.ts
@@ -23,9 +23,9 @@ export class SubCompositionMixerPlayable extends Playable {
     }
 
     if (hasInput) {
-      compositionComponent.showItems();
+      compositionComponent.item.setActive(true);
     } else {
-      compositionComponent.hideItems();
+      compositionComponent.item.setActive(false);
     }
   }
 }

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -416,7 +416,7 @@ export class VFXItem extends EffectsObject implements Disposable {
   /**
    * 当前 VFXItem 是否激活
    */
-  isActive () {
+  get isActive () {
     return this.active;
   }
 
@@ -433,7 +433,15 @@ export class VFXItem extends EffectsObject implements Disposable {
   /**
    * 元素组件显隐状态
    */
-  isVisible () {
+  get isVisible () {
+    return this.visible;
+  }
+
+  /**
+   * 元素组件显隐状态
+   * @deprecated use isVisible instead
+   */
+  getVisible () {
     return this.visible;
   }
 

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -98,10 +98,9 @@ export class VFXItem extends EffectsObject implements Disposable {
   rendererComponents: RendererComponent[] = [];
 
   /**
-   * 元素可见性，该值的改变会触发 `handleVisibleChanged` 回调
-   * @protected
+   * 元素是否激活
    */
-  protected visible = true;
+  private active = true;
   /**
    * 元素动画的速度
    */
@@ -401,19 +400,34 @@ export class VFXItem extends EffectsObject implements Disposable {
   }
 
   /**
-   * 获取元素显隐属性
+   * 元素是否激活
    */
-  getVisible () {
-    return this.visible;
+  isActive () {
+    return this.active;
   }
 
   /**
-   * 设置元素显隐属性 会触发 `handleVisibleChanged` 回调
+   * 激活或停用 VFXItem
+   */
+  setActive (value: boolean) {
+    if (this.active !== value) {
+      this.active = !!value;
+      this.onActiveChanged();
+    }
+  }
+
+  /**
+   * 设置元素的显隐
    */
   setVisible (visible: boolean) {
-    if (this.visible !== visible) {
-      this.visible = !!visible;
-      this.onActiveChanged();
+    if (visible) {
+      for (const component of this.components) {
+        component.enable();
+      }
+    } else {
+      for (const component of this.components) {
+        component.disable();
+      }
     }
   }
 
@@ -549,7 +563,7 @@ export class VFXItem extends EffectsObject implements Disposable {
   beginPlay () {
     this.isDuringPlay = true;
 
-    if (this.composition && this.visible && !this.isEnabled) {
+    if (this.composition && this.active && !this.isEnabled) {
       this.onEnable();
     }
 

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -102,6 +102,10 @@ export class VFXItem extends EffectsObject implements Disposable {
    */
   private active = true;
   /**
+   * 元素组件是否显示，用于批量开关元素组件
+   */
+  private visible = true;
+  /**
    * 元素动画的速度
    */
   private speed = 1;
@@ -400,13 +404,6 @@ export class VFXItem extends EffectsObject implements Disposable {
   }
 
   /**
-   * 元素是否激活
-   */
-  isActive () {
-    return this.active;
-  }
-
-  /**
    * 激活或停用 VFXItem
    */
   setActive (value: boolean) {
@@ -417,12 +414,27 @@ export class VFXItem extends EffectsObject implements Disposable {
   }
 
   /**
-   * 设置元素的显隐
+   * 当前 VFXItem 是否激活
+   */
+  isActive () {
+    return this.active;
+  }
+
+  /**
+   * 设置元素的显隐，该设置会批量开关元素组件
    */
   setVisible (visible: boolean) {
     for (const component of this.components) {
       component.enabled = visible;
     }
+    this.visible = visible;
+  }
+
+  /**
+   * 元素组件显隐状态
+   */
+  isVisible () {
+    return this.visible;
   }
 
   /**

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -420,14 +420,8 @@ export class VFXItem extends EffectsObject implements Disposable {
    * 设置元素的显隐
    */
   setVisible (visible: boolean) {
-    if (visible) {
-      for (const component of this.components) {
-        component.enable();
-      }
-    } else {
-      for (const component of this.components) {
-        component.disable();
-      }
+    for (const component of this.components) {
+      component.enabled = visible;
     }
   }
 

--- a/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
+++ b/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
@@ -32,7 +32,7 @@ export class VFXItemInspector extends ObjectInspector {
     ImGui.Text('Visible');
     ImGui.SameLine(alignWidth);
     ImGui.Checkbox('##Visible', (_ = activeObject.isActive()) => {
-      activeObject.setVisible(_);
+      activeObject.setActive(_);
 
       return activeObject.isActive();
     });

--- a/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
+++ b/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
@@ -31,10 +31,10 @@ export class VFXItemInspector extends ObjectInspector {
     ImGui.Text(activeObject.getInstanceId());
     ImGui.Text('Visible');
     ImGui.SameLine(alignWidth);
-    ImGui.Checkbox('##Visible', (_ = activeObject.getVisible()) => {
+    ImGui.Checkbox('##Visible', (_ = activeObject.isActive()) => {
       activeObject.setVisible(_);
 
-      return activeObject.getVisible();
+      return activeObject.isActive();
     });
 
     ImGui.Text('End Behavior');

--- a/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
+++ b/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
@@ -31,10 +31,10 @@ export class VFXItemInspector extends ObjectInspector {
     ImGui.Text(activeObject.getInstanceId());
     ImGui.Text('Visible');
     ImGui.SameLine(alignWidth);
-    ImGui.Checkbox('##Visible', (_ = activeObject.isActive()) => {
+    ImGui.Checkbox('##Visible', (_ = activeObject.isActive) => {
       activeObject.setActive(_);
 
-      return activeObject.isActive();
+      return activeObject.isActive;
     });
 
     ImGui.Text('End Behavior');

--- a/web-packages/test/unit/src/effects-core/composition/composition.spec.ts
+++ b/web-packages/test/unit/src/effects-core/composition/composition.spec.ts
@@ -149,6 +149,6 @@ describe('core/composition', () => {
 
     comp.setVisible(false);
 
-    expect(comp.items[0].isActive()).to.eql(false, 'composition visible');
+    expect(comp.items[0].isActive).to.eql(false, 'composition visible');
   });
 });

--- a/web-packages/test/unit/src/effects-core/composition/composition.spec.ts
+++ b/web-packages/test/unit/src/effects-core/composition/composition.spec.ts
@@ -149,6 +149,6 @@ describe('core/composition', () => {
 
     comp.setVisible(false);
 
-    expect(comp.items[0].getVisible()).to.eql(false, 'composition visible');
+    expect(comp.items[0].isActive()).to.eql(false, 'composition visible');
   });
 });


### PR DESCRIPTION
- fix ref compostion setVisible() invalid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated methods for managing item visibility now use an "active" state instead of "visible," enhancing clarity in item state management.
	- Introduced a new `setVisible` method for controlling component visibility in the `VFXItem` class.

- **Bug Fixes**
	- Adjusted GUI interactions to reflect the active state of `VFXItem` objects correctly.

- **Documentation**
	- Improved comments and documentation across various classes to clarify the new terminology and functionality.

- **Tests**
	- Updated unit tests to align with the new active state checks instead of visibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->