### PR TITLE
chore: skip loadguid function execution when video id is empty

### DIFF
--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -1,5 +1,5 @@
 import type { Asset, Engine, GeometryFromShape, Renderer, Texture2DSourceOptionsVideo } from '@galacean/effects';
-import { MaskableGraphic, Texture, assertExist, effectsClass, math, spec } from '@galacean/effects';
+import { MaskableGraphic, Texture, assertExist, effectsClass, logger, math, spec } from '@galacean/effects';
 
 /**
  * 用于创建 videoItem 的数据类型, 经过处理后的 spec.VideoContent
@@ -112,20 +112,24 @@ export class VideoComponent extends MaskableGraphic {
     this.transparent = transparent;
 
     if (video) {
-      const videoAsset = this.engine.findObject<Asset<HTMLVideoElement>>(video);
+      if (!video.id) {
+        logger.warn('Video id is undefined. It may be a template video that will be replaced via setTexture.');
+      } else {
+        const videoAsset = this.engine.findObject<Asset<HTMLVideoElement>>(video);
 
-      if (videoAsset) {
-        this.video = videoAsset.data;
-        this.setPlaybackRate(playbackRate);
-        this.setVolume(volume);
-        this.setMuted(muted);
-        const endBehavior = this.item.defination.endBehavior;
+        if (videoAsset) {
+          this.video = videoAsset.data;
+          this.setPlaybackRate(playbackRate);
+          this.setVolume(volume);
+          this.setMuted(muted);
+          const endBehavior = this.item.defination.endBehavior;
 
-        // 如果元素设置为 destroy
-        if (endBehavior === spec.EndBehavior.destroy || endBehavior === spec.EndBehavior.freeze) {
-          this.setLoop(false);
-        } else if (endBehavior === spec.EndBehavior.restart) {
-          this.setLoop(true);
+          // 如果元素设置为 destroy
+          if (endBehavior === spec.EndBehavior.destroy || endBehavior === spec.EndBehavior.freeze) {
+            this.setLoop(false);
+          } else if (endBehavior === spec.EndBehavior.restart) {
+            this.setLoop(true);
+          }
         }
       }
     }


### PR DESCRIPTION
为了解决这个问题：视频模板不绑定视频时执行 loadGUID 会报 console.error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video component error handling to gracefully manage scenarios where video identifiers are missing or invalid, with enhanced diagnostic logging capabilities for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->