### PR TITLE
feat: material add color and mainTexture interface

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -10,7 +10,7 @@ import type { Engine } from '../engine';
 import { glContext } from '../gl';
 import { addItem } from '../utils';
 import type { BoundingBoxTriangle, HitTestTriangleParams } from '../plugins';
-import { HitTestType, maxSpriteMeshItemCount, spriteMeshShaderFromRenderInfo } from '../plugins';
+import { HitTestType, spriteMeshShaderFromRenderInfo } from '../plugins';
 import type { MaterialProps } from '../material';
 import { getPreMultiAlpha, Material, setBlendMode, setMaskMode, setSideMode } from '../material';
 import { trianglesFromRect } from '../math';
@@ -126,7 +126,7 @@ export class BaseRenderComponent extends RendererComponent {
    */
   setTexture (texture: Texture) {
     this.renderer.texture = texture;
-    this.material.setTexture('uSampler0', texture);
+    this.material.setTexture('_MainTex', texture);
   }
 
   /**
@@ -213,17 +213,8 @@ export class BaseRenderComponent extends RendererComponent {
     geometry.setIndexData(indexData);
     geometry.setAttributeData('atlasOffset', attributes.atlasOffset);
     geometry.setDrawCount(data.index.length);
-    for (let i = 0; i < textures.length; i++) {
-      const texture = textures[i];
 
-      material.setTexture('uSampler' + i, texture);
-    }
-    // FIXME: 内存泄漏的临时方案，后面再调整
-    const emptyTexture = this.emptyTexture;
-
-    for (let k = textures.length; k < maxSpriteMeshItemCount; k++) {
-      material.setTexture('uSampler' + k, emptyTexture);
-    }
+    material.setTexture('_MainTex', texture);
   }
 
   protected getItemGeometryData () {
@@ -307,7 +298,7 @@ export class BaseRenderComponent extends RendererComponent {
     setMaskMode(material, states.maskMode);
     setSideMode(material, states.side);
 
-    material.shader.shaderData.properties = 'uSampler0("uSampler0",2D) = "white" {}';
+    material.shader.shaderData.properties = '_MainTex("_MainTex",2D) = "white" {}';
     if (!material.hasUniform('_Color')) {
       material.setVector4('_Color', new Vector4(0, 0, 0, 1));
     }

--- a/packages/effects-core/src/components/post-process-volume.ts
+++ b/packages/effects-core/src/components/post-process-volume.ts
@@ -3,7 +3,6 @@ import { effectsClass, serialize } from '../decorators';
 import { Behaviour } from './component';
 import type { Engine } from '../engine';
 
-// TODO spec 增加 DataType
 /**
  * @since 2.1.0
  */

--- a/packages/effects-core/src/material/material.ts
+++ b/packages/effects-core/src/material/material.ts
@@ -120,6 +120,28 @@ export abstract class Material extends EffectsObject implements Disposable {
     this.shaderDirty = true;
   }
 
+  /**
+   * 材质的主纹理
+   */
+  get mainTexture () {
+    return this.getTexture('_MainTex') as Texture;
+  }
+
+  set mainTexture (value: Texture) {
+    this.setTexture('_MainTex', value);
+  }
+
+  /**
+   * 材质的主颜色
+   */
+  get color () {
+    return this.getColor('_Color') as Color;
+  }
+
+  set color (value: Color) {
+    this.setColor('_Color', value);
+  }
+
   /******** effects-core 中会调用 引擎必须实现 ***********************/
   /**
    * 设置 Material 的颜色融合开关

--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -514,7 +514,7 @@ export class TextComponentBase {
     //与 toDataURL() 两种方式都需要像素读取操作
     const imageData = context.getImageData(0, 0, this.canvas.width, this.canvas.height);
 
-    this.material.setTexture('uSampler0',
+    this.material.setTexture('_MainTex',
       Texture.createWithData(
         this.engine,
         {

--- a/packages/effects-core/src/shader/item.frag.glsl
+++ b/packages/effects-core/src/shader/item.frag.glsl
@@ -4,7 +4,7 @@ varying vec4 vColor;
 varying vec2 vTexCoord;//x y
 varying vec3 vParams;//texIndex mulAplha transparentOcclusion
 
-uniform sampler2D uSampler0;
+uniform sampler2D _MainTex;
 
 vec4 blendColor(vec4 color, vec4 vc, float mode) {
   vec4 ret = color * vc;
@@ -24,7 +24,7 @@ vec4 blendColor(vec4 color, vec4 vc, float mode) {
 
 void main() {
   vec4 color = vec4(0.);
-  vec4 texColor = texture2D(uSampler0, vTexCoord.xy);
+  vec4 texColor = texture2D(_MainTex, vTexCoord.xy);
   color = blendColor(texColor, vColor, floor(0.5 + vParams.y));
   if(vParams.z == 0. && color.a < 0.04) { // 1/256 = 0.04
     discard;

--- a/packages/effects-threejs/src/material/three-material-util.ts
+++ b/packages/effects-threejs/src/material/three-material-util.ts
@@ -82,22 +82,7 @@ export function setUniformValue (uniforms: Record<string, any>, name: string, va
  */
 export const TEXTURE_UNIFORM_MAP = [
   'uMaskTex',
-  'uSampler0',
-  'uSampler1',
-  'uSampler2',
-  'uSampler3',
-  'uSampler4',
-  'uSampler5',
-  'uSampler6',
-  'uSampler7',
-  'uSampler8',
-  'uSampler9',
-  'uSampler10',
-  'uSampler11',
-  'uSampler12',
-  'uSampler13',
-  'uSampler14',
-  'uSampler15',
+  '_MainTex',
   'uColorOverLifetime',
   'uColorOverTrail',
 ];

--- a/packages/effects-threejs/src/material/three-material.ts
+++ b/packages/effects-threejs/src/material/three-material.ts
@@ -2,7 +2,7 @@ import type {
   MaterialProps, Texture, UniformValue, MaterialDestroyOptions, UndefinedAble, Engine, math,
   GlobalUniforms, Renderer,
 } from '@galacean/effects-core';
-import { Material, Shader, ShaderType, ShaderFactory, generateGUID, maxSpriteMeshItemCount, spec } from '@galacean/effects-core';
+import { Material, Shader, ShaderType, ShaderFactory, generateGUID, spec } from '@galacean/effects-core';
 import * as THREE from 'three';
 import type { ThreeTexture } from '../three-texture';
 import {
@@ -56,10 +56,7 @@ export class ThreeMaterial extends Material {
       fragment: shader?.fragment ?? '',
     };
 
-    for (let i = 0; i < maxSpriteMeshItemCount; i++) {
-      this.uniforms[`uSampler${i}`] = new THREE.Uniform(null);
-    }
-
+    this.uniforms['_MainTex'] = new THREE.Uniform(null);
     this.uniforms['uEditorTransform'] = new THREE.Uniform([1, 1, 0, 0]);
     this.uniforms['effects_ObjectToWorld'] = new THREE.Uniform(new THREE.Matrix4().identity());
     this.uniforms['effects_MatrixInvV'] = new THREE.Uniform([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 8, 1]);

--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -45,7 +45,7 @@ export class VideoComponent extends BaseRenderComponent {
 
     this.engine.removeTexture(oldTexture);
     this.renderer.texture = texture;
-    this.material.setTexture('uSampler0', texture);
+    this.material.setTexture('_MainTex', texture);
     this.video = (texture.source as Texture2DSourceOptionsVideo).video;
   }
 

--- a/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
+++ b/web-packages/imgui-demo/src/object-inspectors/vfx-item-inspector.ts
@@ -29,9 +29,9 @@ export class VFXItemInspector extends ObjectInspector {
     ImGui.Text('GUID');
     ImGui.SameLine(alignWidth);
     ImGui.Text(activeObject.getInstanceId());
-    ImGui.Text('Visible');
+    ImGui.Text('Is Active');
     ImGui.SameLine(alignWidth);
-    ImGui.Checkbox('##Visible', (_ = activeObject.isActive) => {
+    ImGui.Checkbox('##IsActive', (_ = activeObject.isActive) => {
       activeObject.setActive(_);
 
       return activeObject.isActive;
@@ -65,33 +65,40 @@ export class VFXItemInspector extends ObjectInspector {
     for (const componet of activeObject.components) {
       const customEditor = UIManager.customEditors.get(componet.constructor);
 
-      if (customEditor) {
-        if (ImGui.CollapsingHeader(componet.constructor.name, ImGui.TreeNodeFlags.DefaultOpen)) {
-          customEditor.onInspectorGUI();
-        }
-        continue;
-      }
       if (ImGui.CollapsingHeader(componet.constructor.name, ImGui.TreeNodeFlags.DefaultOpen)) {
+        ImGui.Text('Enabled');
+        ImGui.SameLine(alignWidth);
+        ImGui.Checkbox('##Enabled', (_ = componet.enabled) => {
+          componet.enabled = _;
+
+          return componet.enabled;
+        });
+
+        if (customEditor) {
+          customEditor.onInspectorGUI();
+          continue;
+
+        }
 
         const propertyDecoratorStore = getMergedStore(componet);
 
-        for (const peopertyName of Object.keys(componet)) {
-          const key = peopertyName as keyof Component;
+        for (const propertyName of Object.keys(componet)) {
+          const key = propertyName as keyof Component;
           const property = componet[key];
-          const ImGuiID = componet.getInstanceId() + peopertyName;
+          const ImGuiID = componet.getInstanceId() + propertyName;
 
           if (typeof property === 'number') {
-            ImGui.Text(peopertyName);
+            ImGui.Text(propertyName);
             ImGui.SameLine(alignWidth);
             //@ts-expect-error
             ImGui.DragFloat('##DragFloat' + ImGuiID, (_ = componet[key]) => componet[key] = _, 0.03);
           } else if (typeof property === 'boolean') {
-            ImGui.Text(peopertyName);
+            ImGui.Text(propertyName);
             ImGui.SameLine(alignWidth);
             //@ts-expect-error
             ImGui.Checkbox('##Checkbox' + ImGuiID, (_ = componet[key]) => componet[key] = _);
           } else if (property instanceof EffectsObject) {
-            ImGui.Text(peopertyName);
+            ImGui.Text(propertyName);
             ImGui.SameLine(alignWidth);
             let name = 'EffectsObject';
 

--- a/web-packages/test/unit/src/effects-core/interact/interact.spec.ts
+++ b/web-packages/test/unit/src/effects-core/interact/interact.spec.ts
@@ -503,7 +503,7 @@ describe('core/interact/item', () => {
 
     player?.gotoAndStop(0.3);
     expect(messagePhrase).to.eql(spec.MESSAGE_ITEM_PHRASE_END, 'MESSAGE_ITEM_PHRASE_END');
-    expect(messageSpy).to.have.been.called.once;
+    expect(messageSpy).to.have.been.called.twice;
     comp?.dispose();
   });
 

--- a/web-packages/test/unit/src/effects-core/plugins/sprite/sprite-item.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/sprite/sprite-item.spec.ts
@@ -287,7 +287,7 @@ describe('core/plugins/sprite/item', () => {
 
     spriteItem?.setTexture(testTexture);
     const material = spriteItem?.material;
-    const texture = material?.getTexture('uSampler0');
+    const texture = material?.getTexture('_MainTex');
 
     expect(texture?.id).to.eql(testTexture.id, 'texture id');
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced texture management in rendering components, simplifying the way textures are referenced and handled.
	- Introduced new properties for directly accessing the main texture and color in materials.
	- Added a new checkbox labeled "Enabled" in the VFX item inspector for toggling component states.
	- Introduced a new `PostProcessVolume` class for managing post-processing effects with adjustable properties.

- **Bug Fixes**
	- Improved clarity and robustness in the `VideoComponent` regarding texture management and renderer configuration.

- **Tests**
	- Updated unit tests to reflect changes in texture handling and interaction logic, ensuring accurate functionality.

These updates improve performance and usability in texture handling across various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->