### PR TITLE
fix: rendering scale was incorrect after setting the scale of spine

### DIFF
--- a/plugin-packages/spine/src/shader/vertex.glsl
+++ b/plugin-packages/spine/src/shader/vertex.glsl
@@ -2,8 +2,10 @@ attribute vec2 aPosition;
 attribute vec4 aColor;
 attribute vec4 aColor2;
 attribute vec2 aTexCoords;
+
 uniform mat4 effects_ObjectToWorld;
 uniform mat4 effects_MatrixVP;
+uniform vec2 _Size;
 
 #ifdef ENV_EDITOR
 uniform vec4 uEditorTransform; //sx sy dx dy
@@ -17,7 +19,7 @@ void main() {
   vLight = aColor;
   vDark = aColor2;
   vTexCoords = aTexCoords;
-  gl_Position = effects_MatrixVP * effects_ObjectToWorld * vec4(aPosition, 0.0, 1.0);
+  gl_Position = effects_MatrixVP * effects_ObjectToWorld * vec4(aPosition * _Size, 0.0, 1.0);
 
     #ifdef ENV_EDITOR
   gl_Position = vec4(gl_Position.xy * uEditorTransform.xy + uEditorTransform.zw * gl_Position.w, gl_Position.zw);

--- a/plugin-packages/spine/src/spine-component.ts
+++ b/plugin-packages/spine/src/spine-component.ts
@@ -192,8 +192,18 @@ export class SpineComponent extends RendererComponent implements Maskable {
   }
 
   override render (renderer: Renderer) {
+    if (!this.content) {
+      return;
+    }
+
+    for (let i = 0; i < this.content.meshGroups.length; i++) {
+      const material = this.content.meshGroups[i].mesh.material;
+
+      material.setVector2('_Size', new Vector2(this.startSize * this.scaleFactor, this.startSize * this.scaleFactor));
+    }
+
     this.maskManager.drawStencilMask(renderer);
-    this.content?.render(renderer);
+    this.content.render(renderer);
   }
 
   drawStencilMask (renderer: Renderer): void {
@@ -557,7 +567,6 @@ export class SpineComponent extends RendererComponent implements Maskable {
       return;
     }
     const { width } = res;
-    const scale = this.transform.scale;
     let scaleFactor;
 
     if (this.resizeRule) {
@@ -574,7 +583,6 @@ export class SpineComponent extends RendererComponent implements Maskable {
       scaleFactor = 1 / width;
     }
     this.scaleFactor = scaleFactor;
-    this.transform.setScale(this.startSize * scaleFactor, this.startSize * scaleFactor, scale.z);
   }
 
   // 转换当前大小为旧缩放规则下的大小


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented render errors by safely handling missing content.
  * Ensured consistent visual scaling by adjusting mesh material size per render.
  * Improved resize behavior by decoupling visual scaling from the transform, reducing unexpected scale artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->