### PR TITLE
fix: player auto play false rendering

### DIFF
--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -412,7 +412,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       this.autoPlaying = true;
       composition.play();
     } else {
-      composition.gotoAndStop(0);
+      composition.pause();
     }
 
     const compileTime = performance.now() - compileStart;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of composition state after loading; compositions now pause instead of automatically going to the start frame when autoplay is disabled.
  
- **Documentation**
	- Enhanced comments and documentation for better clarity on methods and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->