### PR TITLE
refactor: renderer draw geometry matrix setting

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -414,7 +414,6 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
     for (let i = 0; i < this.materials.length; i++) {
       const material = this.materials[i];
 
-      material.setMatrix('effects_ObjectToWorld', this.transform.getWorldMatrix());
       material.setVector2('_Size', this.transform.size);
 
       if (this.renderer.renderMode === spec.RenderMode.BILLBOARD ||
@@ -424,7 +423,7 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
         material.setVector3('_Scale', this.transform.scale);
       }
 
-      renderer.drawGeometry(this.geometry, material, i);
+      renderer.drawGeometry(this.geometry, this.transform.getWorldMatrix(), material, i);
     }
   }
 

--- a/packages/effects-core/src/components/mesh-component.ts
+++ b/packages/effects-core/src/components/mesh-component.ts
@@ -23,8 +23,7 @@ export class MeshComponent extends RendererComponent {
     for (let i = 0;i < this.materials.length;i++) {
       const material = this.materials[i];
 
-      material.setMatrix('effects_ObjectToWorld', this.transform.getWorldMatrix());
-      renderer.drawGeometry(this.geometry, material, i);
+      renderer.drawGeometry(this.geometry, this.transform.getWorldMatrix(), material, i);
     }
   }
 

--- a/packages/effects-core/src/components/shape-component.ts
+++ b/packages/effects-core/src/components/shape-component.ts
@@ -429,9 +429,7 @@ void main() {
     for (let i = 0; i < this.materials.length; i++) {
       const material = this.materials[i];
 
-      material.setMatrix('effects_ObjectToWorld', this.transform.getWorldMatrix());
-
-      renderer.drawGeometry(this.geometry, material, i);
+      renderer.drawGeometry(this.geometry, this.transform.getWorldMatrix(), material, i);
     }
   }
 

--- a/packages/effects-core/src/material/material.ts
+++ b/packages/effects-core/src/material/material.ts
@@ -2,7 +2,7 @@ import type { Matrix3, Matrix4, Quaternion, Vector2, Vector3, Vector4, Color } f
 import type { GlobalUniforms, Renderer, Shader, ShaderVariant, ShaderWithSource } from '../render';
 import type { Texture } from '../texture';
 import type { DestroyOptions, Disposable } from '../utils';
-import type { UniformSemantic, UniformValue } from './types';
+import type { UniformValue } from './types';
 import type { Engine } from '../engine';
 import { EffectsObject } from '../effects-object';
 
