### PR TITLE
refactor: move old shape logic to migration

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -13,7 +13,7 @@ import { MeshCollider } from '../plugins';
 import type { Renderer } from '../render';
 import { Geometry } from '../render';
 import { itemFrag, itemVert } from '../shader';
-import { getGeometryByShape, rotateVec2, type GeometryFromShape } from '../shape';
+import { rotateVec2 } from '../shape';
 import { Texture } from '../texture';
 import { RendererComponent } from './renderer-component';
 
@@ -23,7 +23,6 @@ import { RendererComponent } from './renderer-component';
 export interface ItemRenderer extends Required<Omit<spec.RendererOptions, 'texture' | 'shape' | 'anchor' | 'particleOrigin' | 'mask'>> {
   texture: Texture,
   mask: number,
-  shape?: GeometryFromShape,
 }
 
 // TODO: Add to spec
@@ -264,27 +263,6 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
     const sx = 1, sy = 1;
     const geometry = this.defaultGeometry;
 
-    if (renderer.shape) {
-      const { index = [], aPoint = [] } = renderer.shape;
-      const point = new Float32Array(aPoint);
-      const position = [];
-
-      const aUV = [];
-
-      for (let i = 0; i < point.length; i += 6) {
-        point[i] *= sx;
-        point[i + 1] *= sy;
-        aUV.push(aPoint[i + 2], aPoint[i + 3]);
-        position.push(point[i], point[i + 1], 0.0);
-      }
-      geometry.setAttributeData('aPos', new Float32Array(position));
-
-      return {
-        index: index as number[],
-        aUV,
-      };
-    }
-
     const originData = [-.5, .5, -.5, -.5, .5, .5, .5, -.5];
     const aUV = [];
     const index = [];
@@ -441,17 +419,6 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
       this.maskManager.setMaskOptions(maskOptions);
     }
 
-    // TODO 新蒙板上线后移除
-    //-------------------------------------------------------------------------
-    const shapeData = renderer.shape as spec.ShapeGeometry;
-    const split = splits && !textureSheetAnimation ? splits[0] : undefined;
-    let shapeGeometry: GeometryFromShape | undefined = undefined;
-
-    if (shapeData !== undefined && shapeData !== null && !('aPoint' in shapeData && 'index' in shapeData)) {
-      shapeGeometry = getGeometryByShape(shapeData, split);
-    }
-    //-------------------------------------------------------------------------
-
     this.splits = splits || singleSplits;
     this.textureSheetAnimation = textureSheetAnimation;
 
