### PR TITLE
feat: auto fontScale

### DIFF
--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -439,7 +439,7 @@ export class TextComponentBase {
     const layout = this.textLayout;
     const fontScale = style.fontScale;
 
-    const pixelRatio = this.getPixelRatio(style.autoFontScale);
+    const pixelRatio = style.getPixelRatio();
 
     const width = (layout.width + style.fontOffset) * fontScale;
     const finalHeight = layout.lineHeight * this.lineCount;
@@ -622,22 +622,6 @@ export class TextComponentBase {
       context.shadowOffsetX = shadowOffsetX;
       context.shadowOffsetY = -shadowOffsetY;
     }
-  }
-
-  private getPixelRatio (autoFontScale: boolean): number {
-    const g = typeof window !== 'undefined'
-      ? window
-      : typeof self !== 'undefined'
-        ? self
-        : globalThis as any;
-
-    const dpr = g && typeof g.devicePixelRatio === 'number' ? g.devicePixelRatio : undefined;
-
-    if (!autoFontScale) {
-      return 1;
-    }
-
-    return (typeof dpr === 'number' && isFinite(dpr) && dpr > 0) ? dpr : 1;
   }
 
 }

--- a/packages/effects-core/src/plugins/text/text-style.ts
+++ b/packages/effects-core/src/plugins/text/text-style.ts
@@ -70,7 +70,7 @@ export class TextStyle {
   /**
    * 字体倍数
    */
-  fontScale = 1;
+  fontScale = 2;
 
   autoFontScale = true;
 
@@ -110,5 +110,25 @@ export class TextStyle {
       this.fontOffset += this.fontSize * Math.tan(12 * 0.0174532925);
     }
 
+  }
+
+  /**
+   * 获取设备像素比
+   * @returns 设备像素比
+   */
+  getPixelRatio (): number {
+    const g = typeof window !== 'undefined'
+      ? window
+      : typeof self !== 'undefined'
+        ? self
+        : globalThis as any;
+
+    const dpr = g && typeof g.devicePixelRatio === 'number' ? g.devicePixelRatio / 2 : undefined;
+
+    if (!this.autoFontScale) {
+      return 2;
+    }
+
+    return (typeof dpr === 'number' && isFinite(dpr) && dpr > 0) ? dpr : 2;
   }
 }


### PR DESCRIPTION
使用自动设置文本的渲染倍率以解决文本模糊（先前是使用setFontScale设置）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text rendering quality on high-DPI devices through enhanced device pixel ratio handling.
  * Fixed font scaling behavior to prevent unnecessary adjustments when values remain unchanged.

* **New Features**
  * Enhanced automatic font scaling control for improved typography management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->