### PR TITLE
fix: scene load autoplay options invalid

### DIFF
--- a/packages/effects-core/src/fallback/index.ts
+++ b/packages/effects-core/src/fallback/index.ts
@@ -45,8 +45,10 @@ export function getStandardJSON (json: any): JSONScene {
       json = version30Migration(version21Migration(json));
     }
     // 3.x 版本格式转换
-    if (mainVersion < 4 || (mainVersion === 4 && minorVersion < 2)) {
-      json = version31Migration(json);
+    if (mainVersion < 4) {
+      if (mainVersion === 4 && minorVersion < 2) {
+        json = version31Migration(json);
+      }
     }
 
     return json;

--- a/packages/effects-core/src/fallback/index.ts
+++ b/packages/effects-core/src/fallback/index.ts
@@ -46,7 +46,7 @@ export function getStandardJSON (json: any): JSONScene {
     }
     // 3.x 版本格式转换
     if (mainVersion < 4) {
-      if (mainVersion === 4 && minorVersion < 2) {
+      if (mainVersion === 3 && minorVersion < 2) {
         json = version31Migration(json);
       }
     }

--- a/packages/effects-core/src/plugin-system.ts
+++ b/packages/effects-core/src/plugin-system.ts
@@ -8,9 +8,6 @@ import type { VFXItemConstructor } from './vfx-item';
 
 export const pluginLoaderMap: Record<string, PluginConstructor> = {};
 export const defaultPlugins: string[] = [];
-export type PrecompileOptions = {
-  [key: string]: any,
-};
 
 const pluginCtrlMap: Record<string, VFXItemConstructor> = {};
 
@@ -97,10 +94,9 @@ export class PluginSystem {
   precompile (
     compositions: spec.CompositionData[],
     renderer: Renderer,
-    options?: PrecompileOptions,
   ) {
     for (const plugin of this.plugins) {
-      plugin.precompile(compositions, renderer, options);
+      plugin.precompile(compositions, renderer);
     }
   }
 

--- a/packages/effects-core/src/plugins/plugin.ts
+++ b/packages/effects-core/src/plugins/plugin.ts
@@ -3,7 +3,6 @@ import type { Scene, SceneLoadOptions } from '../scene';
 import type { VFXItem } from '../vfx-item';
 import type { RenderFrame, Renderer } from '../render';
 import type { Composition } from '../composition';
-import type { PrecompileOptions } from '../plugin-system';
 
 export interface Plugin {
   /**
@@ -18,7 +17,7 @@ export interface Plugin {
    * @param json
    * @param player
    */
-  precompile: (compositions: spec.CompositionData[], renderer: Renderer, options?: PrecompileOptions) => void,
+  precompile: (compositions: spec.CompositionData[], renderer: Renderer) => void,
 
   /**
    * 合成创建时调用，用于触发元素在合成创建时的回调
@@ -144,7 +143,7 @@ export abstract class AbstractPlugin implements Plugin {
    * @param json
    * @param player
    */
-  precompile (compositions: spec.CompositionData[], renderer: Renderer, options?: PrecompileOptions): void { }
+  precompile (compositions: spec.CompositionData[], renderer: Renderer): void { }
 
   onCompositionConstructed (composition: Composition, scene: Scene): void { }
 

--- a/packages/effects-threejs/src/three-display-object.ts
+++ b/packages/effects-threejs/src/three-display-object.ts
@@ -102,7 +102,7 @@ export class ThreeDisplayObject extends THREE.Group {
         this.assetService.updateTextVariables(scene, assetManager.options.variables);
         this.assetService.initializeTexture(scene);
 
-        scene.pluginSystem.precompile(scene.jsonScene.compositions, this.renderer, options);
+        scene.pluginSystem.precompile(scene.jsonScene.compositions, this.renderer);
 
         const composition = this.createComposition(scene, opts);
 

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -326,11 +326,16 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       scenes.push(scene);
     }
 
+    if (autoplay) {
+      this.autoPlaying = true;
+    }
+
     const autoplayFlags: boolean[] = [];
 
     await Promise.all(
       scenes.map(async (url, index) => {
         const { source, options: opts } = this.assetService.assembleSceneLoadOptions(url, { autoplay, ...options });
+        const compositionAutoplay = opts?.autoplay ?? autoplay;
         const assetManager = new AssetManager(opts);
 
         // TODO 多 json 之间目前不共用资源，如果后续需要多 json 共用，这边缓存机制需要额外处理
@@ -349,13 +354,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
         this.baseCompositionIndex += 1;
         composition.setIndex(baseOrder + index);
         compositions[index] = composition;
-
-        if (opts?.autoplay === true || opts?.autoplay === undefined && autoplay) {
-          autoplayFlags[index] = true;
-        } else {
-          autoplayFlags[index] = false;
-        }
-
+        autoplayFlags[index] = compositionAutoplay;
       }),
     );
 
@@ -369,7 +368,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
 
     for (let i = 0; i < compositions.length; i++) {
       if (autoplayFlags[i]) {
-        this.autoPlaying = true;
         compositions[i].play();
       } else {
         compositions[i].pause();

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -5,8 +5,18 @@ import '@galacean/effects-plugin-spine';
 const json = 'https://gw.alipayobjects.com/os/gltf-asset/mars-cli/ILDKKFUFMVJA/1705406034-80896.json';
 const jsons = [
   json,
-  'https://mdn.alipayobjects.com/mars/afts/file/A*2rNdR76aFvMAAAAAAAAAAAAADlB4AQ',
-  'https://mdn.alipayobjects.com/mars/afts/file/A*u-NFTK_DS0IAAAAAAAAAAAAAelB4AQ',
+  {
+    url: 'https://mdn.alipayobjects.com/mars/afts/file/A*2rNdR76aFvMAAAAAAAAAAAAADlB4AQ',
+    options: {
+      autoplay: true,
+    },
+  },
+  {
+    url: 'https://mdn.alipayobjects.com/mars/afts/file/A*u-NFTK_DS0IAAAAAAAAAAAAAelB4AQ',
+    options: {
+      autoplay: false,
+    },
+  },
   'https://mdn.alipayobjects.com/graph_jupiter/afts/file/A*qTquTKYbk6EAAAAAAAAAAAAADsF2AQ',
 ];
 const container = document.getElementById('J-container');
@@ -20,5 +30,7 @@ const container = document.getElementById('J-container');
     },
   });
 
-  await player.loadScene(jsons);
+  const compositions = await player.loadScene(jsons);
+
+  // compositions[0].play();
 })();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced per-scene autoplay settings for a more personalized playback experience. Each scene now determines its own autoplay behavior rather than relying on a single global flag.

- **Refactor**
  - Simplified the precompile method by removing the options parameter, enhancing the clarity and efficiency of plugin precompilation.
  - Updated the logic for scene loading to improve data handling and streamline operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->