### PR TITLE
fix: type issues

### DIFF
--- a/packages/effects-core/src/fallback/utils.ts
+++ b/packages/effects-core/src/fallback/utils.ts
@@ -123,7 +123,7 @@ export function colorToArr (hex: string | number[], normalized?: boolean): vec4 
       ret = [parseInt(hex[1] + hex[1], 16), parseInt(hex[2] + hex[2], 16), parseInt(hex[3] + hex[3], 16), 255];
       // eslint-disable-next-line no-cond-assign
     } else if (m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)) {
-      ret = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16), 255] || [0, 0, 0, 255];
+      ret = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16), 255];
     }
   } else if (hex instanceof Array) {
     ret = [hex[0], hex[1], hex[2], isNaN(hex[3]) ? 255 : Math.round(hex[3] * 255)];

--- a/packages/effects-core/src/fallback/utils.ts
+++ b/packages/effects-core/src/fallback/utils.ts
@@ -1,7 +1,6 @@
 import type {
   FixedNumberExpression, RGBAColorValue, ColorExpression, NumberExpression, GradientColor,
-  GradientStop, FixedVec3Expression, vec4, vec3, BezierKeyframeValue,
-  vec2,
+  GradientStop, FixedVec3Expression, vec2, vec3, vec4, BezierKeyframeValue,
 } from '@galacean/effects-specification';
 import { BezierKeyframeType, ValueType, ParticleOrigin } from '@galacean/effects-specification';
 

--- a/packages/effects-core/src/utils/color.ts
+++ b/packages/effects-core/src/utils/color.ts
@@ -20,7 +20,7 @@ export function colorToArr (hex: string | number[], normalized?: boolean): numbe
       ret = [parseInt(hex[1] + hex[1], 16), parseInt(hex[2] + hex[2], 16), parseInt(hex[3] + hex[3], 16), 255];
       // eslint-disable-next-line no-cond-assign
     } else if (m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)) {
-      ret = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16), 255] || [0, 0, 0, 255];
+      ret = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16), 255];
     }
   } else if (hex instanceof Array) {
     ret = [hex[0], hex[1], hex[2], isNaN(hex[3]) ? 255 : hex[3]];

--- a/plugin-packages/stats/src/hooks/texture-hook.ts
+++ b/plugin-packages/stats/src/hooks/texture-hook.ts
@@ -1,11 +1,14 @@
+type CreateTexture = typeof WebGLRenderingContext.prototype.createTexture;
+type DeleteTexture = typeof WebGLRenderingContext.prototype.deleteTexture;
+
 /**
  * TextureHook
  */
 export default class TextureHook {
   textures = 0;
 
-  private readonly realCreateTexture: () => WebGLTexture | null;
-  private readonly realDeleteTexture: (texture: WebGLTexture | null) => void;
+  private readonly realCreateTexture: CreateTexture;
+  private readonly realDeleteTexture: DeleteTexture;
   private hooked = true;
 
   constructor (
@@ -23,8 +26,8 @@ export default class TextureHook {
     }
   }
 
-  private hookedCreateTexture (): WebGLTexture | null {
-    const texture = this.realCreateTexture.call(this.gl);
+  private hookedCreateTexture: CreateTexture = (...args) => {
+    const texture = this.realCreateTexture.call(this.gl, ...args);
 
     this.textures++;
 
@@ -33,16 +36,16 @@ export default class TextureHook {
     }
 
     return texture;
-  }
+  };
 
-  private hookedDeleteTexture (texture: WebGLTexture | null): void {
-    this.realDeleteTexture.call(this.gl, texture);
+  private hookedDeleteTexture: DeleteTexture = (...args: Parameters<DeleteTexture>) => {
+    this.realDeleteTexture.call(this.gl, ...args);
     this.textures--;
 
     if (this.debug) {
       console.debug(`DeleteTexture, textures: ${this.textures}.`);
     }
-  }
+  };
 
   reset (): void {
     this.textures = 0;

--- a/web-packages/test/unit/src/effects-core/composition/graph.spec.ts
+++ b/web-packages/test/unit/src/effects-core/composition/graph.spec.ts
@@ -23,7 +23,16 @@ export function getCompositionGraph (comp: spec.CompositionData, items: spec.VFX
   items.forEach(item => collectNodes(item));
 
   function collectNodes (item: spec.VFXItemData, treeNodeChildren: number[] = []) {
-    const node = {
+    type Node = {
+      name: string,
+      type: spec.ItemType,
+      id: string,
+      transform?: spec.TransformData,
+      parentId?: string,
+      children?: number[],
+    };
+
+    const node: Node = {
       name: item.name,
       type: item.type,
       id: item.id,
@@ -43,7 +52,7 @@ export function getCompositionGraph (comp: spec.CompositionData, items: spec.VFX
     nodeMap[node.id] = node;
     if (node.type === spec.ItemType.tree) {
       let children: number[];
-      let nodes;
+      let nodes: Node[];
       const isTreeNode = node.id.includes('^');
 
       if (isTreeNode) {


### PR DESCRIPTION
修复项目类型在不同的 TS 版本下类型报错的问题：

- [x] 按 package.json 的最低版本 5.3.3
- [x] 如果 pnpm-lock.json 生效时的最低版本 5.4.3 
- [x] 如果 pnpm-lock.json 不生效时 package.json  允许的当前最高版本 5.8.3 

另外 plugin-packages/stats/src/hooks/texture-hook.ts 的改动是很有必要的，当前的写法是直接抄 ts 内置 lib.d.ts 中的出入参的签名，这个 lib.d.ts 维护中签名是会变的。应该用类型推断代替直接抄，避免后续升级 package.json 中 typescript 后产生类型报错

其他的改动主要是为了适配 5.3.3 ~ 5.8.3 这个范围的内的所有 ts 的签名，后续可以按需升级依赖的 ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved type safety and code clarity in texture handling and color parsing functions.
  - Enhanced explicit typing in test code for better maintainability.

- **Style**
  - Simplified internal assignments to remove redundant fallback values without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->