### PR TITLE
fix: 视频不循环、合成循环时闪烁

### DIFF
--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -144,8 +144,10 @@ export class VideoComponent extends BaseRenderComponent {
       const endBehavior = this.item.taggedProperties.endBehavior;
 
       // 如果元素设置为 destroy
-      if (endBehavior === spec.EndBehavior.destroy) {
+      if (endBehavior === spec.EndBehavior.destroy || endBehavior === spec.EndBehavior.freeze) {
         this.setLoop(false);
+      } else if (endBehavior === spec.EndBehavior.restart) {
+        this.setLoop(true);
       }
     }
 
@@ -211,7 +213,6 @@ export class VideoComponent extends BaseRenderComponent {
       if (endBehavior === spec.EndBehavior.freeze) {
         this.pauseVideo();
       } else if (endBehavior === spec.EndBehavior.restart) {
-        this.setVisible(false);
         // 重播
         this.pauseVideo();
         this.setCurrentTime(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved video playback behavior by adjusting how looping and end actions are handled for "freeze" and "restart" options.
	- Fixed an issue where video visibility was incorrectly toggled during the "restart" end behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->