### PR TITLE
refactor: white and transparent texture usage

### DIFF
--- a/packages/effects-core/src/asset-service.ts
+++ b/packages/effects-core/src/asset-service.ts
@@ -4,7 +4,6 @@ import type { Engine } from './engine';
 import type { ImageLike, SceneLoadOptions } from './scene';
 import { Scene } from './scene';
 import type { Texture } from './texture';
-import { generateWhiteTexture } from './texture';
 import type { EffectsObject } from './effects-object';
 import { Asset } from './asset';
 import { Material } from './material';
@@ -22,7 +21,7 @@ export class AssetService implements Disposable {
   constructor (
     private readonly engine: Engine,
   ) {
-    this.builtinObjects.push(generateWhiteTexture(engine));
+    this.builtinObjects.push(engine.whiteTexture);
   }
 
   /**

--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -59,7 +59,7 @@ export class MaskableGraphic extends RendererComponent implements Maskable {
     this.renderer = {
       renderMode: spec.RenderMode.MESH,
       blending: spec.BlendingMode.ALPHA,
-      texture: this.engine.emptyTexture,
+      texture: this.engine.whiteTexture,
       occlusion: false,
       transparentOcclusion: false,
       side: spec.SideMode.DOUBLE,
@@ -312,7 +312,7 @@ export class MaskableGraphic extends RendererComponent implements Maskable {
     this.renderer = {
       renderMode: renderer.renderMode ?? spec.RenderMode.MESH,
       blending: renderer.blending ?? spec.BlendingMode.ALPHA,
-      texture: renderer.texture ? this.engine.findObject<Texture>(renderer.texture) : this.engine.emptyTexture,
+      texture: renderer.texture ? this.engine.findObject<Texture>(renderer.texture) : this.engine.whiteTexture,
       occlusion: !!renderer.occlusion,
       transparentOcclusion: !!renderer.transparentOcclusion || (this.maskManager.maskMode === MaskMode.MASK),
       side: renderer.side ?? spec.SideMode.DOUBLE,

--- a/packages/effects-core/src/components/shape-component.ts
+++ b/packages/effects-core/src/components/shape-component.ts
@@ -217,7 +217,7 @@ export class ShapeComponent extends RendererComponent implements Maskable {
     this.rendererOptions = {
       renderMode: spec.RenderMode.MESH,
       blending: spec.BlendingMode.ALPHA,
-      texture: this.engine.emptyTexture,
+      texture: this.engine.whiteTexture,
       occlusion: false,
       transparentOcclusion: false,
       side: spec.SideMode.DOUBLE,
@@ -675,7 +675,7 @@ export class ShapeComponent extends RendererComponent implements Maskable {
     this.rendererOptions = {
       renderMode: renderer.renderMode ?? spec.RenderMode.MESH,
       blending: renderer.blending ?? spec.BlendingMode.ALPHA,
-      texture: renderer.texture ? this.engine.findObject<Texture>(renderer.texture) : this.engine.emptyTexture,
+      texture: renderer.texture ? this.engine.findObject<Texture>(renderer.texture) : this.engine.whiteTexture,
       occlusion: !!renderer.occlusion,
       transparentOcclusion: !!renderer.transparentOcclusion || (this.maskManager.maskMode === MaskMode.MASK),
       side: renderer.side ?? spec.SideMode.DOUBLE,

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -7,7 +7,7 @@ import { PLAYER_OPTIONS_ENV_EDITOR } from './constants';
 import { setRayFromCamera } from './math';
 import type { PluginSystem } from './plugin-system';
 import type { EventSystem, Plugin, Region } from './plugins';
-import type { MeshRendererOptions, Renderer } from './render';
+import type { Renderer } from './render';
 import { RenderFrame } from './render';
 import type { Scene } from './scene';
 import type { Texture } from './texture';
@@ -228,8 +228,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
    * 是否开启后处理
    */
   postProcessingEnabled = false;
-
-  protected rendererOptions: MeshRendererOptions | null;
   /**
    * 销毁状态位
    */
@@ -373,7 +371,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
     this.interactive = true;
     this.handleItemMessage = handleItemMessage;
     this.createRenderFrame();
-    this.rendererOptions = null;
 
     Composition.buildItemTree(this.rootItem);
     this.rootComposition.setChildrenRenderOrder(0);
@@ -614,7 +611,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
    * 重置状态函数
    */
   protected reset () {
-    this.rendererOptions = null;
     this.isEnded = false;
     this.isEndCalled = false;
     this.rootComposition.time = 0;
@@ -918,7 +914,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
     this.rootItem.dispose();
     // FIXME: 注意这里增加了renderFrame销毁
     this.renderFrame.dispose();
-    this.rendererOptions?.emptyTexture.dispose();
     this.pluginSystem?.destroyComposition(this);
     this.update = () => {
       if (!__DEBUG__) {
@@ -1029,17 +1024,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
       this.textures.forEach(tex => tex && tex.offloadData());
       this.textureOffloaded = true;
     }
-  }
-
-  getRendererOptions (): MeshRendererOptions {
-    if (!this.rendererOptions) {
-      this.rendererOptions = {
-        emptyTexture: this.renderFrame.emptyTexture,
-        cachePrefix: '-',
-      };
-    }
-
-    return this.rendererOptions;
   }
 
   /**

--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -24,7 +24,7 @@ export class Engine implements Disposable {
    * 渲染等级
    */
   renderLevel?: SceneRenderLevel;
-  emptyTexture: Texture;
+  whiteTexture: Texture;
   transparentTexture: Texture;
   /**
    * GPU 能力
@@ -55,7 +55,7 @@ export class Engine implements Disposable {
     this.jsonSceneData = {};
     this.objectInstance = {};
     this.assetLoader = new AssetLoader(this);
-    this.emptyTexture = generateWhiteTexture(this);
+    this.whiteTexture = generateWhiteTexture(this);
     this.transparentTexture = generateTransparentTexture(this);
   }
 

--- a/packages/effects-core/src/plugins/interact/interact-item.ts
+++ b/packages/effects-core/src/plugins/interact/interact-item.ts
@@ -117,17 +117,12 @@ export class InteractComponent extends RendererComponent {
 
   override onStart (): void {
     const { env } = this.item.engine.renderer;
-    const composition = this.item.composition;
     const { type, showPreview } = this.interactData.options as spec.ClickInteractOption;
 
     if (type === spec.InteractType.CLICK) {
       this.clickable = true;
       if (showPreview && env === PLAYER_OPTIONS_ENV_EDITOR) {
-        const rendererOptions = composition?.getRendererOptions();
-
-        if (rendererOptions !== undefined) {
-          this.previewContent = new InteractMesh((this.item.props as spec.InteractItem).content, rendererOptions, this.transform, this.engine);
-        }
+        this.previewContent = new InteractMesh((this.item.props as spec.InteractItem).content, this.transform, this.engine);
       }
     }
     if (this.previewContent) {

--- a/packages/effects-core/src/plugins/interact/interact-mesh.ts
+++ b/packages/effects-core/src/plugins/interact/interact-mesh.ts
@@ -6,7 +6,7 @@ import { glContext } from '../../gl';
 import type { MaterialProps } from '../../material';
 import { Material } from '../../material';
 import { createValueGetter } from '../../math';
-import type { MeshRendererOptions, ShaderMacros } from '../../render';
+import type { ShaderMacros } from '../../render';
 import { GLSLVersion, Geometry, Mesh } from '../../render';
 import type { Transform } from '../../transform';
 
@@ -59,12 +59,11 @@ export class InteractMesh {
 
   constructor (
     props: spec.InteractContent,
-    rendererOptions: MeshRendererOptions,
     private readonly transform: Transform,
     private readonly engine: Engine,
   ) {
     this.color = (props.options as spec.ClickInteractOption).previewColor;
-    const material = this.createMaterial(rendererOptions);
+    const material = this.createMaterial();
     const geometry = this.createGeometry();
 
     this.mesh = this.createMesh(geometry, material);
@@ -93,7 +92,7 @@ export class InteractMesh {
     material.setQuaternion('uQuat', tempQuat);
   }
 
-  private createMaterial (rendererOptions: MeshRendererOptions): Material {
+  private createMaterial (): Material {
     const macros: ShaderMacros = [
       ['ENV_EDITOR', this.engine.renderer?.env === PLAYER_OPTIONS_ENV_EDITOR],
     ];
@@ -103,7 +102,6 @@ export class InteractMesh {
         vertex,
         fragment,
         glslVersion: GLSLVersion.GLSL1,
-        cacheId: `${rendererOptions.cachePrefix}_effects_interact`,
         macros,
       },
     };

--- a/packages/effects-core/src/render/index.ts
+++ b/packages/effects-core/src/render/index.ts
@@ -5,7 +5,6 @@ export * from './render-pass';
 export * from './shader';
 export * from './gpu-capability';
 export * from './mesh';
-export * from './types';
 export * from './geometry';
 export * from './framebuffer';
 export * from './renderer';

--- a/packages/effects-core/src/render/render-frame.ts
+++ b/packages/effects-core/src/render/render-frame.ts
@@ -10,7 +10,7 @@ import { PassTextureCache } from '../paas-texture-cache';
 import type { SemanticFunc } from './semantic-map';
 import { SemanticMap } from './semantic-map';
 import {
-  Texture, TextureLoadAction, TextureSourceType, generateWhiteTexture, generateTransparentTexture,
+  Texture, TextureLoadAction, TextureSourceType,
 } from '../texture';
 import type { Disposable } from '../utils';
 import { DestroyOptions, OrderType, removeItem } from '../utils';
@@ -209,14 +209,6 @@ export class RenderFrame implements Disposable {
    */
   readonly semantics: SemanticMap;
   readonly globalUniforms: GlobalUniforms;
-  /**
-   * 空纹理，大小1x1，白色
-   */
-  readonly emptyTexture: Texture;
-  /**
-   * 空纹理，大小1x1，透明
-   */
-  readonly transparentTexture: Texture;
 
   protected destroyed = false;
   protected renderPassInfoMap: WeakMap<RenderPass, RenderPassInfo> = new WeakMap();
@@ -367,8 +359,6 @@ export class RenderFrame implements Disposable {
 
     const firstRP = renderPasses[0];
 
-    this.emptyTexture = generateWhiteTexture(engine);
-    this.transparentTexture = generateTransparentTexture(engine);
     this.camera = camera;
     this.keepColorBuffer = keepColorBuffer;
     this.renderPassInfoMap.set(firstRP, { listStart: 0, listEnd: 0, renderPass: firstRP, intermedia: false });
@@ -430,8 +420,6 @@ export class RenderFrame implements Disposable {
     }
     this.passTextureCache.dispose();
     this._renderPasses.length = 0;
-    this.emptyTexture.dispose();
-    this.transparentTexture.dispose();
     if (this.resource) {
       this.resource.color_a.dispose();
       this.resource.color_b.dispose();

--- a/packages/effects-core/src/render/types.ts
+++ b/packages/effects-core/src/render/types.ts
@@ -1,6 +1,0 @@
-import type { Texture } from '../texture';
-
-export interface MeshRendererOptions {
-  emptyTexture: Texture,
-  cachePrefix: string,
-}

--- a/packages/effects-threejs/src/three-composition.ts
+++ b/packages/effects-threejs/src/three-composition.ts
@@ -1,9 +1,8 @@
 import type {
-  Scene, ShaderLibrary, Transform, MeshRendererOptions, EventSystem, CompositionProps,
+  Scene, ShaderLibrary, Transform, EventSystem, CompositionProps,
 } from '@galacean/effects-core';
 import { Composition, CompositionComponent, RendererComponent } from '@galacean/effects-core';
 import type THREE from 'three';
-import { ThreeTexture } from './three-texture';
 
 /**
  * 基础 composition 参数
@@ -89,30 +88,5 @@ export class ThreeComposition extends Composition {
         }
       }
     }
-  }
-
-  /**
-   * 获取 render 参数
-   *
-   * @returns
-   */
-  override getRendererOptions (): MeshRendererOptions {
-    const emptyTexture = ThreeTexture.createWithData(
-      this.renderer.engine,
-      {
-        data: new Uint8Array(4).fill(255),
-        width: 1,
-        height: 1,
-      });
-
-    (emptyTexture as ThreeTexture).texture.needsUpdate = true;
-    if (!this.rendererOptions) {
-      this.rendererOptions = {
-        emptyTexture,
-        cachePrefix: '-',
-      };
-    }
-
-    return this.rendererOptions;
   }
 }

--- a/packages/effects-webgl/src/gl-renderer.ts
+++ b/packages/effects-webgl/src/gl-renderer.ts
@@ -87,8 +87,6 @@ export class GLRenderer extends Renderer implements Disposable {
     if (frame.resource) {
       frame.resource.color_b.initialize();
     }
-    frame.emptyTexture.initialize();
-    frame.transparentTexture.initialize();
 
     const passes = frame._renderPasses;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized default/fallback texture to a white texture for graphics and shapes, improving visual consistency.
  * Renamed Engine property from emptyTexture to whiteTexture.
  * Removed MeshRendererOptions and related APIs, including getRendererOptions; simplified InteractMesh constructor.
  * RenderFrame no longer exposes built-in empty/transparent textures.
  * Stopped re-exporting render type definitions.

* **Chores**
  * Cleaned up preview/renderer-options paths and removed unused frame texture initialization for leaner runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->