### PR TITLE
perf: optimize bezier performance of function getTForX

### DIFF
--- a/packages/effects-core/src/math/bezier.ts
+++ b/packages/effects-core/src/math/bezier.ts
@@ -325,6 +325,9 @@ export class BezierEasing {
   }
 
   private getTForX (aX: number) {
+    if (decimalEqual(this.control1.x, 1 / 3, 0.0001) && decimalEqual(this.control2.x, 2 / 3, 0.0001)) {
+      return aX;
+    }
     const mSampleValues = this.mSampleValues, lastSample = kSplineTableSize - 1;
     let intervalStart = 0, currentSample = 1;
 


### PR DESCRIPTION
When control1.x equals 1/3 and control2.x equals 2/3, x equals t

@wumaolinmaoan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the standard easing path used in animations to reduce computation, improving performance in common cases.
  * No changes to behavior or configuration are expected; animations should feel as smooth as before with reduced overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->