### PR TITLE
fix: mask is still drawn when the component is not activated

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -159,6 +159,9 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
    * @internal
    */
   drawStencilMask (renderer: Renderer) {
+    if (!this.isActiveAndEnabled) {
+      return;
+    }
     const previousColorMask = this.material.colorMask;
 
     this.material.colorMask = false;

--- a/packages/effects-core/src/material/mask-ref-manager.ts
+++ b/packages/effects-core/src/material/mask-ref-manager.ts
@@ -7,7 +7,7 @@ import { TextureLoadAction } from '../texture/types';
 import type { RenderPassClearAction } from '../render/render-pass';
 
 export class MaskProcessor {
-  maskable?: Maskable;
+  maskable: Maskable | null = null;
 
   private stencilClearAction: RenderPassClearAction;
 
@@ -29,7 +29,9 @@ export class MaskProcessor {
         maskMode = MaskMode.MASK;
       } else if (mode === spec.ObscuredMode.OBSCURED || mode === spec.ObscuredMode.REVERSE_OBSCURED) {
         maskMode = mode === spec.ObscuredMode.OBSCURED ? MaskMode.OBSCURED : MaskMode.REVERSE_OBSCURED;
-        this.maskable = ref;
+        if (ref) {
+          this.maskable = ref;
+        }
       }
     }
 

--- a/packages/effects-core/src/material/types.ts
+++ b/packages/effects-core/src/material/types.ts
@@ -2,7 +2,6 @@ import type * as spec from '@galacean/effects-specification';
 import type { Matrix3, Matrix4, Vector2, Vector3, Vector4 } from '@galacean/effects-math/es/core/index';
 import type { Texture } from '../texture';
 import type { DestroyOptions } from '../utils';
-import type { MaskProcessor } from './mask-ref-manager';
 import type { Renderer } from '../render';
 
 export type UniformSemantic =
@@ -97,7 +96,6 @@ export interface MaskProps {
  *
  */
 export interface Maskable {
-  readonly maskManager: MaskProcessor,
   drawStencilMask: (renderer: Renderer) => void,
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component rendering reliability by ensuring stencil mask drawing is skipped for inactive or disabled components.
  - Enhanced mask processing logic to prevent unintended assignments when mask references are missing.

- **Refactor**
  - Updated interface definitions to remove unnecessary properties and improve code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->