### PR TITLE
fix: prevent video from auto-playing when it finishes loading

### DIFF
--- a/packages/effects-core/src/downloader.ts
+++ b/packages/effects-core/src/downloader.ts
@@ -284,19 +284,17 @@ export async function loadVideo (url: string | MediaProvider): Promise<HTMLVideo
   video.setAttribute('playsinline', 'playsinline');
 
   return new Promise<HTMLVideoElement>((resolve, reject) => {
-    const handleLoadedData = function listener () {
+    const handleCanPlay = () => {
       resolve(video);
-      video.removeEventListener('canplay', handleLoadedData);
       video.removeEventListener('error', handleError);
     };
     const handleError = (e: any) => {
-      video.removeEventListener('canplay', handleLoadedData);
-      video.removeEventListener('error', handleError);
+      video.removeEventListener('canplay', handleCanPlay);
       reject('Load video fail.');
     };
 
-    video.addEventListener('canplay', handleLoadedData, true);
-    video.addEventListener('error', handleError);
+    video.addEventListener('canplay', handleCanPlay, { once: true });
+    video.addEventListener('error', handleError, { once: true });
 
     // 显式触发视频加载
     video.load();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved video loading reliability and error handling for smoother playback start.
  * Optimized event handling to reduce redundant listeners and ensure clearer failure paths.
  * Explicit load triggering to make startup behavior more consistent.
  * No changes to public APIs or exported interfaces; behavior is more robust without surface changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->