### PR TITLE
feat: 动画图增加合并类型的混合节点

### DIFF
--- a/packages/effects-core/src/plugins/animation-graph/nodes/index.ts
+++ b/packages/effects-core/src/plugins/animation-graph/nodes/index.ts
@@ -1,5 +1,6 @@
 export * from './animation-clip-node';
 export * from './apply-additive-node';
+export * from './merge-blend-node';
 export * from './blend-1d-node';
 export * from './bool-nodes';
 export * from './const-value-nodes';

--- a/packages/effects-core/src/plugins/animation-graph/nodes/merge-blend-node.ts
+++ b/packages/effects-core/src/plugins/animation-graph/nodes/merge-blend-node.ts
@@ -1,0 +1,156 @@
+import * as spec from '@galacean/effects-specification';
+import type { GraphContext, InstantiationContext } from '../graph-context';
+import { PoseResult } from '../pose-result';
+import { nodeDataClass } from '../node-asset-type';
+import { GraphNodeData, PoseNode } from '../graph-node';
+import type { Quaternion } from '@galacean/effects-math/es/core/quaternion';
+
+@nodeDataClass(spec.NodeDataType.MergeBlendNodeData)
+export class MergeBlendNodeData extends GraphNodeData {
+  nodeIndexes: number[];
+
+  override instantiate (context: InstantiationContext) {
+    const node = this.createNode(MergeBlendNode, context);
+
+    node.poseNodes = this.nodeIndexes.map(index => context.getNode<PoseNode>(index));
+  }
+
+  override load (data: spec.MergeBlendNodeData): void {
+    super.load(data);
+    this.nodeIndexes = data.nodeIndexes.filter(index => index >= 0);
+  }
+}
+
+export class MergeBlendNode extends PoseNode {
+  poseNodes: PoseNode[];
+
+  protected override initializeInternal (context: GraphContext): void {
+    super.initializeInternal(context);
+
+    this.poseNodes.forEach(node => {
+      node.initialize(context);
+    });
+  }
+
+  protected override shutdownInternal (context: GraphContext): void {
+    this.poseNodes.forEach(node => {
+      node.shutdown(context);
+    });
+    super.shutdownInternal(context);
+  }
+
+  override evaluate (context: GraphContext, result: PoseResult): PoseResult {
+    this.markNodeActive(context);
+    if (!this.poseNodes.length) {
+      return result;
+    }
+
+    const poseResults = this.poseNodes.map(() => new PoseResult(context.skeleton));
+    const originValues: number[] = [];
+
+    poseResults.forEach(result => {
+      result.pose.parentSpaceTransforms.forEach(transform => {
+        (['position', 'scale', 'euler', 'rotation'] as const).forEach(key => {
+          originValues.push(transform[key].x);
+          this.reset(transform[key], 'x');
+        });
+      });
+
+      result.pose.colorPropertyValues.forEach(color => {
+        originValues.push(color.a);
+        this.reset(color, 'a');
+      });
+
+      result.pose.floatPropertyValues.forEach((float, index) => {
+        originValues.push(float);
+        this.reset(result.pose.floatPropertyValues, index);
+      });
+
+      return result;
+    });
+
+    this.poseNodes.forEach((node, index) => {
+      node.evaluate(context, poseResults[index]);
+    });
+
+    poseResults.push(result);
+    let valueIndex = 0;
+    const setBefore: boolean[][] = [];
+
+    for (let i = 0; i < poseResults.length - 1; i++) {
+      const first = poseResults[i];
+      const second = poseResults[i + 1];
+      const isLast = i === poseResults.length - 1;
+      let setIndex = 0;
+
+      setBefore[i] = [];
+      first.pose.parentSpaceTransforms.forEach((firstTransform, index) => {
+        const secondTransform = second.pose.parentSpaceTransforms[index];
+
+        (['position', 'scale', 'euler', 'rotation'] as const).forEach(key => {
+          const firstSet = this.hasSet(firstTransform[key], 'x') ;
+          const secondSet = this.hasSet(secondTransform[key], 'x') && !isLast;
+
+          if (firstSet) {
+            setBefore[i][setIndex] = true;
+          } else {
+            firstTransform[key].x = originValues[valueIndex++];
+          }
+
+          if (firstSet || (!secondSet && setBefore[i][setIndex])) {
+            secondTransform[key].copyFrom(firstTransform[key] as Quaternion);
+          }
+
+          setIndex++;
+        });
+      });
+
+      first.pose.colorPropertyValues.forEach((color, index) => {
+        const secondColor = second.pose.colorPropertyValues[index];
+        const firstSet = this.hasSet(color, 'a');
+        const secondSet = this.hasSet(secondColor, 'a') && !isLast;
+
+        if (firstSet) {
+          setBefore[i][setIndex] = true;
+        } else {
+          color.a = originValues[valueIndex++];
+        }
+
+        if (firstSet || (!secondSet && setBefore[i][setIndex])) {
+          second.pose.colorPropertyValues[index].copyFrom(color);
+        }
+
+        setIndex++;
+      });
+
+      first.pose.floatPropertyValues.forEach((float, index) => {
+        const firstSet = this.hasSet(first.pose.floatPropertyValues, index);
+        const secondSet = this.hasSet(second.pose.floatPropertyValues, index) && !isLast;
+
+        if (firstSet) {
+          setBefore[i][setIndex] = true;
+        } else {
+          first.pose.floatPropertyValues[index] = originValues[valueIndex++];
+        }
+
+        if (firstSet || (!secondSet && setBefore[i][setIndex])) {
+          second.pose.floatPropertyValues[index] = first.pose.floatPropertyValues[index];
+        }
+
+        setIndex++;
+      });
+
+    }
+
+    return result;
+  }
+
+  private hasSet<T extends object, U extends keyof T> (obj: T, key: U) {
+    return !Object.is(obj[key], -0);
+  }
+
+  private reset<T extends object, U extends keyof T> (obj: T, key: U) {
+    obj[key] = -0 as any;
+  }
+
+}

