### PR TITLE
fix: unused assetManager is not released

### DIFF
--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -336,12 +336,13 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       this.autoPlaying = true;
     }
 
-    const autoplayFlags: boolean[] = [];
-
     for (const assetManager of this.assetManagers) {
       assetManager.dispose();
     }
+
     this.assetManagers = [];
+    const autoplayFlags: boolean[] = [];
+
     await Promise.all(
       scenes.map(async (url, index) => {
         const { source, options: opts } = this.assetService.assembleSceneLoadOptions(url, { autoplay, ...options });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed leftover assets persisting across multi-scene loads, preventing incorrect content, memory bloat, and degraded performance.
  * Asset managers are now cleared at the start of scene loads to stop accumulation between loads.
  * Users should see smoother scene transitions, more consistent resource usage, and fewer slowdowns or crashes after repeatedly loading different scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->