### PR TITLE
fix: 修复计算行数未初始化 canvas 字符描述导致字体上移问题

### DIFF
--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -156,10 +156,10 @@ export class TextComponentBase {
     let lineCount = 1;
     let x = 0;
 
-    //设置context.font的字号
-    // if (context) {
-    //   context.font = this.getFontDesc(this.textStyle.fontSize);
-    // }
+    // 设置context.font的字号，确保measureText能正确计算字宽
+    if (context) {
+      context.font = this.getFontDesc(this.textStyle.fontSize);
+    }
     for (let i = 0; i < text.length; i++) {
       const str = text[i];
       const textMetrics = (context?.measureText(str)?.width ?? 0) * fontScale;


### PR DESCRIPTION
修复行数计算时没有初始化canvas字号导致字符宽度计算错误从而导致行数计算错误

```
import { Player, TextComponent } from '@galacean/effects';

const json = 'https://g.alicdn.com/ani-assets/5bcd4da9b51e051c3422bdbcee7fa4ff/0.0.1/mars.json';
const container = document.getElementById('J-container');

(async () => {
  try {
    const player = new Player({
      container,
    });

    const compostion = await player.loadScene(json, {
      variables: {
        text_1: 'Galacean Effects'.toLocaleUpperCase().split('').reverse().join(''),
      },
    });
    const textItem = compostion.getItemByName('text_1');
    const textComponent = textItem?.getComponent(TextComponent);

    textComponent?.setTextColor([255, 0, 0, 1]);

    let lotteryTimes = 999;

    textComponent?.setText(`${lotteryTimes}`); // 设置初始值

    const timer = setInterval(() => {
      lotteryTimes += 1;
      textComponent?.setText(`${lotteryTimes}`);
    }, 1000); // 每秒增加1
  } catch (e) {
    console.error('biz', e);
  }
})();
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text measurement calculations to properly account for font size settings, ensuring accurate width computations and line break positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->