### PR TITLE
refactor: material textures dispose

### DIFF
--- a/packages/effects-core/src/material/material.ts
+++ b/packages/effects-core/src/material/material.ts
@@ -462,7 +462,6 @@ export abstract class Material extends EffectsObject implements Disposable {
 
   /**
    * 销毁当前 Material
-   * @param destroy - 包含纹理的销毁选项
    */
   abstract override dispose (): void;
 

--- a/packages/effects-core/src/material/material.ts
+++ b/packages/effects-core/src/material/material.ts
@@ -464,7 +464,7 @@ export abstract class Material extends EffectsObject implements Disposable {
    * 销毁当前 Material
    * @param destroy - 包含纹理的销毁选项
    */
-  abstract override dispose (destroy?: MaterialDestroyOptions | DestroyOptions): void;
+  abstract override dispose (): void;
 
   /**
    * 创建 Material

--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -14,7 +14,6 @@ import type { ShapeGenerator, ShapeGeneratorOptions, ShapeParticle } from '../..
 import { createShape } from '../../shape';
 import { Texture } from '../../texture';
 import { Transform } from '../../transform';
-import { DestroyOptions } from '../../utils';
 import type { BoundingBoxSphere, HitTestCustomParams } from '../interact/click-handler';
 import { HitTestType } from '../interact/click-handler';
 import { Burst } from './burst';
@@ -493,7 +492,7 @@ export class ParticleSystem extends Component implements Maskable {
 
   override onDestroy (): void {
     if (this.item && this.item.composition) {
-      this.meshes.forEach(mesh => mesh.dispose({ material: { textures: DestroyOptions.keep } }));
+      this.meshes.forEach(mesh => mesh.dispose());
     }
   }
 

--- a/packages/effects-core/src/render/mesh.ts
+++ b/packages/effects-core/src/render/mesh.ts
@@ -1,6 +1,6 @@
 import { Matrix4 } from '@galacean/effects-math/es/core/index';
 import type { Engine } from '../engine';
-import type { Material, MaterialDestroyOptions } from '../material';
+import type { Material } from '../material';
 import type { Geometry, Renderer } from '../render';
 import type { Disposable } from '../utils';
 import { DestroyOptions } from '../utils';
@@ -19,7 +19,6 @@ export interface GeometryMeshProps extends MeshOptionsBase {
 
 export interface MeshDestroyOptions {
   geometries?: DestroyOptions,
-  material?: MaterialDestroyOptions | DestroyOptions,
 }
 
 let seed = 1;
@@ -121,10 +120,8 @@ export class Mesh extends RendererComponent implements Disposable {
    * @param material - 要设置的材质
    * @param destroy - 可选的材质销毁选项
    */
-  setMaterial (material: Material, destroy?: MaterialDestroyOptions | DestroyOptions.keep) {
-    if (destroy !== DestroyOptions.keep) {
-      this.material.dispose(destroy);
-    }
+  setMaterial (material: Material) {
+    this.material.dispose();
     this.material = material;
   }
 
@@ -144,11 +141,8 @@ export class Mesh extends RendererComponent implements Disposable {
     if (options?.geometries !== DestroyOptions.keep) {
       this.geometry.dispose();
     }
-    const materialDestroyOption = options?.material;
 
-    if (materialDestroyOption !== DestroyOptions.keep) {
-      this.material.dispose(materialDestroyOption);
-    }
+    this.material.dispose();
     this.destroyed = true;
 
     if (this.engine !== undefined) {

--- a/packages/effects-core/src/render/mesh.ts
+++ b/packages/effects-core/src/render/mesh.ts
@@ -1,6 +1,6 @@
 import { Matrix4 } from '@galacean/effects-math/es/core/index';
 import type { Engine } from '../engine';
-import type { Material } from '../material';
+import type { Material, MaterialDestroyOptions } from '../material';
 import type { Geometry, Renderer } from '../render';
 import type { Disposable } from '../utils';
 import { DestroyOptions } from '../utils';
@@ -19,6 +19,7 @@ export interface GeometryMeshProps extends MeshOptionsBase {
 
 export interface MeshDestroyOptions {
   geometries?: DestroyOptions,
+  material?: MaterialDestroyOptions | DestroyOptions,
 }
 
 let seed = 1;
@@ -120,8 +121,10 @@ export class Mesh extends RendererComponent implements Disposable {
    * @param material - 要设置的材质
    * @param destroy - 可选的材质销毁选项
    */
-  setMaterial (material: Material) {
-    this.material.dispose();
+  setMaterial (material: Material, destroy?: MaterialDestroyOptions | DestroyOptions.keep) {
+    if (destroy !== DestroyOptions.keep) {
+      this.material.dispose();
+    }
     this.material = material;
   }
 
@@ -141,8 +144,11 @@ export class Mesh extends RendererComponent implements Disposable {
     if (options?.geometries !== DestroyOptions.keep) {
       this.geometry.dispose();
     }
+    const materialDestroyOption = options?.material;
 
-    this.material.dispose();
+    if (materialDestroyOption !== DestroyOptions.keep) {
+      this.material.dispose();
+    }
     this.destroyed = true;
 
     if (this.engine !== undefined) {

--- a/packages/effects-threejs/src/three-mesh.ts
+++ b/packages/effects-threejs/src/three-mesh.ts
@@ -1,8 +1,8 @@
 import type {
-  Geometry, Material, MaterialDestroyOptions, MeshDestroyOptions, GeometryMeshProps, Sortable,
+  Geometry, Material, MeshDestroyOptions, GeometryMeshProps, Sortable,
   Engine, Renderer,
 } from '@galacean/effects-core';
-import { DestroyOptions, glContext, Mesh } from '@galacean/effects-core';
+import { glContext, Mesh } from '@galacean/effects-core';
 import * as THREE from 'three';
 import type { ThreeMaterial } from './material';
 import type { ThreeGeometry } from './three-geometry';
@@ -101,11 +101,8 @@ export class ThreeMesh extends Mesh implements Sortable {
    * @param mtl - material 对象
    * @param destroy 销毁参数
    */
-  override setMaterial (mtl: Material, destroy?: MaterialDestroyOptions | DestroyOptions.keep): void {
-    // TODO: 这里可以放到抽象类里
-    if (destroy !== DestroyOptions.keep) {
-      this.material.dispose(destroy);
-    }
+  override setMaterial (mtl: Material): void {
+    this.material.dispose();
     this.material = mtl;
     this.mesh.material = (mtl as ThreeMaterial).material;
   }

--- a/packages/effects-webgl/src/gl-material.ts
+++ b/packages/effects-webgl/src/gl-material.ts
@@ -1,9 +1,9 @@
 import type {
-  Engine, GlobalUniforms, MaterialDestroyOptions, MaterialProps,
+  Engine, GlobalUniforms, MaterialProps,
   Renderer, Texture, UndefinedAble,
 } from '@galacean/effects-core';
 import {
-  spec, DestroyOptions, Material, Shader, assertExist, generateGUID, isFunction, logger,
+  spec, Material, Shader, assertExist, generateGUID, isFunction, logger,
   math, throwDestroyedError, glContext,
 } from '@galacean/effects-core';
 import type { GLEngine } from './gl-engine';
@@ -722,21 +722,12 @@ export class GLMaterial extends Material {
     }
   }
 
-  dispose (options?: MaterialDestroyOptions) {
+  dispose () {
     if (this.destroyed) {
       return;
     }
     this.shaderVariant?.dispose();
-    if (options?.textures !== DestroyOptions.keep) {
-      Object.keys(this.textures).forEach(key => {
-        const texture = this.textures[key];
-
-        // TODO 纹理释放需要引用计数
-        if (texture !== this.engine.emptyTexture) {
-          texture.dispose();
-        }
-      });
-    }
+    this.textures = {};
 
     // @ts-expect-error
     this.shaderSource = null;

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -735,12 +735,11 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
   restore = async () => {
     this.renderer.restore();
     this.compositions = await Promise.all(this.compositions.map(async composition => {
-      const { time: currentTime, url, speed, keepResource, reusable, renderOrder, transform, videoState } = composition;
+      const { time: currentTime, url, speed, reusable, renderOrder, transform, videoState } = composition;
       const newComposition = await this.loadScene(url);
 
       newComposition.speed = speed;
       newComposition.reusable = reusable;
-      newComposition.keepResource = keepResource;
       newComposition.renderOrder = renderOrder;
       newComposition.transform.setPosition(transform.position.x, transform.position.y, transform.position.z);
       newComposition.transform.setRotation(transform.rotation.x, transform.rotation.y, transform.rotation.z);

--- a/plugin-packages/editor-gizmo/src/wireframe.ts
+++ b/plugin-packages/editor-gizmo/src/wireframe.ts
@@ -49,7 +49,7 @@ export enum WireframeGeometryType {
 
 export function destroyWireframeMesh (mesh: Mesh) {
   mesh.geometry?.dispose();
-  mesh.dispose({ material: { textures: DestroyOptions.keep }, geometries: DestroyOptions.keep });
+  mesh.dispose({ geometries: DestroyOptions.keep });
 }
 
 export function updateWireframeMesh (originGeometry: Geometry, originMaterial: Material, wireframe: Mesh, type: WireframeGeometryType) {

--- a/plugin-packages/model/src/utility/plugin-helper.ts
+++ b/plugin-packages/model/src/utility/plugin-helper.ts
@@ -350,9 +350,6 @@ export class WebGLHelper {
   static deleteMesh (mesh: Mesh) {
     mesh.dispose({
       geometries: DestroyOptions.destroy,
-      material: {
-        textures: DestroyOptions.destroy,
-      },
     });
   }
 
@@ -372,9 +369,6 @@ export class WebGLHelper {
     pass.dispose({
       meshes: {
         geometries: DestroyOptions.destroy,
-        material: {
-          textures: DestroyOptions.destroy,
-        },
       },
       depthStencilAttachment: RenderPassDestroyAttachmentType.force,
       colorAttachment: RenderPassDestroyAttachmentType.force,

--- a/web-packages/test/unit/src/effects-webgl/gl-dispose.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-dispose.spec.ts
@@ -353,7 +353,7 @@ describe('webgl/dispose', function () {
     const framebuffer = renderPass.framebuffer as GLFramebuffer;
 
     renderPass.dispose({
-      meshes: { geometries: DestroyOptions.destroy },
+      meshes: { geometries: DestroyOptions.destroy, material: DestroyOptions.keep },
       colorAttachment: RenderPassDestroyAttachmentType.keep,
       depthStencilAttachment: RenderPassDestroyAttachmentType.keep,
     });
@@ -402,7 +402,7 @@ describe('webgl/dispose', function () {
     const framebuffer = renderPass.framebuffer as GLFramebuffer;
 
     renderPass.dispose({
-      meshes: { geometries: DestroyOptions.keep },
+      meshes: { geometries: DestroyOptions.keep, material: DestroyOptions.destroy },
       colorAttachment: RenderPassDestroyAttachmentType.keep,
       depthStencilAttachment: RenderPassDestroyAttachmentType.keep,
     });

--- a/web-packages/test/unit/src/effects-webgl/gl-dispose.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-dispose.spec.ts
@@ -353,7 +353,7 @@ describe('webgl/dispose', function () {
     const framebuffer = renderPass.framebuffer as GLFramebuffer;
 
     renderPass.dispose({
-      meshes: { geometries: DestroyOptions.destroy, material: DestroyOptions.keep },
+      meshes: { geometries: DestroyOptions.destroy },
       colorAttachment: RenderPassDestroyAttachmentType.keep,
       depthStencilAttachment: RenderPassDestroyAttachmentType.keep,
     });
@@ -402,7 +402,7 @@ describe('webgl/dispose', function () {
     const framebuffer = renderPass.framebuffer as GLFramebuffer;
 
     renderPass.dispose({
-      meshes: { geometries: DestroyOptions.keep, material: DestroyOptions.destroy },
+      meshes: { geometries: DestroyOptions.keep },
       colorAttachment: RenderPassDestroyAttachmentType.keep,
       depthStencilAttachment: RenderPassDestroyAttachmentType.keep,
     });

--- a/web-packages/test/unit/src/effects-webgl/gl-dispose.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-dispose.spec.ts
@@ -149,7 +149,7 @@ describe('webgl/dispose', function () {
     expect(spy1).has.been.called.once;
     expect(material.isDestroyed).to.be.true;
     expect(material.shaderVariant.program.pipelineContext).to.eql(null);
-    expect(texture.isDestroyed).to.be.true;
+    expect(Object.keys(material.textures).length).to.eql(0);
     expect(geom.isDestroyed).to.be.false;
 
   });

--- a/web-packages/test/unit/src/effects-webgl/gl-material.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-material.spec.ts
@@ -365,11 +365,8 @@ describe('webgl/gl-material', () => {
     expect(material.getTexture('u_Tex')).to.deep.equal(texture);
     material.initialize();
     expect(material).not.eql(undefined);
-    material.dispose({
-      textures: DestroyOptions.destroy,
-    });
+    material.dispose();
     expect(material.isDestroyed).to.be.true;
-    expect(texture.isDestroyed).to.be.true;
     expect(() => material.initialize()).to.throw(Error);
   });
 
@@ -384,7 +381,6 @@ describe('webgl/gl-material', () => {
     expect(material).not.eql(undefined);
     material.dispose();
     expect(material.isDestroyed).to.be.true;
-    expect(texture.isDestroyed).to.be.true;
     expect(material.getTexture('u_Tex')).to.equal(undefined);
     expect(() => material.initialize()).to.throw(Error);
   });
@@ -398,9 +394,7 @@ describe('webgl/gl-material', () => {
     material.initialize();
     expect(material.getTexture('u_Tex')).to.deep.equal(texture);
     expect(material).not.eql(undefined);
-    material.dispose({
-      textures: DestroyOptions.keep,
-    });
+    material.dispose();
     expect(material.isDestroyed).to.be.true;
     expect(texture.isDestroyed).to.be.false;
     expect(() => material.initialize()).to.throw(Error);
@@ -414,9 +408,7 @@ describe('webgl/gl-material', () => {
     material.setTexture('u_Tex', texture);
     material.initialize();
     expect(material).not.eql(undefined);
-    material.dispose({
-      textures: DestroyOptions.keep,
-    });
+    material.dispose();
     expect(material.isDestroyed).to.be.true;
     expect(texture.isDestroyed).to.be.false;
     expect(material.getTexture('u_Tex')).to.equal(undefined);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified resource disposal by always disposing textures and clearing texture lists, removing conditional logic for preserving texture resources.
  * Updated method signatures to remove options related to texture disposal.
  * Cleaned up unused imports and streamlined internal logic for material and composition disposal.
  * Modified disposal calls across components to no longer preserve material textures, ensuring consistent cleanup.
  * Removed disposal of material textures in mesh and render pass deletion utilities.

* **Tests**
  * Updated test cases to reflect the new disposal behavior, removing checks for texture destruction state and focusing on the clearing of texture references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->