### PR TITLE
fix: opt canvas dispose logic

### DIFF
--- a/packages/effects-webgl/src/gl-engine.ts
+++ b/packages/effects-webgl/src/gl-engine.ts
@@ -4,14 +4,8 @@ import type { GLRenderer } from './gl-renderer';
 import type { GLPipelineContext } from './gl-pipeline-context';
 
 export class GLEngine extends Engine {
-  /**
-   * @internal
-   */
-  gl: WebGLRenderingContext | WebGL2RenderingContext;
-
   constructor (gl: WebGLRenderingContext | WebGL2RenderingContext) {
     super();
-    this.gl = gl;
     this.gpuCapability = new GPUCapability(gl);
   }
 

--- a/packages/effects-webgl/src/gl-engine.ts
+++ b/packages/effects-webgl/src/gl-engine.ts
@@ -4,16 +4,21 @@ import type { GLRenderer } from './gl-renderer';
 import type { GLPipelineContext } from './gl-pipeline-context';
 
 export class GLEngine extends Engine {
+  /**
+   * @internal
+   */
+  gl: WebGLRenderingContext | WebGL2RenderingContext;
+
   constructor (gl: WebGLRenderingContext | WebGL2RenderingContext) {
     super();
+    this.gl = gl;
     this.gpuCapability = new GPUCapability(gl);
   }
 
   override dispose () {
-    if (this.isDestroyed) {
+    if (this.destroyed) {
       return;
     }
-
     super.dispose();
   }
 

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -9,7 +9,7 @@ import {
   isArray, pluginLoaderMap, setSpriteMeshMaxItemCountByGPU, spec, PLAYER_OPTIONS_ENV_EDITOR,
   assertExist, AssetService,
 } from '@galacean/effects-core';
-import type { GLEngine, GLRenderer } from '@galacean/effects-webgl';
+import type { GLRenderer } from '@galacean/effects-webgl';
 import { HELP_LINK } from './constants';
 import { handleThrowError, isDowngradeIOS, throwError, throwErrorPromise } from './utils';
 import type { PlayerConfig, PlayerErrorCause, PlayerEvent } from './types';
@@ -813,11 +813,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       }
       this.canvas.remove();
     }
-
-    if (!this.useExternalCanvas) {
-      (this.renderer.engine as GLEngine).gl.getExtension('WEBGL_lose_context')?.loseContext();
-    }
-
     // 在报错函数中传入 player.name
     const errorMsg = getDestroyedErrorMessage(this.name);
     const throwErrorFunc = () => throwError(errorMsg);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup when disposing of internally created canvases, ensuring the WebGL context is properly released.
  * Enhanced error handling to remove internally created canvases from the DOM if initialization fails.

* **Refactor**
  * Improved internal tracking of whether a canvas is user-supplied or created by the player.
  * Updated WebGL engine initialization and disposal logic for better context management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->