@@ -463,7 +430,6 @@ export class BaseRenderComponent extends RendererComponent implements Maskable {
       transparentOcclusion: !!renderer.transparentOcclusion || (this.maskManager.maskMode === MaskMode.MASK),
       side: renderer.side ?? spec.SideMode.DOUBLE,
       mask: this.maskManager.getRefValue(),
-      shape: shapeGeometry,
     };
 
     this.configureMaterial(this.renderer);

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -249,7 +249,6 @@ export function version34Migration (json: JSONScene): JSONScene {
 /**
  * @description 根据形状获取形状几何体数据
  * @param shape 形状
- * @param resourceIndex 资源索引
  * @returns 形状几何体数据
  */
 function createGeometryDataByShape (shape: spec.ShapeGeometry, geometryDataName = '形状') {

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -109,6 +109,7 @@ export function version31Migration (json: JSONScene): JSONScene {
 export function version32Migration (json: JSONScene): JSONScene {
   componentMap.clear();
   itemMap.clear();
+
   const { compositions, items, components } = json;
   // 处理旧蒙版数据
 
@@ -171,11 +172,11 @@ export function version33Migration (json: JSONScene): JSONScene {
 
     const compositionComponent = {
       id: generateGUID(),
-      dataType:'CompositionComponent',
+      dataType: 'CompositionComponent',
       items: composition.items,
       timelineAsset: composition.timelineAsset,
       sceneBindings: composition.sceneBindings,
-      item:{ id:composition.id },
+      item: { id: composition.id },
     } as unknown as spec.ComponentData;
 
     //@ts-expect-error
@@ -183,7 +184,7 @@ export function version33Migration (json: JSONScene): JSONScene {
     //@ts-expect-error
     composition.sceneBindings = undefined;
     //@ts-expect-error
-    composition.components = [{ id:compositionComponent.id }];
+    composition.components = [{ id: compositionComponent.id }];
     json.components.push(compositionComponent);
   }
   // 预合成元素 refId 同步改为生成的合成 guid
@@ -224,17 +225,14 @@ export function version34Migration (json: JSONScene): JSONScene {
   for (const componentData of json.components) {
     if (componentData.dataType === spec.DataType.SpriteComponent) {
       const spriteComponentData = componentData as spec.SpriteComponentData;
-
       const renderer = spriteComponentData.renderer;
-
       const shapeData = renderer.shape as spec.ShapeGeometry;
 
       if (shapeData !== undefined && shapeData !== null && !('aPoint' in shapeData && 'index' in shapeData)) {
-
         const geometryData = createGeometryDataByShape(shapeData);
 
         //@ts-expect-error
-        spriteComponentData.geometry = { id:geometryData.id };
+        spriteComponentData.geometry = { id: geometryData.id };
         json.geometries.push(geometryData);
       }
     }
@@ -247,17 +245,15 @@ export function version34Migration (json: JSONScene): JSONScene {
 }
 
 /**
- * @description 根据形状获取形状几何体数据
- * @param shape 形状
+ * 根据形状获取形状几何体数据
+ * @param shape - 形状
  * @returns 形状几何体数据
  */
 function createGeometryDataByShape (shape: spec.ShapeGeometry, geometryDataName = '形状') {
   const targetGeometry = getGeometryByShape(shape);
   const { index = [], aPoint = [] } = targetGeometry;
-
   const point = new Float32Array(aPoint);
   const position = [];
-
   const atlasOffset = [];
 
   for (let i = 0; i < point.length; i += 6) {
@@ -271,7 +267,6 @@ function createGeometryDataByShape (shape: spec.ShapeGeometry, geometryDataName 
     indexCount: number,
     vertexCount: number,
   }[] = [];
-
   const vertexCount = position.length / 3;
   const indexCount = index.length;
   const positionByteLength = position.length * 4;

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -10,6 +10,7 @@ import {
 import { MaskMode } from '../material';
 import { generateGUID } from '../utils';
 import { convertAnchor, ensureFixedNumber, ensureFixedVec3 } from './utils';
+import { getGeometryByShape } from '../shape/geometry';
 
 /**
  * 2.1 以下版本数据适配（mars-player@2.4.0 及以上版本支持 2.1 以下数据的适配）
@@ -219,10 +220,117 @@ export function version34Migration (json: JSONScene): JSONScene {
     }
   }
 
+  // 兼容老 Shape 资源
+  for (const componentData of json.components) {
+    if (componentData.dataType === spec.DataType.SpriteComponent) {
+      const spriteComponentData = componentData as spec.SpriteComponentData;
+
+      const renderer = spriteComponentData.renderer;
+
+      const shapeData = renderer.shape as spec.ShapeGeometry;
+
+      if (shapeData !== undefined && shapeData !== null && !('aPoint' in shapeData && 'index' in shapeData)) {
+
+        const geometryData = createGeometryDataByShape(shapeData);
+
+        //@ts-expect-error
+        spriteComponentData.geometry = { id:geometryData.id };
+        json.geometries.push(geometryData);
+      }
+    }
+  }
+
   //@ts-expect-error
   json.version = '3.5';
 
   return json;
+}
+
+/**
+ * @description 根据形状获取形状几何体数据
+ * @param shape 形状
+ * @param resourceIndex 资源索引
+ * @returns 形状几何体数据
+ */
+function createGeometryDataByShape (shape: spec.ShapeGeometry, geometryDataName = '形状') {
+  const targetGeometry = getGeometryByShape(shape);
+  const { index = [], aPoint = [] } = targetGeometry;
+
+  const point = new Float32Array(aPoint);
+  const position = [];
+
+  const atlasOffset = [];
+
+  for (let i = 0; i < point.length; i += 6) {
+    atlasOffset.push(aPoint[i + 2], aPoint[i + 3]);
+    position.push(point[i], point[i + 1], 0.0);
+  }
+
+  // 用 position altasOffset index 创建GeometryData
+  const subMeshes: {
+    offset: number,
+    indexCount: number,
+    vertexCount: number,
+  }[] = [];
+
+  const vertexCount = position.length / 3;
+  const indexCount = index.length;
+  const positionByteLength = position.length * 4;
+  const uvByteLength = atlasOffset.length * 4;
+  const vertexByteLength = positionByteLength + uvByteLength;
+  const indexByteLength = index.length * 2;
+
+  const geometryData: spec.GeometryData = {
+    mode: spec.GeometryType.TRIANGLES,
+    vertexData: {
+      vertexCount,
+      channels: [],
+    },
+    name: geometryDataName,
+    indexFormat: spec.IndexFormatType.UInt16,
+    indexOffset: vertexByteLength,
+    buffer: '',
+    id: generateGUID(),
+    dataType: spec.DataType.Geometry,
+    subMeshes,
+  };
+
+  geometryData.vertexData.channels.push({
+    semantic: spec.VertexBufferSemantic.Position,
+    offset: 0,
+    format: spec.VertexFormatType.Float32,
+    dimension: 3,
+  });
+
+  geometryData.vertexData.channels.push({
+    semantic: spec.VertexBufferSemantic.Uv,
+    offset: positionByteLength,
+    format: spec.VertexFormatType.Float32,
+    dimension: 2,
+  });
+
+  geometryData.subMeshes.push({
+    offset: 0,
+    indexCount,
+    vertexCount,
+  });
+
+  const supByteLength = indexByteLength % 4 === 0 ? 0 : 2;
+  const infoBuffer = new ArrayBuffer(vertexByteLength + indexByteLength + supByteLength);
+  const vertexArray = new Float32Array(infoBuffer);
+
+  vertexArray.set(position, 0);
+  vertexArray.set(atlasOffset, position.length);
+
+  const indexArray = new Uint16Array(infoBuffer, vertexByteLength);
+
+  indexArray.set(index, 0);
+
+  const uint8View = new Uint8Array(infoBuffer).slice(0, vertexByteLength + indexByteLength);
+
+  geometryData.binaryData = uint8View;
+
+  return geometryData;
 }
 
 export function processContent (composition: spec.CompositionData) {

--- a/packages/effects-core/src/plugins/text/text-layout.ts
+++ b/packages/effects-core/src/plugins/text/text-layout.ts
@@ -24,6 +24,8 @@ export class TextLayout {
   lineHeight: number;
 
   constructor (options: spec.TextContentOptions) {
+    // TODO: Update lineGap spec
+    // @ts-expect-error
     const { textHeight = 100, textWidth = 100, textOverflow = spec.TextOverflow.clip, textBaseline = spec.TextBaseline.top, textAlign = spec.TextAlignment.left, text = ' ', letterSpace = 0, lineGap = 0.571, autoWidth = false, fontSize, lineHeight = fontSize } = options;
 
     const tempWidth = fontSize + letterSpace;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed direct shape-based geometry support from the renderer; rendering now uses the standard geometry pipeline.
- Chores
  - Added automatic migration to convert legacy shape-based sprite data into geometry resources during project upgrade to preserve visuals.
- Style
  - Minor annotation added in text layout constructor; no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->