@@ -39,10 +39,6 @@ export interface MaterialProps {
    */
   name?: string,
   /**
-   * 传递的变换矩阵
-   */
-  uniformSemantics?: Record<string, UniformSemantic>,
-  /**
    * 渲染类型
    */
   renderType?: MaterialRenderType,
@@ -67,7 +63,6 @@ export abstract class Material extends EffectsObject implements Disposable {
   // TODO: 待移除
   shaderSource: ShaderWithSource;
   stringTags: Record<string, string> = {};
-  readonly uniformSemantics: Record<string, UniformSemantic>;
   readonly enabledMacros: Record<string, number | boolean> = {};
   readonly renderType: MaterialRenderType;
   readonly name: string;
@@ -94,14 +89,12 @@ export abstract class Material extends EffectsObject implements Disposable {
         name = 'Material' + seed++,
         renderType = MaterialRenderType.normal,
         shader,
-        uniformSemantics,
       } = props;
 
       this.name = name;
       this.renderType = renderType; // TODO 没有地方用到
       this.shaderSource = shader;
       this.props = props;
-      this.uniformSemantics = { ...uniformSemantics }; // TODO 废弃，待移除
     } else {
       this.name = 'Material' + seed++;
       this.renderType = MaterialRenderType.normal;

--- a/packages/effects-core/src/plugins/interact/interact-mesh.ts
+++ b/packages/effects-core/src/plugins/interact/interact-mesh.ts
@@ -22,9 +22,6 @@ uniform mat4 effects_ObjectToWorld;
 uniform mat4 effects_MatrixInvV;
 uniform mat4 effects_MatrixVP;
 varying vec4 vColor;
-#ifdef ENV_EDITOR
-  uniform vec4 uEditorTransform;
-#endif
 
 vec3 rotateByQuat(vec3 a, vec4 quat){
   vec3 qvec = quat.xyz;
@@ -41,9 +38,6 @@ void main() {
   pos.xyz += effects_MatrixInvV[0].xyz * point.x+ effects_MatrixInvV[1].xyz * point.y;
   gl_Position = effects_MatrixVP * pos;
   vColor = uColor;
-  #ifdef ENV_EDITOR
-    gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w, gl_Position.zw);
-  #endif
 }
 `;
 const fragment = `
@@ -111,12 +105,6 @@ export class InteractMesh {
         glslVersion: GLSLVersion.GLSL1,
         cacheId: `${rendererOptions.cachePrefix}_effects_interact`,
         macros,
-      },
-      uniformSemantics: {
-        effects_MatrixVP: 'VIEWPROJECTION',
-        effects_MatrixInvV: 'VIEWINVERSE',
-        effects_ObjectToWorld: 'MODEL',
-        uEditorTransform: 'EDITOR_TRANSFORM',
       },
     };
 

--- a/packages/effects-core/src/plugins/particle/particle-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/particle-mesh.ts
@@ -316,12 +316,6 @@ export class ParticleMesh implements ParticleMeshData {
     };
     const mtlOptions: MaterialProps = {
       shader,
-      uniformSemantics: {
-        effects_MatrixV: 'VIEW',
-        effects_MatrixVP: 'VIEWPROJECTION',
-        uEditorTransform: 'EDITOR_TRANSFORM',
-        effects_ObjectToWorld: 'MODEL',
-      },
     };
     const preMulAlpha = getPreMultiAlpha(blending);
 

--- a/packages/effects-core/src/plugins/particle/trail-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/trail-mesh.ts
@@ -144,12 +144,6 @@ export class TrailMesh {
         name: `trail#${name}`,
         cacheId: `-t:+${shaderCacheId}+${keyFrameMeta.index}+${keyFrameMeta.max}`,
       },
-      uniformSemantics: {
-        effects_MatrixVP: 'VIEWPROJECTION',
-        effects_MatrixInvV: 'VIEWINVERSE',
-        effects_ObjectToWorld: 'MODEL',
-        uEditorTransform: 'EDITOR_TRANSFORM',
-      },
     });
 
     const maxVertexCount = pointCountPerTrail * maxTrailCount * 2;

