### PR TITLE
fix: outline fontOffset bug

### DIFF
--- a/packages/effects-core/src/plugins/text/text-style.ts
+++ b/packages/effects-core/src/plugins/text/text-style.ts
@@ -89,7 +89,9 @@ export class TextStyle {
       this.isOutlined = true;
       this.outlineColor = outline.outlineColor ?? [1, 1, 1, 1];
       this.outlineWidth = outline.outlineWidth ?? 1;
-      this.fontOffset += this.outlineWidth;
+      //this.fontOffset += this.outlineWidth;
+      //预期效果不需要因为描边而修改文字计算的宽度
+      //当描边宽度扩大，最后效果是描边重叠
     }
 
     if (shadow) {


### PR DESCRIPTION
修复描边错误的offset逻辑，文字宽度计算不需要对描边宽度部分进行增加，预期的是描边宽度变宽会重叠

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text outlines no longer artificially expand text width or glyph spacing. Alignment, wrapping, and positioning remain consistent regardless of outline thickness.
  * Prevents unexpected layout shifts or clipping when outlines are enabled, improving predictability of text layouts while preserving the intended visual outline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->