### PR TITLE
fix: add video assets dispose logic

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -251,6 +251,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   private paused = false;
   private isEndCalled = false;
   private _textures: Texture[] = [];
+  private videos: HTMLVideoElement[] = [];
 
   /**
    * 合成中消息元素创建/销毁时触发的回调
@@ -305,6 +306,15 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
 
     this.renderer = renderer;
     this._textures = scene.textures;
+
+    for (const key of Object.keys(scene.assets)) {
+      const videoAsset = scene.assets[key];
+
+      if (videoAsset instanceof HTMLVideoElement) {
+        this.videos.push(videoAsset);
+      }
+    }
+
     this.postProcessingEnabled = scene.jsonScene.renderSettings?.postProcessingEnabled ?? false;
     this.getEngine().renderLevel = scene.renderLevel;
 
@@ -905,6 +915,14 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
         // textures.forEach(tex => tex && tex.dispose());
       }
     }
+
+    for (const video of this.videos) {
+      video.pause();
+      video.removeAttribute('src');
+      video.load();
+    }
+    this.videos = [];
+
     this.rootItem.dispose();
     // FIXME: 注意这里增加了renderFrame销毁
     this.renderFrame.dispose();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures video assets are properly paused and released when a composition is disposed, preventing lingering playback and potential memory leaks.

* **Performance**
  * Improves resource cleanup for video assets during disposal, reducing memory footprint and CPU usage over time.

* **Chores**
  * Internal improvements to asset lifecycle management within compositions without changing any public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->