### PR TITLE
fix: model wireframe use wrong world matrix

### DIFF
--- a/plugin-packages/editor-gizmo/src/gizmo-component.ts
+++ b/plugin-packages/editor-gizmo/src/gizmo-component.ts
@@ -127,10 +127,12 @@ export class GizmoComponent extends RendererComponent {
     if (this.subType === GizmoSubType.modelWireframe) { // 模型线框
       if (this.wireframeMesh && this.targetItem) {
         //@ts-expect-error TODO 和 3D 类型解耦
-        const meshes = this.targetItem.getComponent(RendererComponent)?.content.subMeshes;
+        const pMesh = this.targetItem.getComponent(RendererComponent)?.content;
+        const meshes = pMesh.subMeshes;
         const wireframeMeshes = this.wireframeMeshes;
 
         if (meshes?.length > 0) {
+          wireframeMeshes[0].worldMatrix.copyFrom(pMesh.matrix);
           updateWireframeMesh(meshes[0].geometry.geometry, meshes[0].material.effectMaterial, wireframeMeshes[0], WireframeGeometryType.triangle);
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wireframe rendering in the editor gizmo. The wireframe now reliably aligns with the target model’s position, rotation, and scale, eliminating occasional offsets or misalignment.
  * Ensures smoother, more accurate visualization when moving, rotating, or scaling models in wireframe mode. No changes to user-facing settings or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->