### PR TITLE
fix: video element autoplay false

### DIFF
--- a/packages/effects-core/src/downloader.ts
+++ b/packages/effects-core/src/downloader.ts
@@ -278,6 +278,7 @@ export async function loadVideo (url: string | MediaProvider): Promise<HTMLVideo
   }
   video.crossOrigin = 'anonymous';
   video.muted = true;
+  video.autoplay = false;
   if (isAndroid()) {
     video.setAttribute('renderer', 'standard');
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where videos were unintentionally auto-playing in certain environments. Videos now consistently will not auto-play by default, ensuring predictable playback behavior across all platforms and devices, while giving users explicit control over when media playback begins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->