### PR TITLE
fix: old json texture mask migration

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -25,6 +25,7 @@ export interface ItemRenderer extends Required<Omit<spec.RendererOptions, 'textu
   mask: number,
   maskMode: MaskMode,
   shape?: GeometryFromShape,
+  alphaMask: boolean,
 }
 
 interface BaseRenderComponentData extends spec.ComponentData {
@@ -65,6 +66,7 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
       side: spec.SideMode.DOUBLE,
       maskMode: MaskMode.NONE,
       mask: 0,
+      alphaMask: true,
     };
 
     const material = Material.create(this.engine, {
@@ -293,7 +295,7 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
     texParams.w = renderer.maskMode;
     material.setVector4('_TexParams', texParams);
 
-    if (texParams.x === 0 || (renderer.maskMode === MaskMode.MASK && !renderer.shape)) {
+    if (texParams.x === 0 || (renderer.alphaMask)) {
       material.enableMacro('ALPHA_CLIP');
     } else {
       material.disableMacro('ALPHA_CLIP');
@@ -356,6 +358,8 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
       mask: this.maskManager.getRefValue(),
       shape: shapeGeometry,
       maskMode,
+      //@ts-expect-error TODO 新蒙版兼容老数据需要增加纹理透明度蒙版是否开启参数
+      alphaMask: renderer.alphaMask ?? true,
     };
 
     this.configureMaterial(this.renderer);

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -251,6 +251,7 @@ export function processMask (renderContent: any) {
     renderContent.mask = {
       mask: true,
     };
+    renderer.alphaMask = false;
     currentMaskComponent = renderContent.id;
   } else if (
     maskMode === spec.ObscuredMode.OBSCURED ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting to control alpha clipping behavior for rendered items, providing more flexibility in visual effects.

- **Bug Fixes**
  - Improved compatibility for mask behavior during data migration, ensuring correct alpha mask settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->