### PR TITLE
chore: add gl lost check when framebuffer failed

### DIFF
--- a/packages/effects-webgl/src/gl-framebuffer.ts
+++ b/packages/effects-webgl/src/gl-framebuffer.ts
@@ -298,7 +298,7 @@ export class GLFramebuffer extends Framebuffer implements Disposable {
     const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
 
     if (status !== gl.FRAMEBUFFER_COMPLETE) {
-      throw new Error(`Framebuffer failed, status: ${status}, error: ${gl.getError()}.`);
+      throw new Error(`Framebuffer failed. gl status=${status}, gl error=${gl.getError()}, gl isContextLost=${gl.isContextLost()}.`);
     }
     this.ready = true;
   }

--- a/packages/effects-webgl/src/gl-renderer-internal.ts
+++ b/packages/effects-webgl/src/gl-renderer-internal.ts
@@ -194,7 +194,7 @@ export class GLRendererInternal implements Disposable, LostHandler {
       addItem(this.framebuffers, framebuffer);
       assignInspectorName(fbo, name, name);
     } else {
-      throw new Error('Failed to create WebGL framebuffer');
+      throw new Error(`Failed to create WebGL framebuffer. gl isContextLost=${this.gl.isContextLost()}`);
     }
 
     return fbo;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error reporting for WebGL framebuffer operations
	- Improved error messages to include WebGL context state information
	- Added context loss detection to framebuffer-related error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->