--- a/packages/effects-core/src/plugins/animation-graph/nodes/merge-blend-node.ts
+++ b/packages/effects-core/src/plugins/animation-graph/nodes/merge-blend-node.ts
@@ -75,69 +75,43 @@ export class MergeBlendNode extends PoseNode {
 
     poseResults.push(result);
     let valueIndex = 0;
-    const setBefore: boolean[][] = [];
 
     for (let i = 0; i < poseResults.length - 1; i++) {
       const first = poseResults[i];
       const second = poseResults[i + 1];
-      const isLast = i === poseResults.length - 1;
-      let setIndex = 0;
 
-      setBefore[i] = [];
       first.pose.parentSpaceTransforms.forEach((firstTransform, index) => {
         const secondTransform = second.pose.parentSpaceTransforms[index];
 
         (['position', 'scale', 'euler', 'rotation'] as const).forEach(key => {
           const firstSet = this.hasSet(firstTransform[key], 'x') ;
-          const secondSet = this.hasSet(secondTransform[key], 'x') && !isLast;
 
           if (firstSet) {
-            setBefore[i][setIndex] = true;
+            secondTransform[key].copyFrom(firstTransform[key] as Quaternion);
           } else {
             firstTransform[key].x = originValues[valueIndex++];
           }
-
-          if (firstSet || (!secondSet && setBefore[i][setIndex])) {
-            secondTransform[key].copyFrom(firstTransform[key] as Quaternion);
-          }
-
-          setIndex++;
         });
       });
 
       first.pose.colorPropertyValues.forEach((color, index) => {
-        const secondColor = second.pose.colorPropertyValues[index];
         const firstSet = this.hasSet(color, 'a');
-        const secondSet = this.hasSet(secondColor, 'a') && !isLast;
 
         if (firstSet) {
-          setBefore[i][setIndex] = true;
+          second.pose.colorPropertyValues[index].copyFrom(color);
         } else {
           color.a = originValues[valueIndex++];
         }
-
-        if (firstSet || (!secondSet && setBefore[i][setIndex])) {
-          second.pose.colorPropertyValues[index].copyFrom(color);
-        }
-
-        setIndex++;
       });
 
       first.pose.floatPropertyValues.forEach((float, index) => {
         const firstSet = this.hasSet(first.pose.floatPropertyValues, index);
-        const secondSet = this.hasSet(second.pose.floatPropertyValues, index) && !isLast;
 
         if (firstSet) {
-          setBefore[i][setIndex] = true;
+          second.pose.floatPropertyValues[index] = first.pose.floatPropertyValues[index];
         } else {
           first.pose.floatPropertyValues[index] = originValues[valueIndex++];
         }
-
-        if (firstSet || (!secondSet && setBefore[i][setIndex])) {
-          second.pose.floatPropertyValues[index] = first.pose.floatPropertyValues[index];
-        }
-
-        setIndex++;
       });
 
     }


### PR DESCRIPTION
从前往后合并，如果是同元素同属性则覆盖。这个的需求场景比较强烈。

（依赖spec更新）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new animation graph node that blends multiple child pose nodes into a single output, enabling advanced pose merging capabilities within the animation system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->