### PR TITLE
fix: compatible player update logic, only emit when playing is true

### DIFF
--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -482,10 +482,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       this.doTick(0, true);
     }
     this.emit('pause');
-    this.emit('update', {
-      player: this,
-      playing: false,
-    });
   }
 
   /**
@@ -617,10 +613,12 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
         .then(t => this.reportGPUTime?.(t ?? 0))
         .catch;
 
-      this.emit('update', {
-        player: this,
-        playing: this.compositions.some(c => !c.getPaused()),
-      });
+      if (this.compositions.some(c => !c.getPaused())) {
+        this.emit('update', {
+          player: this,
+          playing: true,
+        });
+      }
     }
   }
 

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -613,6 +613,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
         .then(t => this.reportGPUTime?.(t ?? 0))
         .catch;
 
+      // TODO: 待移除
       if (this.compositions.some(c => !c.getPaused())) {
         this.emit('update', {
           player: this,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary update notifications when playback is paused or stopped, resulting in fewer irrelevant status updates during media playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->