### PR TITLE
perf: opt sprite shader alpha clip performance

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -206,6 +206,12 @@ export class BaseRenderComponent extends RendererComponent {
       texParams.x = renderer.occlusion ? +(renderer.transparentOcclusion) : 1;
       texParams.y = +this.preMultiAlpha;
       texParams.z = renderer.renderMode;
+
+      if (texParams.x === 0) {
+        this.material.enableMacro('ALPHA_CLIP');
+      } else {
+        this.material.disableMacro('ALPHA_CLIP');
+      }
     }
 
     const attributes = {

--- a/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
@@ -67,9 +67,9 @@ export function spriteMeshShaderFromRenderInfo (renderInfo: ItemRenderInfo, coun
   });
 
   shader.shared = true;
-  if (!wireframe) {
-    shader.cacheId = spriteMeshShaderIdFromRenderInfo(renderInfo, count);
-  }
+  // if (!wireframe) {
+  //   shader.cacheId = spriteMeshShaderIdFromRenderInfo(renderInfo, count);
+  // }
 
   return shader;
 }

--- a/packages/effects-core/src/shader/item.frag.glsl
+++ b/packages/effects-core/src/shader/item.frag.glsl
@@ -26,9 +26,12 @@ void main() {
   vec4 color = vec4(0.);
   vec4 texColor = texture2D(_MainTex, vTexCoord.xy);
   color = blendColor(texColor, vColor, floor(0.5 + vParams.y));
+
+  #ifdef ALPHA_CLIP
   if(vParams.z == 0. && color.a < 0.04) { // 1/256 = 0.04
     discard;
   }
+  #endif
   //color.rgb = pow(color.rgb, vec3(2.2));
   color.a = clamp(color.a, 0.0, 1.0);
   gl_FragColor = color;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering behavior with conditional application of the 'ALPHA_CLIP' macro.
	- Improved efficiency in hit testing by refining control flow based on interaction properties.
  
- **Bug Fixes**
	- Disabled caching mechanism for non-wireframe shaders to streamline performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->