### PR TITLE
fix: reset sprite animation time when component disable

### DIFF
--- a/packages/effects-core/src/plugins/animation-graph/skeleton.ts
+++ b/packages/effects-core/src/plugins/animation-graph/skeleton.ts
@@ -92,7 +92,7 @@ export class Skeleton {
   private addRecordedProperty (path: string, className: string, property: string, type: AnimatedPropertyType) {
     const totalPath = path + className + property;
 
-    if (this.pathToObjectIndex.get(totalPath)) {
+    if (this.pathToObjectIndex.get(totalPath) !== undefined) {
       return;
     }
 

--- a/packages/effects-core/src/plugins/sprite/sprite-item.ts
+++ b/packages/effects-core/src/plugins/sprite/sprite-item.ts
@@ -150,7 +150,12 @@ export class SpriteComponent extends BaseRenderComponent {
       ]);
     }
 
-    this.time += dt / 1000;
+    this.time = time + dt / 1000;
+  }
+
+  override onDisable (): void {
+    super.onDisable();
+    this.time = 0;
   }
 
   override onDestroy (): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lifecycle behavior that resets animation timing when the sprite component is disabled.

* **Bug Fixes**
  * Improved logic for handling recorded properties in animation graphs, ensuring correct behavior when stored indices are zero or falsy values.

* **Improvements**
  * Enhanced time management in sprite animations for more accurate updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->