### PR TITLE
refactor: baseRenderComponent material create

### DIFF
--- a/packages/effects-core/src/plugins/sprite/sprite-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-item.ts
@@ -2,7 +2,7 @@ import { Color, Vector4 } from '@galacean/effects-math/es/core/index';
 import * as spec from '@galacean/effects-specification';
 import type { ColorPlayableAssetData } from '../../animation';
 import { ColorPlayable } from '../../animation';
-import { BaseRenderComponent, getImageItemRenderInfo } from '../../components';
+import { BaseRenderComponent } from '../../components';
 import { effectsClass } from '../../decorators';
 import type { Engine } from '../../engine';
 import { glContext } from '../../gl';
@@ -307,10 +307,9 @@ export class SpriteComponent extends BaseRenderComponent {
 
     this.splits = data.splits || singleSplits;
     this.textureSheetAnimation = data.textureSheetAnimation;
-    this.renderInfo = getImageItemRenderInfo(this);
 
     const geometry = this.createGeometry(glContext.TRIANGLES);
-    const material = this.createMaterial(this.renderInfo, 2);
+    const material = this.createMaterial(this.renderer);
 
     this.material = material;
     this.geometry = geometry;

--- a/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-mesh.ts
@@ -1,11 +1,7 @@
 import type { Vector3 } from '@galacean/effects-math/es/core/vector3';
 import type * as spec from '@galacean/effects-specification';
-import { PLAYER_OPTIONS_ENV_EDITOR } from '../../constants';
-import type { GPUCapabilityDetail, ShaderMacros, SharedShaderWithSource } from '../../render';
-import { GLSLVersion } from '../../render';
-import { itemFrag, itemFrameFrag, itemVert } from '../../shader';
+import type { GPUCapabilityDetail } from '../../render';
 import type { Transform } from '../../transform';
-import type { ItemRenderInfo } from '../../components';
 
 export type SpriteRenderData = {
   life: number,
@@ -33,45 +29,6 @@ export function setSpriteMeshMaxItemCountByGPU (gpuCapability: GPUCapabilityDeta
   } else if (gpuCapability.maxVertexUniforms >= 128) {
     return maxSpriteMeshItemCount = 16;
   }
-}
-
-export function spriteMeshShaderFromFilter (
-  level: number,
-  options?: { wireframe?: boolean, env?: string },
-): SharedShaderWithSource {
-  const { env = '', wireframe } = options ?? {};
-  const macros: ShaderMacros = [
-    ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
-  ];
-  const fragment = wireframe ? itemFrameFrag : itemFrag;
-  const vertex = itemVert;
-
-  return {
-    fragment,
-    vertex,
-    glslVersion: level === 1 ? GLSLVersion.GLSL1 : GLSLVersion.GLSL3,
-    macros,
-    shared: true,
-  };
-}
-
-export function spriteMeshShaderIdFromRenderInfo (renderInfo: ItemRenderInfo, count: number): string {
-  return `${renderInfo.cachePrefix}_effects_sprite_${count}`;
-}
-
-export function spriteMeshShaderFromRenderInfo (renderInfo: ItemRenderInfo, count: number, level: number, env?: string): SharedShaderWithSource {
-  const { wireframe } = renderInfo;
-  const shader = spriteMeshShaderFromFilter(level, {
-    wireframe,
-    env,
-  });
-
-  shader.shared = true;
-  // if (!wireframe) {
-  //   shader.cacheId = spriteMeshShaderIdFromRenderInfo(renderInfo, count);
-  // }
-
-  return shader;
 }
 
 // TODO: 只有单测用

--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -3,7 +3,7 @@ import { Color, Vector4 } from '@galacean/effects-math/es/core/index';
 import * as spec from '@galacean/effects-specification';
 import { canvasPool } from '../../canvas-pool';
 import type { ItemRenderer } from '../../components';
-import { BaseRenderComponent, getImageItemRenderInfo } from '../../components';
+import { BaseRenderComponent } from '../../components';
 import { effectsClass } from '../../decorators';
 import type { Engine } from '../../engine';
 import { glContext } from '../../gl';
@@ -125,9 +125,8 @@ export class TextComponent extends BaseRenderComponent {
       order: listIndex,
     };
     this.interaction = interaction;
-    this.renderInfo = getImageItemRenderInfo(this);
 
-    const material = this.createMaterial(this.renderInfo, 2);
+    const material = this.createMaterial(this.renderer);
 
     this.material = material;
 

--- a/packages/effects-threejs/src/three-text-component.ts
+++ b/packages/effects-threejs/src/three-text-component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 import type { Engine, SpriteItemProps } from '@galacean/effects-core';
-import { math, effectsClass, spec, applyMixins, canvasPool, TextComponentBase, getImageItemRenderInfo } from '@galacean/effects-core';
+import { math, effectsClass, spec, applyMixins, canvasPool, TextComponentBase } from '@galacean/effects-core';
 import { ThreeSpriteComponent } from './three-sprite-component';
 
 export interface ThreeTextComponent extends TextComponentBase { }
@@ -39,8 +39,6 @@ export class ThreeTextComponent extends ThreeSpriteComponent {
   override fromData (data: SpriteItemProps): void {
     super.fromData(data);
     const options = data.options as spec.TextContentOptions;
-
-    this.renderInfo = getImageItemRenderInfo(this);
 
     this.material.setVector4('_TexOffset', new math.Vector4().setFromArray([0, 0, 1, 1]));
     // TextComponentBase

--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -1,10 +1,10 @@
 import type {
   Engine, Texture2DSourceOptionsVideo, Asset, SpriteItemProps, GeometryFromShape,
-  ItemRenderInfo, MaterialProps, ShaderMacros, MaskProps,
+  MaterialProps, ShaderMacros, MaskProps,
 } from '@galacean/effects';
 import {
   spec, math, Texture, MaskMode, effectsClass, BaseRenderComponent, glContext,
-  PLAYER_OPTIONS_ENV_EDITOR, itemFrag, itemVert, GLSLVersion, getImageItemRenderInfo,
+  itemFrag, itemVert, GLSLVersion,
   assertExist,
 } from '@galacean/effects';
 
@@ -98,10 +98,9 @@ export class VideoComponent extends BaseRenderComponent {
     });
   }
 
-  protected override getMaterialProps (renderInfo: ItemRenderInfo, count: number): MaterialProps {
+  protected override getMaterialProps (): MaterialProps {
     const macros: ShaderMacros = [
       ['TRANSPARENT_VIDEO', this.transparent],
-      ['ENV_EDITOR', this.engine.renderer?.env === PLAYER_OPTIONS_ENV_EDITOR],
     ];
     const fragment = itemFrag;
     const vertex = itemVert;
@@ -109,7 +108,7 @@ export class VideoComponent extends BaseRenderComponent {
     const shader = {
       fragment,
       vertex,
-      glslVersion: count === 1 ? GLSLVersion.GLSL1 : GLSLVersion.GLSL3,
+      glslVersion: GLSLVersion.GLSL1,
       macros,
       shared: true,
     };
@@ -167,10 +166,9 @@ export class VideoComponent extends BaseRenderComponent {
 
     this.interaction = interaction;
     this.pauseVideo();
-    this.renderInfo = getImageItemRenderInfo(this);
 
     const geometry = this.createGeometry(glContext.TRIANGLES);
-    const material = this.createMaterial(this.renderInfo, 2);
+    const material = this.createMaterial(this.renderer);
 
     if (this.transparent) {
       this.material.enableMacro('TRANSPARENT_VIDEO', this.transparent);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified material and shader creation processes across components by removing intermediate render info objects and related functions.
  - Material creation now uses renderer properties directly, reducing complexity and dependencies.
  - Shader configuration is now static, with explicit GLSL version settings, improving consistency.
  - Cleaned up unused imports and streamlined method signatures for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->