### PR TITLE
refactor: opt global uniforms setting perfromance

### DIFF
--- a/packages/effects-core/src/render/render-frame.ts
+++ b/packages/effects-core/src/render/render-frame.ts
@@ -29,6 +29,7 @@ import {
   BloomThresholdPass, HQGaussianDownSamplePass, HQGaussianUpSamplePass, ToneMappingPass,
 } from './post-process-pass';
 import type { PostProcessVolume, RendererComponent } from '../components';
+import type { Vector3 } from '@galacean/effects-math/es/core/vector3';
 
 /**
  * 渲染数据，保存了当前渲染使用到的数据。
@@ -1012,7 +1013,7 @@ class FinalCopyRP extends RenderPass {
 export class GlobalUniforms {
   floats: Record<string, number> = {};
   ints: Record<string, number> = {};
-  // vector3s: Record<string, vec3> = {};
+  vector3s: Record<string, Vector3> = {};
   vector4s: Record<string, Vector4> = {};
   matrices: Record<string, Matrix4> = {};
   //...

--- a/packages/effects-core/src/render/renderer.ts
+++ b/packages/effects-core/src/render/renderer.ts
@@ -1,4 +1,4 @@
-import type { Matrix4, Vector4 } from '@galacean/effects-math/es/core/index';
+import type { Matrix4, Vector3, Vector4 } from '@galacean/effects-math/es/core/index';
 import type { RendererComponent } from '../components';
 import type { Engine } from '../engine';
 import type { Material } from '../material';
@@ -38,6 +38,10 @@ export class Renderer implements LostHandler, RestoreHandler {
   }
 
   setGlobalVector4 (name: string, value: Vector4) {
+    // OVERRIDE
+  }
+
+  setGlobalVector3 (name: string, value: Vector3) {
     // OVERRIDE
   }
 

--- a/packages/effects-webgl/src/gl-material.ts
+++ b/packages/effects-webgl/src/gl-material.ts
@@ -331,6 +331,9 @@ export class GLMaterial extends Material {
       for (name in globalUniforms.vector4s) {
         shaderVariant.setVector4(name, globalUniforms.vector4s[name]);
       }
+      for (name in globalUniforms.vector3s) {
+        shaderVariant.setVector3(name, globalUniforms.vector3s[name]);
+      }
       for (name in globalUniforms.matrices) {
         shaderVariant.setMatrix(name, globalUniforms.matrices[name]);
       }

--- a/packages/effects-webgl/src/gl-renderer.ts
+++ b/packages/effects-webgl/src/gl-renderer.ts
@@ -117,13 +117,11 @@ export class GLRenderer extends Renderer implements Disposable {
     this.renderingData.currentFrame = frame;
     this.renderingData.currentCamera = currentCamera;
 
-    if (currentCamera) {
-      this.setGlobalMatrix('effects_MatrixInvV', currentCamera.getInverseViewMatrix());
-      this.setGlobalMatrix('effects_MatrixV', currentCamera.getViewMatrix());
-      this.setGlobalMatrix('effects_MatrixVP', currentCamera.getViewProjectionMatrix());
-      this.setGlobalMatrix('_MatrixP', currentCamera.getProjectionMatrix());
-      this.setGlobalVector3('effects_WorldSpaceCameraPos', currentCamera.position);
-    }
+    this.setGlobalMatrix('effects_MatrixInvV', currentCamera.getInverseViewMatrix());
+    this.setGlobalMatrix('effects_MatrixV', currentCamera.getViewMatrix());
+    this.setGlobalMatrix('effects_MatrixVP', currentCamera.getViewProjectionMatrix());
+    this.setGlobalMatrix('_MatrixP', currentCamera.getProjectionMatrix());
+    this.setGlobalVector3('effects_WorldSpaceCameraPos', currentCamera.position);
 
     // 根据 priority 排序 pass
     sortByOrder(passes);

--- a/packages/effects-webgl/src/gl-renderer.ts
+++ b/packages/effects-webgl/src/gl-renderer.ts
@@ -18,6 +18,7 @@ import { GLTexture } from './gl-texture';
 
 type Matrix4 = math.Matrix4;
 type Vector4 = math.Vector4;
+type Vector3 = math.Vector3;
 
 export class GLRenderer extends Renderer implements Disposable {
   glRenderer: GLRendererInternal;
@@ -111,8 +112,18 @@ export class GLRenderer extends Renderer implements Disposable {
     this.setFramebuffer(null);
     this.clear(frame.clearAction);
 
+    const currentCamera = frame.camera;
+
     this.renderingData.currentFrame = frame;
-    this.renderingData.currentCamera = frame.camera;
+    this.renderingData.currentCamera = currentCamera;
+
+    if (currentCamera) {
+      this.setGlobalMatrix('effects_MatrixInvV', currentCamera.getInverseViewMatrix());
+      this.setGlobalMatrix('effects_MatrixV', currentCamera.getViewMatrix());
+      this.setGlobalMatrix('effects_MatrixVP', currentCamera.getViewProjectionMatrix());
+      this.setGlobalMatrix('_MatrixP', currentCamera.getProjectionMatrix());
+      this.setGlobalVector3('effects_WorldSpaceCameraPos', currentCamera.position);
+    }
 
     // 根据 priority 排序 pass
     sortByOrder(passes);
@@ -173,6 +184,11 @@ export class GLRenderer extends Renderer implements Disposable {
     this.renderingData.currentFrame.globalUniforms.matrices[name] = value;
   }
 
+  override setGlobalVector3 (name: string, value: Vector3) {
+    this.checkGlobalUniform(name);
+    this.renderingData.currentFrame.globalUniforms.vector3s[name] = value;
+  }
+
   override drawGeometry (geometry: Geometry, material: Material, subMeshIndex = 0): void {
     if (!geometry || !material) {
       return;
@@ -181,27 +197,6 @@ export class GLRenderer extends Renderer implements Disposable {
     geometry.initialize();
     geometry.flush();
     const renderingData = this.renderingData;
-
-    // TODO 后面移到管线相机渲染开始位置
-    if (renderingData.currentFrame.globalUniforms) {
-      if (renderingData.currentCamera) {
-        this.setGlobalMatrix('effects_MatrixInvV', renderingData.currentCamera.getInverseViewMatrix());
-        this.setGlobalMatrix('effects_MatrixV', renderingData.currentCamera.getViewMatrix());
-        this.setGlobalMatrix('effects_MatrixVP', renderingData.currentCamera.getViewProjectionMatrix());
-        this.setGlobalMatrix('_MatrixP', renderingData.currentCamera.getProjectionMatrix());
-      }
-
-      // TODO 自定义材质测试代码
-      const time = Date.now() % 100000000 * 0.001 * 1;
-      let _Time = this.getGlobalVector4('_Time');
-
-      // TODO 待移除
-      this.setGlobalFloat('_GlobalTime', time);
-      if (!_Time) {
-        _Time = new math.Vector4(time / 20, time, time * 2, time * 3);
-      }
-      this.setGlobalVector4('_Time', _Time.set(time / 20, time, time * 2, time * 3));
-    }
 
     if (renderingData.currentFrame.editorTransform) {
       material.setVector4('uEditorTransform', renderingData.currentFrame.editorTransform);


### PR DESCRIPTION
- add effects_WorldSpaceCameraPos shader built-in property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a method to set global vector3 uniforms in the rendering pipeline, enhancing material capabilities.
  - Added handling for camera data in rendering logic to improve clarity and performance.

- **Bug Fixes**
  - Improved processing of vector3 uniforms in the `GLMaterial` class for better shader integration.

- **Refactor**
  - Streamlined camera-related data handling in the `GLRenderer` class.
  - Updated type definitions for vector3 handling in the rendering framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->