### PR TITLE
fix: add video.play error processing in loadVideo

### DIFF
--- a/packages/effects-core/src/downloader.ts
+++ b/packages/effects-core/src/downloader.ts
@@ -266,7 +266,9 @@ export async function loadVideo (url: string | MediaProvider): Promise<HTMLVideo
   video.setAttribute('playsinline', 'playsinline');
 
   return new Promise<HTMLVideoElement>((resolve, reject) => {
-    const pending = video.play();
+    const pending = video.play().catch(e=>{
+      reject(e);
+    });
 
     if (pending) {
       void pending.then(() => resolve(video));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when playing videos, ensuring that playback errors are now properly reported to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->