### PR TITLE
chore: prevent duplicate texture loader registration

### DIFF
--- a/packages/effects-core/src/texture/texture-loader.ts
+++ b/packages/effects-core/src/texture/texture-loader.ts
@@ -44,7 +44,9 @@ class TextureLoaderRegistry {
    */
   register (type: string, factory: TextureLoaderFactory): void {
     if (this.loaders.has(type)) {
-      console.warn(`TextureLoader for type "${type}" is already registered, overwriting.`);
+      console.warn(`TextureLoader for type "${type}" is already registered, skipping.`);
+
+      return; // 阻止重复注册
     }
     this.loaders.set(type, factory);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed texture loader registration to prevent accidental overwrites. When registering a loader for an existing type, the system now exits early instead of replacing the existing loader, improving application stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->