### PR TITLE
fix: item render order

### DIFF
--- a/packages/effects-core/src/comp-vfx-item.ts
+++ b/packages/effects-core/src/comp-vfx-item.ts
@@ -224,6 +224,24 @@ export class CompositionComponent extends Behaviour {
     return regions;
   }
 
+  /**
+   * 设置当前合成子元素的渲染顺序
+   * @internal
+   */
+  setChildrenRenderOrder (startOrder: number): number {
+    for (const item of this.items) {
+      item.renderOrder = startOrder++;
+
+      const subCompositionComponent = item.getComponent(CompositionComponent);
+
+      if (subCompositionComponent) {
+        startOrder = subCompositionComponent.setChildrenRenderOrder(startOrder);
+      }
+    }
+
+    return startOrder;
+  }
+
   override fromData (data: any): void {
     super.fromData(data);
 

--- a/packages/effects-core/src/composition-source-manager.ts
+++ b/packages/effects-core/src/composition-source-manager.ts
@@ -9,8 +9,6 @@ import type { Texture } from './texture';
 import type { Disposable } from './utils';
 import type { VFXItemData } from './asset-loader';
 
-let listOrder = 0;
-
 interface RendererOptionsWithMask extends spec.RendererOptions {
   mask?: number,
 }
@@ -75,7 +73,6 @@ export class CompositionSourceManager implements Disposable {
     this.pluginSystem = pluginSystem;
     this.totalTime = totalTime ?? 0;
     this.textures = cachedTextures;
-    listOrder = 0;
     this.sourceContent = this.getContent(this.composition);
   }
 
@@ -115,8 +112,6 @@ export class CompositionSourceManager implements Disposable {
       const itemProps = sourceItemData;
 
       if (passRenderLevel(sourceItemData.renderLevel, this.renderLevel)) {
-        itemProps.listIndex = listOrder++;
-
         if (
           itemProps.type === spec.ItemType.sprite ||
           itemProps.type === spec.ItemType.particle ||

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -290,6 +290,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
     this.rootComposition.createContent();
 
     this.buildItemTree(this.rootItem);
+    this.rootComposition.setChildrenRenderOrder(0);
     this.pluginSystem.resetComposition(this, this.renderFrame);
   }
 

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -30,7 +30,6 @@ export type VFXItemProps =
     items: VFXItemProps[],
     startTime: number,
     relative?: boolean,
-    listIndex?: number,
     refId?: string,
   }
   ;
@@ -634,7 +633,6 @@ export class VFXItem extends EffectsObject implements Disposable {
     super.fromData(data);
     const {
       id, name, delay, parentId, endBehavior, transform,
-      listIndex = 0,
       duration = 0,
     } = data;
 
@@ -700,8 +698,6 @@ export class VFXItem extends EffectsObject implements Disposable {
         this.rendererComponents.push(component.renderer);
       }
     }
-    // renderOrder 在 component 初始化后设置。确保能拿到 rendererComponent。
-    this.renderOrder = listIndex;
   }
 
   override toData (): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a method to set rendering order for child elements in compositions
  - Improved initialization of composition render order

- **Bug Fixes**
  - Added validation to prevent items with negative duration
  - Simplified item indexing logic

- **Refactor**
  - Removed `listIndex` property from item data structure
  - Streamlined item initialization process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->