### PR TITLE
fix: rich text plugin name migration

### DIFF
--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -61,13 +61,6 @@ const refCompositions: Map<string, spec.CompositionData> = new Map();
  * - 富文本插件名称的适配
  */
 export function version31Migration (json: JSONScene): JSONScene {
-  // 修正老版本数据中，富文本插件名称的问题
-  json.plugins?.forEach((plugin, index) => {
-    if (plugin === 'richtext') {
-      json.plugins[index] = 'rich-text';
-    }
-  });
-
   // Custom shape fill 属性位置迁移
   for (const component of json.components) {
     if (component.dataType === DataType.ShapeComponent) {
@@ -139,6 +132,13 @@ export function version32Migration (json: JSONScene): JSONScene {
 }
 
 export function version33Migration (json: JSONScene): JSONScene {
+  // 修正老版本数据中，富文本插件名称的问题
+  json.plugins?.forEach((plugin, index) => {
+    if (plugin === 'richtext') {
+      json.plugins[index] = 'rich-text';
+    }
+  });
+
   // 老 shape 数据兼容
   for (const item of json.items) {
     if (item.type === spec.ItemType.sprite) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the migration process to handle rich-text plugin name corrections in a later migration step. No changes to user-facing features or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->