### PR TITLE
fix: custom shape do not draw the last segment when not closed

### DIFF
--- a/packages/effects-core/src/components/shape-component.ts
+++ b/packages/effects-core/src/components/shape-component.ts
@@ -400,6 +400,14 @@ void main() {
           }
 
           if (shape.close) {
+            const pointIndex = indices[0];
+            const lastPointIndex = indices[indices.length - 1];
+            const point = points[pointIndex.point];
+            const lastPoint = points[lastPointIndex.point];
+            const control1 = easingOuts[lastPointIndex.easingOut];
+            const control2 = easingIns[pointIndex.easingIn];
+
+            this.graphicsPath.bezierCurveTo(control1.x + lastPoint.x, control1.y + lastPoint.y, control2.x + point.x, control2.y + point.y, point.x, point.y, 1);
             this.graphicsPath.closePath();
           }
         }

--- a/packages/effects-core/src/components/shape-component.ts
+++ b/packages/effects-core/src/components/shape-component.ts
@@ -399,15 +399,6 @@ void main() {
             this.graphicsPath.bezierCurveTo(control1.x + lastPoint.x, control1.y + lastPoint.y, control2.x + point.x, control2.y + point.y, point.x, point.y, 1);
           }
 
-          const pointIndex = indices[0];
-          const lastPointIndex = indices[indices.length - 1];
-          const point = points[pointIndex.point];
-          const lastPoint = points[lastPointIndex.point];
-          const control1 = easingOuts[lastPointIndex.easingOut];
-          const control2 = easingIns[pointIndex.easingIn];
-
-          this.graphicsPath.bezierCurveTo(control1.x + lastPoint.x, control1.y + lastPoint.y, control2.x + point.x, control2.y + point.y, point.x, point.y, 1);
-
           if (shape.close) {
             this.graphicsPath.closePath();
           }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering of custom shapes by ensuring bezier curves connect points only when shapes are closed, resulting in smoother and more accurate paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->