### PR TITLE
feat: support querying playable by item id from timeline instance

### DIFF
--- a/packages/effects-core/src/components/composition-component.ts
+++ b/packages/effects-core/src/components/composition-component.ts
@@ -41,7 +41,7 @@ export class CompositionComponent extends Component {
   private timelineAsset: TimelineAsset | null = null;
   private _timelineInstance: TimelineInstance | null = null;
 
-  private get timelineInstance (): TimelineInstance | null {
+  get timelineInstance (): TimelineInstance | null {
     if (!this._timelineInstance && this.timelineAsset) {
       this._timelineInstance = new TimelineInstance(this.timelineAsset, this.sceneBindings);
     }

--- a/packages/effects-core/src/plugins/timeline/timeline-asset.ts
+++ b/packages/effects-core/src/plugins/timeline/timeline-asset.ts
@@ -201,25 +201,26 @@ export class TimelineInstance {
    * 递归收集所有 Playable 并建立映射
    * @internal
    */
-  private collectPlayables (trackInstance: TrackInstance) {
+  private collectPlayables (trackInstance: TrackInstance, inheritedItemId?: string) {
     const boundObject = trackInstance.boundObject;
+    let currentItemId = inheritedItemId;
 
     if (boundObject instanceof VFXItem) {
-      const itemId = boundObject.getInstanceId();
+      currentItemId = boundObject.getInstanceId();
+    }
 
-      if (!this.playableMap[itemId]) {
-        this.playableMap[itemId] = [];
+    if (currentItemId) {
+      if (!this.playableMap[currentItemId]) {
+        this.playableMap[currentItemId] = [];
       }
 
-      // 收集该轨道的所有 Playable
       for (const clipPlayable of trackInstance.mixer.clipPlayables) {
-        this.playableMap[itemId].push(clipPlayable);
+        this.playableMap[currentItemId].push(clipPlayable);
       }
     }
 
-    // 递归处理子轨道
     for (const child of trackInstance.children) {
-      this.collectPlayables(child);
+      this.collectPlayables(child, currentItemId);
     }
   }
 

--- a/packages/effects-core/src/plugins/timeline/timeline-asset.ts
+++ b/packages/effects-core/src/plugins/timeline/timeline-asset.ts
@@ -1,9 +1,10 @@
 import * as spec from '@galacean/effects-specification';
 import { effectsClass, serialize } from '../../decorators';
-import type { VFXItem } from '../../vfx-item';
+import { VFXItem } from '../../vfx-item';
 import type { RuntimeClip, TrackAsset } from './track';
 import { ObjectBindingTrack } from './tracks';
 import { PlayState } from './playable';
+import type { Playable } from './playable';
 import type { Constructor } from '../../utils';
 import { TrackInstance } from './track-instance';
 import type { SceneBinding } from '../../components';
@@ -65,6 +66,7 @@ export class TimelineInstance {
 
   private time = 0;
   private clips: RuntimeClip[] = [];
+  private playableMap: Record<string, Playable[]> = {};
 
   constructor (timelineAsset: TimelineAsset, sceneBindings: SceneBinding[]) {
     const sceneBindingMap: Record<string, VFXItem> = {};
@@ -146,6 +148,9 @@ export class TimelineInstance {
     for (const trackInstance of this.masterTrackInstances) {
       this.updateTrackAnimatedObject(trackInstance);
     }
+
+    // Build playable map for quick lookup by VFXItem id
+    this.buildPlayableMap();
   }
 
   private tickTrack (track: TrackInstance, deltaTime: number) {
@@ -178,5 +183,64 @@ export class TimelineInstance {
       }
       this.updateTrackAnimatedObject(subTrack);
     }
+  }
+
+  /**
+   * 构建 VFXItem id 到 Playable 的映射表
+   * @internal
+   */
+  private buildPlayableMap () {
+    this.playableMap = {};
+
+    for (const trackInstance of this.masterTrackInstances) {
+      this.collectPlayables(trackInstance);
+    }
+  }
+
+  /**
+   * 递归收集所有 Playable 并建立映射
+   * @internal
+   */
+  private collectPlayables (trackInstance: TrackInstance) {
+    const boundObject = trackInstance.boundObject;
+
+    if (boundObject instanceof VFXItem) {
+      const itemId = boundObject.getInstanceId();
+
+      if (!this.playableMap[itemId]) {
+        this.playableMap[itemId] = [];
+      }
+
+      // 收集该轨道的所有 Playable
+      for (const clipPlayable of trackInstance.mixer.clipPlayables) {
+        this.playableMap[itemId].push(clipPlayable);
+      }
+    }
+
+    // 递归处理子轨道
+    for (const child of trackInstance.children) {
+      this.collectPlayables(child);
+    }
+  }
+
+  /**
+   * 通过 VFXItem 的 id 获取对应的 Playable 数组
+   * @param itemId - VFXItem 的实例 id
+   * @returns Playable 数组，如果没有找到则返回空数组
+   */
+  getPlayablesByItemId (itemId: string): Playable[] {
+    return this.playableMap[itemId] || [];
+  }
+
+  /**
+   * 通过 VFXItem 的 id 获取指定类型的 Playable
+   * @param itemId - VFXItem 的实例 id
+   * @param playableType - Playable 的类型构造函数
+   * @returns 指定类型的 Playable 数组，如果没有找到则返回空数组
+   */
+  getPlayablesByItemIdAndType<T extends Playable> (itemId: string, playableType: new (...args: any[]) => T): T[] {
+    const playables = this.getPlayablesByItemId(itemId);
+
+    return playables.filter(playable => playable instanceof playableType) as T[];
   }
 }


### PR DESCRIPTION
**修改：**
1. 将 CompositionComponent 中的 timelineInstance 访问权限从 private 改为公开，允许外部访问。
2. 在 TimelineInstance 中新增 playableMap 映射表及查询接口 getPlayablesByItemId、getPlayablesByItemIdAndType，支持通过 VFXItem id 快速查找对应的 Playable。

**用法：**
`const timelineInstance = composition
  .getComponent<CompositionComponent>(CompositionComponent)
  .timelineInstance;

const transformPlayables = timelineInstance
  .getPlayablesByItemIdAndType(itemId, TransformPlayable);

// 修改某项运动曲线数据
transformPlayables[0].positionOverLifetime.path[1][1][1] = [x, y, z];
// 重新初始化使修改生效
transformPlayables[0].start();`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new public methods to retrieve playables filtered by item ID and type, enabling enhanced querying capabilities within the timeline system.

* **Chores**
  * Exposed timelineInstance getter as part of the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->