### PR TITLE
fix: the reporting words for unexpected parse result

### DIFF
--- a/plugin-packages/rich-text/src/rich-text-parser.ts
+++ b/plugin-packages/rich-text/src/rich-text-parser.ts
@@ -92,11 +92,11 @@ export const richTextParser = (input: string): RichTextAST[] => {
         const { attributeName: endAttributeName } = ContextEnd();
 
         if (!endAttributeName) {
-          throw new Error('Expected end of font style with tag "' + expectedEndAttributeName + '" at position ' + cursor + ' but not found any tag!');
+          throw new Error('Expect an end tag marker "' + expectedEndAttributeName + '" at position ' + cursor + ' but found no tag!');
         }
 
         if (endAttributeName !== expectedEndAttributeName) {
-          throw new Error('Expected end of font style with tag "' + expectedEndAttributeName + '" at position ' + cursor + ' but found tag "' + endAttributeName + '"');
+          throw new Error('Expect an end tag marker "' + expectedEndAttributeName + '" at position ' + cursor + ' but found tag "' + endAttributeName + '"');
         }
 
         return;
@@ -133,7 +133,7 @@ export const richTextParser = (input: string): RichTextAST[] => {
         return { attributeName, attributeParam };
       }
 
-      throw new Error('Expected a font style start tag at position ' + cursor);
+      throw new Error('Expected a start tag marker at position ' + cursor);
     }
 
     return {};
@@ -153,11 +153,12 @@ export const richTextParser = (input: string): RichTextAST[] => {
         return { attributeName };
       }
 
-      throw new Error('Expected a font style end tag at position ' + cursor);
+      throw new Error('Expect an end tag marker at position ' + cursor);
     }
 
     return {};
   }
+
   Grammar();
 
   return ast;
@@ -184,6 +185,7 @@ export function generateProgram (textHandler: (text: string, context: Record<str
 
 export function isRichText (text: string): boolean {
   const lexed = lexer(text);
+
   const contextTokens = lexed.filter(({ tokenType }) => tokenType === TokenType.ContextStart || tokenType === TokenType.ContextEnd);
 
   const contextStartTokens = contextTokens.filter(({ tokenType }) => tokenType === TokenType.ContextStart);

--- a/plugin-packages/rich-text/test/src/rich-text-parser.spec.ts
+++ b/plugin-packages/rich-text/test/src/rich-text-parser.spec.ts
@@ -261,7 +261,7 @@ describe('test unparsable text', () => {
       { tokenType: 'Text', value: ' amused\n' },
     ]);
 
-    expect(() => parser(unparsableRichText1)).to.throw('Expected end of font style with tag "i" at position 41 but found tag "b"');
+    expect(() => parser(unparsableRichText1)).to.throw('Expect an end tag marker "i" at position 41 but found tag "b"');
   });
 
   it('case 2', () => {
@@ -273,7 +273,7 @@ describe('test unparsable text', () => {
       { tokenType: 'Text', value: 'absolutely\n' },
     ]);
 
-    expect(() => parser(unparsableRichText2)).to.throw('Expected end of font style with tag "color" at position 34 but not found any tag!');
+    expect(() => parser(unparsableRichText2)).to.throw('Expect an end tag marker "color" at position 34 but found no tag!');
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clarity of error messages related to expected tags in the rich text parser, enhancing user understanding of issues encountered during text processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->