### PR TITLE
fix: opt composition restart timimg to prevent item flash

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -717,7 +717,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
 
     let isEnded = false;
 
-    if (localTime - duration > 0.001) {
+    if (localTime >= duration) {
 
       isEnded = true;
 

--- a/web-packages/test/unit/src/effects-core/plugins/sprite/sprite-base.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/sprite/sprite-base.spec.ts
@@ -113,8 +113,8 @@ describe('core/plugins/sprite/item-base', () => {
     expect(texOffset0?.[2]).to.be.closeTo(0.1249, 0.001);
     expect(texOffset0?.[3]).to.be.closeTo(0.1249, 0.001);
 
-    expect(texOffset2?.[0]).to.be.closeTo(0.25, 0.001);
-    expect(texOffset2?.[1]).to.be.closeTo(0, 0.001);
+    expect(texOffset2?.[0]).to.be.closeTo(0, 0.001);
+    expect(texOffset2?.[1]).to.be.closeTo(0.875, 0.001);
     expect(texOffset2?.[2]).to.be.closeTo(0.1248, 0.001);
     expect(texOffset2?.[3]).to.be.closeTo(0.1249, 0.001);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Composition playback now ends exactly at its duration, ensuring end-of-timeline events and end behaviors trigger reliably at the boundary.
  - Corrected sprite texture offset for frame 1 to prevent visual misalignment, improving sprite animation accuracy.

- Tests
  - Updated unit tests to reflect the precise composition end timing and corrected sprite texture offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->