### PR TITLE
fix: particle simulate loop issue

### DIFF
--- a/packages/effects-core/src/plugins/particle/particle-vfx-item.ts
+++ b/packages/effects-core/src/plugins/particle/particle-vfx-item.ts
@@ -44,7 +44,10 @@ export class ParticleBehaviourPlayable extends Playable {
       ) {
         particleSystem.reset();
       }
-      particleSystem.simulate(context.deltaTime);
+
+      // TODO: There is one less conversion from second to millisecond here,
+      // which is retained for frame test.
+      particleSystem.update(this.time - particleSystem.time);
     }
   }
 }

--- a/web-packages/test/case/src/common/test-controller.ts
+++ b/web-packages/test/case/src/common/test-controller.ts
@@ -4,7 +4,7 @@ import { TestPlayer } from './test-player';
 import { loadScript } from './utilities';
 
 const params = new URLSearchParams(location.search);
-const oldVersion = params.get('version') || '2.7.4';  // 旧版 Player 版本
+const oldVersion = params.get('version') || '2.7.3';  // 旧版 Player 版本
 
 const playerOptions: PlayerConfig = {
   env: 'editor',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Particle effects now bind to the renderer on demand, reducing startup work and avoiding updates when no particle system is available.
  * Particle simulation moved to a per-frame delta update path with improved emission, trail and end-of-life handling for more stable visuals and predictable behavior.
  * Processing now short-circuits when particle data is not bound, lowering wasted CPU and reducing glitches.

* **Chore**
  * Default legacy player version for tests changed to 2.7.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->