### PR TITLE
refactor: remove player unused create and destroy event

### DIFF
--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -6,7 +6,7 @@ import type {
 import {
   AssetManager, Composition, EVENT_TYPE_CLICK, EventSystem, logger, Renderer, EventEmitter,
   TextureLoadAction, Ticker, canvasPool, getPixelRatio, gpuTimer, initErrors, isIOS,
-  isArray, pluginLoaderMap, setSpriteMeshMaxItemCountByGPU, spec, PLAYER_OPTIONS_ENV_EDITOR,
+  isArray, setSpriteMeshMaxItemCountByGPU, spec, PLAYER_OPTIONS_ENV_EDITOR,
   assertExist, AssetService,
 } from '@galacean/effects-core';
 import type { GLRenderer } from '@galacean/effects-webgl';
@@ -162,7 +162,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       playerMap.set(this.canvas, this);
 
       assertNoConcurrentPlayers();
-      broadcastPlayerEvent(this, true);
     } catch (e: any) {
       if (this.canvas && !this.useExternalCanvas) {
         this.canvas.remove();
@@ -732,7 +731,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
     this.compositions.forEach(comp => comp.lost(e));
     this.renderer.lost(e);
     this.handleEmitEvent('webglcontextlost', e);
-    broadcastPlayerEvent(this, false);
   };
 
   /**
@@ -808,7 +806,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
     }
     this.event?.dispose();
     this.assetService?.dispose();
-    broadcastPlayerEvent(this, false);
     if (
       this.canvas instanceof HTMLCanvasElement &&
       !keepCanvas &&
@@ -967,20 +964,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
  */
 export function disableAllPlayer (disable: boolean) {
   enableDebugType = !!disable;
-}
-
-/**
- * 播放器在实例化、销毁（`dispose`）时分别触发插件的 `onPlayerCreated`、`onPlayerDestroy` 回调
- * @param player - 播放器
- * @param isCreate - 是否处于实例化时
- */
-function broadcastPlayerEvent (player: Player, isCreate: boolean) {
-  Object.keys(pluginLoaderMap).forEach(key => {
-    const ctrl = pluginLoaderMap[key];
-    const func = isCreate ? ctrl.onPlayerCreated : ctrl.onPlayerDestroy;
-
-    func?.(player);
-  });
 }
 
 /**

--- a/plugin-packages/editor-gizmo/src/gizmo-loader.ts
+++ b/plugin-packages/editor-gizmo/src/gizmo-loader.ts
@@ -29,12 +29,10 @@ export class EditorGizmoPlugin extends AbstractPlugin {
     return true;
   }
 
-  static onPlayerDestroy (): void {
-    iconTextures.clear();
-  }
-
   override onCompositionConstructed (composition: Composition, scene: Scene) {
     const engine = composition.renderer.engine;
+
+    iconTextures.clear();
 
     iconImages.forEach((image, name) => {
       iconTextures.set(name, createTexture(engine, image));


### PR DESCRIPTION
 unused create and destroy event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevents stale or duplicated editor gizmo icons when switching compositions by clearing textures before reload.
  - Improves memory stability during composition changes.

- Refactor
  - Simplified player–plugin lifecycle handling for more predictable behavior.
  - Removed editor-specific option handling and redundant lifecycle event broadcasts, reducing initialization overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->