### PR TITLE
fix: 解决预合成元素调用 setPosition 不生效

### DIFF
--- a/packages/effects-core/src/comp-vfx-item.ts
+++ b/packages/effects-core/src/comp-vfx-item.ts
@@ -75,6 +75,15 @@ export class CompositionComponent extends Component {
     this.timelineInstance.setTime(time);
 
     this.timelineInstance.evaluate(dt / 1000);
+    
+    // 确保预合成元素的子元素变换能正确更新
+    for (const item of this.items) {
+      // 只在变换无效时进行处理
+      if (!item.transform.getValid()) {
+        item.transform.setValid(true);
+        item.transform.forceUpdate();
+      }
+    }
   }
 
   override onEnable () {

--- a/packages/effects-core/src/transform.ts
+++ b/packages/effects-core/src/transform.ts
@@ -589,4 +589,13 @@ export class Transform implements Disposable {
       c.parentMatrixDirty = true;
     });
   }
+
+  /**
+   * 强制触发值变化，用于确保变换更新能正确传播
+   */
+  forceUpdate () {
+    this.dispatchValueChange();
+    // 标记本地数据为脏，确保矩阵会被重新计算
+    this.dirtyFlags.localData = true;
+  }
 }


### PR DESCRIPTION
https://github.com/galacean/effects-runtime/issues/1256



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transformation updates in precomposed elements to ensure proper propagation during composition updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->