### PR TITLE
fix: lost old gl context when player dispose

### DIFF
--- a/packages/effects-webgl/src/gl-context-manager.ts
+++ b/packages/effects-webgl/src/gl-context-manager.ts
@@ -37,6 +37,11 @@ export class GLContextManager {
       this.canvas.removeEventListener('webglcontextlost', this.contextLostListener);
       this.canvas.removeEventListener('webglcontextrestored', this.contextRestoredListener);
     }
+
+    if (this.gl) {
+      this.gl.getExtension('WEBGL_lose_context')?.loseContext();
+    }
+
     this.gl = null;
     this.canvas = null;
   }

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -6,7 +6,6 @@ import {
   Engine, logger, EventEmitter, TextureLoadAction, canvasPool, getPixelRatio, initErrors,
   isArray, spec, assertExist, SceneLoader,
 } from '@galacean/effects-core';
-import type { GLEngine } from '@galacean/effects-webgl';
 import { HELP_LINK } from './constants';
 import { handleThrowError, isDowngradeIOS, throwError, throwErrorPromise } from './utils';
 import type { PlayerConfig, PlayerErrorCause, PlayerEvent } from './types';
@@ -650,7 +649,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
     this.pause();
     this.engine.dispose();
 
-    if (this.canvas instanceof HTMLCanvasElement && (this.engine as GLEngine).context) {
+    if (this.canvas instanceof HTMLCanvasElement) {
       // TODO: 数据模版下掉可以由文本模块单独管理
       canvasPool.dispose();
       // canvas will become a cry emoji in Android if still in dom


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebGL graphics context cleanup to ensure proper resource release during disposal operations.
  * Refined canvas resource disposal logic for more reliable cleanup and DOM element handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->