### PR TITLE
fix: sprite split rotate issue

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -42,7 +42,7 @@ interface BaseRenderComponentData extends spec.ComponentData {
   mask?: spec.MaskOptions,
 }
 
-const singleSplits: splitsDataType = [[0, 0, 1, 1, undefined]];
+const singleSplits: splitsDataType = [[0, 0, 1, 1, 0]];
 
 /**
  * @since 2.1.0

--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -480,10 +480,10 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
       const uvTransform = baseRenderComponentData.splits && !baseRenderComponentData.textureSheetAnimation ? baseRenderComponentData.splits[0] : singleSplits[0];
       const x = uvTransform[0];
       const y = uvTransform[1];
-      const isRotate90 = uvTransform[4];
+      const isRotate90 = Boolean(uvTransform[4]);
       const width = isRotate90 ? uvTransform[3] : uvTransform[2];
       const height = isRotate90 ? uvTransform[2] : uvTransform[3];
-      const angle = isRotate90 === 0 ? 0 : -Math.PI / 2;
+      const angle = isRotate90 ? -Math.PI / 2 : 0;
 
       const aUV = baseGeometry.getAttributeData('aUV');
       const aPos = baseGeometry.getAttributeData('aPos');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in how rotation is applied to UV coordinates, ensuring more reliable geometry setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->