### PR TITLE
fix: bezier path build const bezier easing

### DIFF
--- a/packages/effects-core/src/math/bezier.ts
+++ b/packages/effects-core/src/math/bezier.ts
@@ -404,7 +404,11 @@ export function buildEasingCurve (leftKeyframe: spec.BezierKeyframeValue, rightK
   if (BezierMap[str]) {
     bezEasing = BezierMap[str];
   } else {
-    bezEasing = new BezierEasing(x1, y1, x2, y2);
+    if (decimalEqual(valueInterval, 0)) {
+      bezEasing = new BezierEasing();
+    } else {
+      bezEasing = new BezierEasing(x1, y1, x2, y2);
+    }
     BezierMap[str] = bezEasing;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of easing curves to ensure correct behavior when the value interval between keyframes is zero, resulting in a constant easing curve when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->