### PR TITLE
fix: remove ktx2 unreasonable test

### DIFF
--- a/web-packages/test/unit/src/effects-webgl/gl-texture.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-texture.spec.ts
@@ -132,11 +132,7 @@ describe('webgl/gl-texture', () => {
     texKTX2.initialize();
     gpuUploadTimes.ktx2 = performance.now() - start;
 
-    // 1. KTX2 load time is the longest
-    expect(cpuDecodeTimes.ktx2).to.be.greaterThan(cpuDecodeTimes.png);
-    expect(cpuDecodeTimes.ktx2).to.be.greaterThan(cpuDecodeTimes.webp);
-
-    // 2. KTX2 upload time is the shortest
+    // KTX2 upload time is the shortest
     expect(gpuUploadTimes.ktx2).to.be.lessThan(gpuUploadTimes.png);
     expect(gpuUploadTimes.ktx2).to.be.lessThan(gpuUploadTimes.webp);
 


### PR DESCRIPTION
Remove a test affected by network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance test assertions to focus on GPU upload timing comparisons between texture formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->