### PR TITLE
docs: changelog 2.6.2

### DIFF
--- a/CHANGELOG-zh_CN.md
+++ b/CHANGELOG-zh_CN.md
@@ -8,6 +8,13 @@
 
 ---
 
+## 2.6.2
+
+`2025-08-15`
+
+- Fix: 3d editor mode demo. [#1112](https://github.com/galacean/effects-runtime/pull/1112) @wumaolinmaoan
+- Fix: rendering scale was incorrect after setting the scale of spine. [#1132](https://github.com/galacean/effects-runtime/pull/1132) @wumaolinmaoan
+
 ## 2.6.1
 
 `2025-08-12`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2.6.2
+
+`2025-08-15`
+
+- Fix: 3d editor mode demo. [#1112](https://github.com/galacean/effects-runtime/pull/1112) @wumaolinmaoan
+- Fix: rendering scale was incorrect after setting the scale of spine. [#1132](https://github.com/galacean/effects-runtime/pull/1132) @wumaolinmaoan
+
 ## 2.6.1
 
 `2025-08-12`

--- a/packages/effects-core/package.json
+++ b/packages/effects-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-core",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects runtime core for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/packages/effects-helper/package.json
+++ b/packages/effects-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-helper",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects runtime helper for the web",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/effects-threejs/package.json
+++ b/packages/effects-threejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-threejs",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects runtime threejs plugin for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/packages/effects-webgl/package.json
+++ b/packages/effects-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-webgl",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects runtime webgl for the web",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects runtime player for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/alipay-downgrade/package.json
+++ b/plugin-packages/alipay-downgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-alipay-downgrade",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player downgrade plugin for Alipay",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/downgrade/package.json
+++ b/plugin-packages/downgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-downgrade",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player downgrade plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/editor-gizmo/package.json
+++ b/plugin-packages/editor-gizmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-editor-gizmo",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player editor gizmo plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/model/package.json
+++ b/plugin-packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-model",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player model plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/multimedia/package.json
+++ b/plugin-packages/multimedia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-multimedia",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player multimedia plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/orientation-transformer/package.json
+++ b/plugin-packages/orientation-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-orientation-transformer",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player orientation transformer plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/rich-text/package.json
+++ b/plugin-packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-rich-text",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player rich text plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/spine/package.json
+++ b/plugin-packages/spine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-spine",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects player spine plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/stats/package.json
+++ b/plugin-packages/stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-stats",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Galacean Effects runtime stats for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added changelog entry for version 2.6.2 (2025-08-15) noting:
    - Fix: 3D editor mode demo
    - Fix: Incorrect rendering scale after adjusting Spine scale
- Chores
  - Bumped versions to 2.6.2 across core packages and plugins (effects, helper, threejs, webgl, editor gizmo, model, multimedia, orientation transformer, rich text, spine, stats, downgrade variants)
- Notes
  - No code changes or public API updates included in this release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->