### PR TITLE
fix: video pause error

### DIFF
--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -189,7 +189,7 @@ export class VideoComponent extends BaseRenderComponent {
     assertExist(composition);
     const { endBehavior: rootEndBehavior, duration: rootDuration } = composition.rootItem;
 
-    if (time > 0) {
+    if (time > 0 && this.video && !this.video.paused) {
       this.setVisible(true);
       this.playVideo();
     }

--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -189,7 +189,10 @@ export class VideoComponent extends BaseRenderComponent {
     assertExist(composition);
     const { endBehavior: rootEndBehavior, duration: rootDuration } = composition.rootItem;
 
-    if (time > 0 && this.video && !this.video.paused) {
+    const isEnd = (time === 0 || time === (rootDuration - start) || Math.abs(rootDuration - duration - time) < 1e-10)
+    || Math.abs(time - duration) < this.threshold;
+
+    if (time > 0 && !isEnd) {
       this.setVisible(true);
       this.playVideo();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video playback behavior to prevent videos from playing or becoming visible at the start, end, or near the end of the timeline. Videos now only play when appropriate, enhancing user experience at timeline boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->