### PR TITLE
fix: 视频不重播、循环播放时闪烁

### DIFF
--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -115,8 +115,10 @@ export class VideoComponent extends BaseRenderComponent {
       const endBehavior = this.item.defination.endBehavior;
 
       // 如果元素设置为 destroy
-      if (endBehavior === spec.EndBehavior.destroy) {
+      if (endBehavior === spec.EndBehavior.destroy || endBehavior === spec.EndBehavior.freeze) {
         this.setLoop(false);
+      } else if (endBehavior === spec.EndBehavior.restart) {
+        this.setLoop(true);
       }
     }
 
@@ -163,7 +165,6 @@ export class VideoComponent extends BaseRenderComponent {
       if (endBehavior === spec.EndBehavior.freeze) {
         this.pauseVideo();
       } else if (endBehavior === spec.EndBehavior.restart) {
-        this.setVisible(false);
         // 重播
         this.pauseVideo();
         this.setCurrentTime(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of video end behavior to ensure correct looping and playback when set to "freeze" or "restart".
  - Resolved an issue where video visibility was incorrectly changed during the "restart" end behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->