### PR TITLE
fix: composition onItemMessage build type issue

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -230,7 +230,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   postProcessingEnabled = false;
   /**
    * 合成中消息元素创建/销毁时触发的回调
-   * @internal
    */
   onItemMessage?: (message: MessageItem) => void;
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Made the onItemMessage callback officially part of the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->