### PR TITLE
fix: track bindings are set incorrectly when there are reused precompositions

### DIFF
--- a/packages/effects-core/src/comp-vfx-item.ts
+++ b/packages/effects-core/src/comp-vfx-item.ts
@@ -72,6 +72,7 @@ export class CompositionComponent extends Behaviour {
     const time = this.time;
 
     this.timelinePlayable.setTime(time);
+    this.resolveBindings();
     this.graph.evaluate(dt);
   }
 

--- a/packages/effects-core/src/comp-vfx-item.ts
+++ b/packages/effects-core/src/comp-vfx-item.ts
@@ -72,6 +72,9 @@ export class CompositionComponent extends Behaviour {
     const time = this.time;
 
     this.timelinePlayable.setTime(time);
+
+    // The properties of the object may change dynamically,
+    // so reset the track binding to avoid invalidation of the previously obtained binding object.
     this.resolveBindings();
     this.graph.evaluate(dt);
   }

--- a/packages/effects-core/src/plugins/timeline/playable-assets/timeline-asset.ts
+++ b/packages/effects-core/src/plugins/timeline/playable-assets/timeline-asset.ts
@@ -100,9 +100,6 @@ export class TimelinePlayable extends Playable {
   evaluate () {
     const time = this.getTime();
 
-    // update all tracks binding
-    this.updateTrackAnimatedObject(this.masterTrackInstances);
-
     // TODO search active clips
 
     for (const clip of this.clips) {
@@ -147,19 +144,6 @@ export class TimelinePlayable extends Playable {
 
         trackInstance.addChild(childTrackInstance);
       }
-    }
-  }
-
-  private updateTrackAnimatedObject (trackInstances: TrackInstance[]) {
-    for (const trackInstance of trackInstances) {
-      const trackAsset = trackInstance.trackAsset;
-
-      // update track binding use custom method
-      trackAsset.updateAnimatedObject();
-      trackInstance.output.setUserData(trackAsset.boundObject);
-
-      // update children tracks
-      this.updateTrackAnimatedObject(trackInstance.children);
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved dynamic handling of bindings during updates.
	- Enhanced error management for referenced precompositions during content creation.

- **Bug Fixes**
	- Resolved issues related to invalid binding objects by ensuring consistent updates.

- **Refactor**
	- Streamlined data deserialization in the `fromData` method.
	- Removed outdated track binding update logic in the `TimelinePlayable` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->