### PR TITLE
chore: no setCurrentTime when playing in video

### DIFF
--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -169,10 +169,11 @@ export class VideoComponent extends MaskableGraphic {
         if (!this.video?.paused) {
           this.pauseVideo();
         }
-      } else if (videoEndBehavior === spec.EndBehavior.destroy || videoEndBehavior === spec.EndBehavior.restart) {
-        // 销毁由Composition管理，此处仅重置时间
-        this.setCurrentTime(0);
       }
+      // ios freeze issue
+      // else if (videoEndBehavior === spec.EndBehavior.destroy || videoEndBehavior === spec.EndBehavior.restart) {
+      //   this.setCurrentTime(0);
+      // }
     }
     // 判断整个合成是否接近播放完成
     // composition.time + threshold >= rootDuration 表示即将结束


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a video playback issue where videos would reset to the beginning upon reaching their end on iOS devices, improving overall stability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->