### PR TITLE
fix: mute audio when calling goto

### DIFF
--- a/plugin-packages/multimedia/src/audio/audio-component.ts
+++ b/plugin-packages/multimedia/src/audio/audio-component.ts
@@ -2,9 +2,6 @@ import type { Asset } from '@galacean/effects';
 import { effectsClass, RendererComponent, spec } from '@galacean/effects';
 import { AudioPlayer } from './audio-player';
 
-/**
- * Audio component class
- */
 @effectsClass(spec.DataType.AudioComponent)
 export class AudioComponent extends RendererComponent {
   audioPlayer: AudioPlayer;
@@ -13,18 +10,21 @@ export class AudioComponent extends RendererComponent {
     super.onAwake();
 
     this.item.composition?.on('play', (option: { time: number }) => {
-      if (this.item.time <= 0) { return; }
+      this.audioPlayer.setMuted(false);
+      if (this.item.time <= 0) {return;}
       this.audioPlayer.setCurrentTime(this.item.time);
       this.audioPlayer.play();
       this.isPlaying = true;
     });
 
     this.item.composition?.on('pause', () => {
+      this.audioPlayer.setMuted(true);
       this.audioPlayer.pause();
       this.isPlaying = false;
     });
 
     this.item.composition?.on('goto', (option: { time: number }) => {
+      this.audioPlayer.setMuted(true);
       this.audioPlayer.setCurrentTime(this.item.time);
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio now automatically unmutes on play, ensuring playback starts as expected even after previous mutes.
  * Audio auto-mutes on pause and while seeking to avoid unintended sounds and clicks.
  * Improved reliability of starting from the correct position when resuming playback.
  * More consistent and predictable audio state across play, pause, and seek controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->