--- a/packages/effects-core/src/render/mesh.ts
+++ b/packages/effects-core/src/render/mesh.ts
@@ -103,8 +103,7 @@ export class Mesh extends RendererComponent implements Disposable {
     if (!this.getVisible()) {
       return;
     }
-    this.material.setMatrix('effects_ObjectToWorld', this.worldMatrix);
-    renderer.drawGeometry(this.geometry, this.material);
+    renderer.drawGeometry(this.geometry, this.worldMatrix, this.material);
   }
 
   /**

--- a/packages/effects-core/src/render/renderer.ts
+++ b/packages/effects-core/src/render/renderer.ts
@@ -131,7 +131,7 @@ export class Renderer implements LostHandler, RestoreHandler {
     // OVERRIDE
   }
 
-  drawGeometry (geometry: Geometry, material: Material, subMeshIndex = 0) {
+  drawGeometry (geometry: Geometry, matrix: Matrix4, material: Material, subMeshIndex = 0) {
     // OVERRIDE
   }
 

--- a/packages/effects-core/src/shader/item.vert.glsl
+++ b/packages/effects-core/src/shader/item.vert.glsl
@@ -17,10 +17,6 @@ uniform mat4 effects_MatrixVP;
 uniform mat4 effects_ObjectToWorld;
 uniform mat4 effects_MatrixV;
 
-#ifdef ENV_EDITOR
-uniform vec4 uEditorTransform;
-#endif
-
 void main() {
   vec4 texParams = _TexParams;
 
@@ -44,8 +40,4 @@ void main() {
     vec3 vertexPosition = worldPosition + camRight * aPos.x * _Size.x * _Scale.x + camUp * aPos.y * _Size.y * _Scale.y;
     gl_Position = effects_MatrixVP * vec4(vertexPosition, 1.0);
   }
-
-#ifdef ENV_EDITOR
-  gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w, gl_Position.zw);
-#endif
 }

--- a/packages/effects-core/src/shader/particle.vert.glsl
+++ b/packages/effects-core/src/shader/particle.vert.glsl
@@ -84,10 +84,6 @@ varying float vLife;
 varying vec4 vColor;
 varying vec2 vTexCoord;
 
-#ifdef ENV_EDITOR
-uniform vec4 uEditorTransform; //sx sy dx dy
-#endif
-
 vec3 calOrbitalMov(float _life, float _dur) {
   vec3 orb = vec3(0.0);
     #ifdef AS_ORBITAL_MOVEMENT
@@ -273,10 +269,5 @@ void main() {
     vSeed = aSeed;
 
     gl_PointSize = 6.0;
-
-        #ifdef ENV_EDITOR
-    gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w, gl_Position.zw);
-        #endif
-
   }
 }

--- a/packages/effects-core/src/shader/trail.vert.glsl
+++ b/packages/effects-core/src/shader/trail.vert.glsl
@@ -37,10 +37,6 @@ varying float vLife;
 varying vec2 vTexCoord;
 varying vec4 vColor;
 
-#ifdef ENV_EDITOR
-uniform vec4 uEditorTransform;
-#endif
-
 void main() {
   vec4 _pa = effects_MatrixVP * vec4(aPos.xyz, 1.);
   vec4 _pb = effects_MatrixVP * vec4(aPos.xyz + aDir, 1.);
@@ -80,8 +76,4 @@ void main() {
   vLife = time;
   vTexCoord = uTextureMap.xy + vec2(trail, aInfo.z) * uTextureMap.zw;
   vSeed = aSeed;
-
-    #ifdef ENV_EDITOR
-  gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w, gl_Position.zw);
-    #endif
 }

--- a/packages/effects-threejs/src/material/three-material.ts
+++ b/packages/effects-threejs/src/material/three-material.ts
@@ -57,7 +57,6 @@ export class ThreeMaterial extends Material {
     };
 
     this.uniforms['_MainTex'] = new THREE.Uniform(null);
-    this.uniforms['uEditorTransform'] = new THREE.Uniform([1, 1, 0, 0]);
     this.uniforms['effects_ObjectToWorld'] = new THREE.Uniform(new THREE.Matrix4().identity());
     this.uniforms['effects_MatrixInvV'] = new THREE.Uniform([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 8, 1]);
     this.uniforms['effects_MatrixVP'] = new THREE.Uniform([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, -8, 1]);

--- a/packages/effects-webgl/src/gl-material.ts
+++ b/packages/effects-webgl/src/gl-material.ts
@@ -731,8 +731,6 @@ export class GLMaterial extends Material {
 
     // @ts-expect-error
     this.shaderSource = null;
-    // @ts-expect-error
-    this.uniformSemantics = {};
     this.floats = {};
     this.ints = {};
     this.vector2s = {};

--- a/packages/effects-webgl/src/gl-renderer.ts
+++ b/packages/effects-webgl/src/gl-renderer.ts
@@ -1,12 +1,11 @@
 import type {
   Disposable, Framebuffer, GLType, Geometry, LostHandler, Material, RenderFrame, RenderPass,
   RenderPassClearAction, RenderPassStoreAction, RendererComponent, RestoreHandler,
-  ShaderLibrary,
-  math } from '@galacean/effects-core';
+  ShaderLibrary, math,
+} from '@galacean/effects-core';
 import {
   FilterMode, GPUCapability, RenderPassAttachmentStorageType, RenderTextureFormat,
-  Renderer, TextureLoadAction, TextureSourceType, assertExist, glContext,
-  sortByOrder,
+  Renderer, TextureLoadAction, TextureSourceType, assertExist, glContext, sortByOrder,
 } from '@galacean/effects-core';
 import { ExtWrap } from './ext-wrap';
 import { GLContextManager } from './gl-context-manager';

--- a/plugin-packages/editor-gizmo/src/mesh.ts
+++ b/plugin-packages/editor-gizmo/src/mesh.ts
@@ -687,12 +687,6 @@ function createMaterial (engine: Engine, color?: vec3, depthTest?: boolean): Mat
         u_color: new Float32Array(myColor.toArray()),
         u_model: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
       },
-      uniformSemantics: {
-        u_viewinverse: 'VIEWINVERSE',
-        u_v: 'VIEW',
-        u_p: 'PROJECTION',
-        u_et: 'EDITOR_TRANSFORM',
-      },
       shader: {
         fragment: `
         precision mediump float;
@@ -710,11 +704,9 @@ function createMaterial (engine: Engine, color?: vec3, depthTest?: boolean): Mat
         uniform mat4 u_model;
         uniform mat4 effects_MatrixV;
         uniform mat4 _MatrixP;
-        uniform vec4 uEditorTransform;
 
         void main(){
           gl_Position = _MatrixP * effects_MatrixV * u_model * vec4(a_Position,1.0);
-          gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w,gl_Position.zw);
         }`,
         shared: true,
       },
@@ -750,12 +742,6 @@ function createHideBackMaterial (engine: Engine, color?: vec3, depthTest?: boole
         u_cameraPos: new Float32Array([0, 0, 0]),
         u_center: new Float32Array([0, 0, 0]),
       },
-      uniformSemantics: {
-        u_viewinverse: 'VIEWINVERSE',
-        u_v: 'VIEW',
-        u_p: 'PROJECTION',
-        u_et: 'EDITOR_TRANSFORM',
-      },
       shader: {
         fragment: `
         precision mediump float;
@@ -779,7 +765,6 @@ function createHideBackMaterial (engine: Engine, color?: vec3, depthTest?: boole
         uniform mat4 u_model;
         uniform mat4 effects_MatrixV;
         uniform mat4 _MatrixP;
-        uniform vec4 uEditorTransform;
 
         uniform vec3 u_cameraPos;
         uniform vec3 u_center;
@@ -790,7 +775,6 @@ function createHideBackMaterial (engine: Engine, color?: vec3, depthTest?: boole
           vec3 worldPosition = (u_model * vec4(a_Position,1.0)).xyz;
           flag = length(u_cameraPos - worldPosition) - distance;
           gl_Position = _MatrixP * effects_MatrixV * u_model * vec4(a_Position,1.0);
-          gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w,gl_Position.zw);
         }`,
         shared: true,
       },
@@ -830,12 +814,6 @@ function createBlendMaterial (engine: Engine, color?: vec3, depthTest?: boolean,
         u_alpha: new Float32Array([myAlpha, 0]),
         u_model: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
       },
-      uniformSemantics: {
-        u_viewinverse: 'VIEWINVERSE',
-        u_v: 'VIEW',
-        u_p: 'PROJECTION',
-        u_et: 'EDITOR_TRANSFORM',
-      },
       shader: {
         shared: true,
         fragment: `
@@ -855,10 +833,8 @@ function createBlendMaterial (engine: Engine, color?: vec3, depthTest?: boolean,
         uniform mat4 u_model;
         uniform mat4 effects_MatrixV;
         uniform mat4 _MatrixP;
-        uniform vec4 uEditorTransform;
         void main(){
           gl_Position = _MatrixP * effects_MatrixV * u_model * vec4(a_Position,1.0);
-          gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w,gl_Position.zw);
         }`,
       },
     });
@@ -887,12 +863,6 @@ function createSpriteMaterial (engine: Engine, data?: vec3 | Texture, depthTest?
     engine,
     {
       uniformValues,
-      uniformSemantics: {
-        u_viewinverse: 'VIEWINVERSE',
-        u_v: 'VIEW',
-        u_p: 'PROJECTION',
-        u_et: 'EDITOR_TRANSFORM',
-      },
       shader: {
         shared: true,
         fragment: `
@@ -922,7 +892,6 @@ function createSpriteMaterial (engine: Engine, data?: vec3 | Texture, depthTest?
         uniform mat4 effects_MatrixV;
         uniform mat4 _MatrixP;
         uniform mat4 effects_MatrixInvV;
-        uniform vec4 uEditorTransform;
         varying vec2 v_uv;
 
         void main(){
@@ -932,7 +901,6 @@ function createSpriteMaterial (engine: Engine, data?: vec3 | Texture, depthTest?
 
           pos.xyz += effects_MatrixInvV[0].xyz * a_Position.x + effects_MatrixInvV[1].xyz * a_Position.y;
           gl_Position = _MatrixP * effects_MatrixV * pos;
-          gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w,gl_Position.zw);
         }`,
       },
     });

--- a/plugin-packages/editor-gizmo/src/shape.ts
+++ b/plugin-packages/editor-gizmo/src/shape.ts
@@ -297,10 +297,6 @@ function createMesh (engine: Engine, points: Float32Array, indices: Uint16Array,
         u_color: new Float32Array(color),
         u_model: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
       },
-      uniformSemantics: {
-        u_vp: 'VIEWPROJECTION',
-        u_et: 'EDITOR_TRANSFORM',
-      },
       shader: {
         shared: true,
         fragment: `
@@ -317,10 +313,8 @@ function createMesh (engine: Engine, points: Float32Array, indices: Uint16Array,
 
     uniform mat4 u_model;
     uniform mat4 effects_MatrixVP;
-    uniform vec4 uEditorTransform;
     void main(){
       gl_Position = effects_MatrixVP * u_model * vec4(a_Position,1.0);
-      gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w,gl_Position.zw);
     }`,
       },
     });

--- a/plugin-packages/model/src/runtime/mesh.ts
+++ b/plugin-packages/model/src/runtime/mesh.ts
@@ -181,6 +181,7 @@ export class PMesh extends PEntity {
     this.subMeshes.forEach((subMesh, index) => {
       renderer.drawGeometry(
         subMesh.getEffectsGeometry(),
+        this.matrix,
         subMesh.getEffectsMaterial(),
         index
       );
@@ -189,7 +190,7 @@ export class PMesh extends PEntity {
     if (this.visBoundingBox && this.boundingBoxMesh !== undefined) {
       const mesh = this.boundingBoxMesh.mesh;
 
-      renderer.drawGeometry(mesh.geometry, mesh.material);
+      renderer.drawGeometry(mesh.geometry, Matrix4.IDENTITY, mesh.material);
     }
   }
 
@@ -806,7 +807,6 @@ export class PSubMesh {
   private updateUniformsByAnimation (worldMatrix: Matrix4, normalMatrix: Matrix4) {
     const material = this.getEffectsMaterial();
 
-    material.setMatrix('effects_ObjectToWorld', worldMatrix);
     material.setMatrix('_NormalMatrix', normalMatrix);
     //
     const skin = this.skin;

--- a/plugin-packages/model/src/runtime/shader-libs/standard/primitive.vert.glsl
+++ b/plugin-packages/model/src/runtime/shader-libs/standard/primitive.vert.glsl
@@ -51,10 +51,6 @@ uniform mat4 effects_MatrixVP;
 uniform mat4 effects_ObjectToWorld;
 uniform mat4 _NormalMatrix;
 
-#ifdef EDITOR_TRANSFORM
-uniform vec4 uEditorTransform;
-#endif
-
 #ifdef USE_SHADOW_MAPPING
 uniform mat4 _LightViewProjectionMatrix;
 uniform float _DeltaSceneSize;
@@ -149,8 +145,4 @@ void main()
     #endif
 
     gl_Position = effects_MatrixVP * pos;
-
-    #ifdef EDITOR_TRANSFORM
-        gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w, gl_Position.zw);
-    #endif
 }

--- a/plugin-packages/model/src/runtime/skybox.ts
+++ b/plugin-packages/model/src/runtime/skybox.ts
@@ -6,7 +6,7 @@ import { PEntity } from './object';
 import { PMaterialBase } from './material';
 import type { PSceneManager } from './scene';
 import { WebGLHelper } from '../utility/plugin-helper';
-import { Vector2, Vector3 } from './math';
+import { Matrix4, Vector2, Vector3 } from './math';
 import type { ModelSkyboxComponent } from '../plugin/model-item';
 
 /**
@@ -150,7 +150,7 @@ export class PSkybox extends PEntity {
     if (this.visible && this.renderable && this.skyboxMesh !== undefined) {
       const mesh = this.skyboxMesh;
 
-      renderer.drawGeometry(mesh.geometry, mesh.material);
+      renderer.drawGeometry(mesh.geometry, Matrix4.IDENTITY, mesh.material);
     }
   }
 

--- a/plugin-packages/spine/src/shader/vertex.glsl
+++ b/plugin-packages/spine/src/shader/vertex.glsl
@@ -5,10 +5,6 @@ attribute vec2 aTexCoords;
 uniform mat4 effects_ObjectToWorld;
 uniform mat4 effects_MatrixVP;
 
-#ifdef ENV_EDITOR
-uniform vec4 uEditorTransform; //sx sy dx dy
-#endif
-
 varying vec4 vLight;
 varying vec4 vDark;
 varying vec2 vTexCoords;
@@ -18,8 +14,4 @@ void main() {
   vDark = aColor2;
   vTexCoords = aTexCoords;
   gl_Position = effects_MatrixVP * effects_ObjectToWorld * vec4(aPosition, 0.0, 1.0);
-
-    #ifdef ENV_EDITOR
-  gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w, gl_Position.zw);
-    #endif
 }

--- a/plugin-packages/spine/src/spine-mesh.ts
+++ b/plugin-packages/spine/src/spine-mesh.ts
@@ -1,9 +1,9 @@
 import type { BlendMode } from '@esotericsoftware/spine-core';
 import type {
   Attribute, Disposable, Engine, ShaderMacros, SharedShaderWithSource, Texture,
-} from '@galacean/effects';
+  math } from '@galacean/effects';
 import {
-  GLSLVersion, Geometry, Material, Mesh, PLAYER_OPTIONS_ENV_EDITOR, glContext, math, setMaskMode,
+  GLSLVersion, Geometry, Material, Mesh, PLAYER_OPTIONS_ENV_EDITOR, glContext, setMaskMode,
 } from '@galacean/effects';
 import fs from './shader/fragment.glsl';
 import vs from './shader/vertex.glsl';
@@ -98,14 +98,9 @@ export class SpineMesh implements Disposable {
       this.engine,
       {
         shader: createShader(this.engine),
-        uniformSemantics: {
-          effects_MatrixVP: 'VIEWPROJECTION',
-          uEditorTransform: 'EDITOR_TRANSFORM',
-        },
       });
 
     material.setTexture('uTexture', this.lastTexture);
-    material.setMatrix('effects_ObjectToWorld', math.Matrix4.fromIdentity());
     material.blending = true;
     material.culling = false;
     material.depthTest = false;
@@ -148,7 +143,6 @@ export class SpineMesh implements Disposable {
     this.geometry.setAttributeData('aPosition', this.vertices);
     this.geometry.setIndexData(this.indices);
     this.geometry.setDrawCount(this.indicesLength);
-    this.material.setMatrix('effects_ObjectToWorld', worldMatrix);
   }
 
   startUpdate () {

--- a/plugin-packages/spine/src/spine-mesh.ts
+++ b/plugin-packages/spine/src/spine-mesh.ts
@@ -1,7 +1,7 @@
 import type { BlendMode } from '@esotericsoftware/spine-core';
 import type {
-  Attribute, Disposable, Engine, ShaderMacros, SharedShaderWithSource, Texture,
-  math } from '@galacean/effects';
+  Attribute, Disposable, Engine, ShaderMacros, SharedShaderWithSource, Texture, math,
+} from '@galacean/effects';
 import {
   GLSLVersion, Geometry, Material, Mesh, PLAYER_OPTIONS_ENV_EDITOR, glContext, setMaskMode,
 } from '@galacean/effects';

--- a/web-packages/imgui-demo/src/ge.ts
+++ b/web-packages/imgui-demo/src/ge.ts
@@ -1,7 +1,7 @@
 import type { MaterialProps, Renderer } from '@galacean/effects';
 import { GLSLVersion, Geometry, Material, OrderType, Player, RenderPass, RenderPassPriorityPostprocess, VFXItem, glContext, math } from '@galacean/effects';
 import '@galacean/effects-plugin-model';
-import { JSONConverter } from '@galacean/effects-plugin-model';
+import { JSONConverter, Matrix4 } from '@galacean/effects-plugin-model';
 import '@galacean/effects-plugin-orientation-transformer';
 import '@galacean/effects-plugin-spine';
 import { Selection } from './core/selection';
@@ -161,7 +161,7 @@ export class OutlinePass extends RenderPass {
 
       this.geometry.setDrawCount(4);
       this.geometry.setAttributeData('aPos', new Float32Array(point1.toArray().concat(point2.toArray(), point3.toArray(), point4.toArray())));
-      renderer.drawGeometry(this.geometry, this.material);
+      renderer.drawGeometry(this.geometry, Matrix4.IDENTITY, this.material);
     }
   }
 }

--- a/web-packages/test/unit/src/effects-core/plugins/particle/particle.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/particle/particle.spec.ts
@@ -39,15 +39,6 @@ describe('core/plugins/particle/test', function () {
     // expect(pMesh.priority).to.eql(1, 'particle');
     // expect(tMesh.priority).to.eql(1, 'trail');
     expect(content.renderer.particleMesh.maxCount).to.eql(18);
-    expect(pMesh.material.uniformSemantics).to.include({
-      effects_MatrixV: 'VIEW',
-      effects_MatrixVP: 'VIEWPROJECTION',
-    }, 'particle');
-    expect(tMesh?.material.uniformSemantics).to.includes({
-      effects_ObjectToWorld: 'MODEL',
-      effects_MatrixInvV: 'VIEWINVERSE',
-      effects_MatrixVP: 'VIEWPROJECTION',
-    }, 'trail');
     const tex = content.getTextures();
 
     expect(tex).to.be.an('array').with.lengthOf(2);

--- a/web-packages/test/unit/src/effects-webgl/gl-render-frame.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-render-frame.spec.ts
@@ -22,19 +22,6 @@ describe('webgl/gl-render-frame', () => {
     canvas = null;
   });
 
-  // it('create copy mesh', () => {
-  //   const frame = new RenderFrame({ renderer, camera: new Camera() });
-  //   const mesh = frame.createCopyMesh();
-
-  //   // mesh.initialize(renderer.glRenderer);
-  //   expect(mesh.material.uniformSemantics['uFilterSource']).to.eql(SEMANTIC_MAIN_PRE_COLOR_ATTACHMENT_0);
-  //   expect(mesh.material.uniformSemantics['uFilterSourceSize']).to.eql(SEMANTIC_MAIN_PRE_COLOR_ATTACHMENT_SIZE_0);
-
-  //   // TODO: 补充
-  //   frame.renderer.pipelineContext.shaderLibrary.compileShader(m.material.shaderCacheId);
-  //   expect(frame.renderer.pipelineContext.shaderLibrary.shaderResults[m.material.shaderCacheId].status).to.eql(1);//success
-  // });
-
   it('add default render Pass with info', () => {
     const frame = new RenderFrame({ renderer, camera: new Camera('') });
     const meshes = generateMeshes(renderer, 3);


### PR DESCRIPTION
- remove unused material uniform semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rendering methods to pass transformation matrices directly to rendering calls instead of setting them on materials.
  * Removed uniform semantic mappings and related uniforms from materials and shaders.
  * Simplified shader and material setup by eliminating editor-specific transformation logic.

* **Bug Fixes**
  * Improved consistency in how transformation matrices are handled during rendering across components and plugins.

* **Tests**
  * Updated and removed tests related to uniform semantics to reflect the new rendering approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->