### PR TITLE
fix: 修复 Spine 混合模式渲染问题

### DIFF
--- a/plugin-packages/spine/src/shader/fragment.glsl
+++ b/plugin-packages/spine/src/shader/fragment.glsl
@@ -8,4 +8,5 @@ void main() {
   vec4 texColor = texture2D(uTexture, vTexCoords);
   gl_FragColor.a = texColor.a * vLight.a;
   gl_FragColor.rgb = ((texColor.a - 1.0) * vDark.a + 1.0 - texColor.rgb) * vDark.rgb + texColor.rgb * vLight.rgb;
+  gl_FragColor.rgb *= gl_FragColor.a;
 }

--- a/plugin-packages/spine/src/slot-group.ts
+++ b/plugin-packages/spine/src/slot-group.ts
@@ -248,7 +248,6 @@ export class SlotGroup {
             texture,
             name: this.meshName,
             priority: this.listIndex += 0.01,
-            pma,
             renderOptions: this.renderOptions,
             engine: this.engine,
           });

--- a/plugin-packages/spine/src/spine-mesh.ts
+++ b/plugin-packages/spine/src/spine-mesh.ts
@@ -15,7 +15,6 @@ export interface SpineMeshRenderInfo {
   priority: number,
   blendMode: BlendMode,
   name?: string,
-  pma: boolean,
   renderOptions: {
     maskMode?: number,
     mask?: number,
@@ -40,7 +39,7 @@ export class SpineMesh implements Disposable {
   priority: number;
 
   constructor (renderInfo: SpineMeshRenderInfo) {
-    const { blendMode, texture, priority, renderOptions = {}, pma, name = 'MSpine', engine } = renderInfo;
+    const { blendMode, texture, priority, renderOptions = {}, name = 'MSpine', engine } = renderInfo;
     const { mask = 0, maskMode = 0 } = renderOptions;
 
     this.blendMode = blendMode;
@@ -48,7 +47,7 @@ export class SpineMesh implements Disposable {
     this.priority = priority;
     this.engine = engine;
     this.geometry = this.createGeometry();
-    this.material = this.createMaterial(pma, maskMode, mask);
+    this.material = this.createMaterial(maskMode, mask);
     this.mesh = Mesh.create(
       engine,
       {
@@ -94,7 +93,7 @@ export class SpineMesh implements Disposable {
       });
   }
 
-  createMaterial (pma: boolean, maskMode: number, maskOrder: number): Material {
+  createMaterial (maskMode: number, maskOrder: number): Material {
     const material = Material.create(
       this.engine,
       {
@@ -113,7 +112,7 @@ export class SpineMesh implements Disposable {
     material.depthMask = false;
     material.stencilRef = maskOrder !== undefined ? [maskOrder, maskOrder] : undefined;
 
-    setBlending(material, this.blendMode, pma);
+    setBlending(material, this.blendMode);
     setMaskMode(material, maskMode);
 
     return material;

--- a/plugin-packages/spine/src/utils.ts
+++ b/plugin-packages/spine/src/utils.ts
@@ -11,7 +11,7 @@ export function setBlending (material: Material, mode: BlendMode, pma: boolean) 
   material.blendEquation = [glContext.FUNC_ADD, glContext.FUNC_ADD];
   switch (mode) {
     case BlendMode.Multiply:
-      material.blendFunction = [glContext.DST_COLOR, glContext.ONE_MINUS_SRC_ALPHA, glContext.ONE_MINUS_SRC_ALPHA, glContext.ONE_MINUS_SRC_ALPHA];
+      material.blendFunction = [glContext.DST_COLOR, glContext.ONE_MINUS_SRC_ALPHA, glContext.DST_COLOR, glContext.ONE_MINUS_SRC_ALPHA];
 
       break;
     case BlendMode.Screen:
@@ -19,11 +19,11 @@ export function setBlending (material: Material, mode: BlendMode, pma: boolean) 
 
       break;
     case BlendMode.Additive:
-      material.blendFunction = [pma ? glContext.ONE : glContext.SRC_ALPHA, glContext.ONE, glContext.ONE, glContext.ONE];
+      material.blendFunction = [glContext.ONE, glContext.ONE, glContext.ONE, glContext.ONE];
 
       break;
     case BlendMode.Normal:
-      material.blendFunction = [pma ? glContext.ONE : glContext.SRC_ALPHA, glContext.ONE_MINUS_SRC_ALPHA, glContext.ONE, glContext.ONE_MINUS_SRC_ALPHA];
+      material.blendFunction = [glContext.ONE, glContext.ONE_MINUS_SRC_ALPHA, glContext.ONE, glContext.ONE_MINUS_SRC_ALPHA];
 
       break;
     default:

--- a/plugin-packages/spine/src/utils.ts
+++ b/plugin-packages/spine/src/utils.ts
@@ -7,7 +7,7 @@ import type { Material, Texture } from '@galacean/effects';
 import { assertExist, glContext } from '@galacean/effects';
 import { decodeText } from './polyfill';
 
-export function setBlending (material: Material, mode: BlendMode, pma: boolean) {
+export function setBlending (material: Material, mode: BlendMode) {
   material.blendEquation = [glContext.FUNC_ADD, glContext.FUNC_ADD];
   switch (mode) {
     case BlendMode.Multiply:

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -30,7 +30,7 @@ const container = document.getElementById('J-container');
     },
   });
 
-  const compositions = await player.loadScene(jsons);
+  const compositions = await player.loadScene('https://mdn.alipayobjects.com/mars/afts/file/A*Z7CdSZraICQAAAAAAAAAAAAAelB4AQ');
 
   // compositions[0].play();
 })();

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -30,7 +30,7 @@ const container = document.getElementById('J-container');
     },
   });
 
-  const compositions = await player.loadScene('https://mdn.alipayobjects.com/mars/afts/file/A*Z7CdSZraICQAAAAAAAAAAAAAelB4AQ');
+  const compositions = await player.loadScene(jsons);
 
   // compositions[0].play();
 })();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified blending logic in Spine rendering by removing support for premultiplied alpha (pma) across related components.
  - Updated interfaces and method signatures to reflect the removal of the pma property and parameter.
  - Adjusted blend mode handling for more consistent rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->