### PR TITLE
refactor: particle system renderer create in particle systerm onStart

### DIFF
--- a/packages/effects-core/src/plugins/particle/particle-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/particle-mesh.ts
@@ -49,7 +49,6 @@ export interface ParticleMeshData {
     y?: ValueGetter<number>,
     separateAxes?: boolean,
   },
-  meshSlots?: number[],
   forceTarget?: {
     curve: ValueGetter<number>,
     target: spec.vec3,
@@ -151,7 +150,7 @@ export class ParticleMesh implements ParticleMeshData {
       speedOverLifetime, colorOverLifetime, linearVelOverLifetime, orbitalVelOverLifetime, sizeOverLifetime, rotationOverLifetime,
       sprite, gravityModifier, maxCount, textureFlip, useSprite, name,
       gravity, forceTarget, side, occlusion, anchor, blending,
-      transparentOcclusion, meshSlots,
+      transparentOcclusion,
       renderMode = 0,
       diffuse = Texture.createWithData(engine),
     } = props;
@@ -272,17 +271,6 @@ export class ParticleMesh implements ParticleMeshData {
     }
     const vertexCurveTexture = vertexKeyFrameMeta.max + vertexKeyFrameMeta.curves.length - 32 > maxVertexUniforms;
 
-    // if (getConfig(RENDER_PREFER_LOOKUP_TEXTURE)) {
-    //   vertexCurveTexture = true;
-    // }
-    if (level === 2) {
-      vertexKeyFrameMeta.max = -1;
-      vertexKeyFrameMeta.index = meshSlots ? meshSlots[0] : getSlot(vertexKeyFrameMeta.index);
-      if (fragmentKeyFrameMeta.index > 0) {
-        fragmentKeyFrameMeta.max = -1;
-        fragmentKeyFrameMeta.index = meshSlots ? meshSlots[1] : getSlot(fragmentKeyFrameMeta.index);
-      }
-    }
     if (vertexCurveTexture && halfFloatTexture && enableVertexTexture) {
       const tex = generateHalfFloatTexture(engine, ValueGetter.getAllData(vertexKeyFrameMeta, true) as Uint16Array, vertexKeyFrameMeta.index, 1);
 
@@ -880,20 +868,6 @@ export class ParticleMesh implements ParticleMeshData {
   }
 }
 
-const gl2UniformSlots = [10, 32, 64, 160];
-
-function getSlot (count: number): number {
-  for (let w = 0; w < gl2UniformSlots.length; w++) {
-    const slot = gl2UniformSlots[w];
-
-    if (slot > count) {
-      return slot;
-    }
-  }
-
-  return count || gl2UniformSlots[0];
-}
-
 function generateGeometryProps (
   maxVertex: number,
   useSprite?: boolean,
@@ -937,7 +911,7 @@ export function getParticleMeshShader (
     ['RENDER_MODE', renderMode],
     ['ENV_EDITOR', env === PLAYER_OPTIONS_ENV_EDITOR],
   ];
-  const { level, detail } = gpuCapability;
+  const { detail } = gpuCapability;
   const vertexKeyFrameMeta = createKeyFrameMeta();
   const fragmentKeyFrameMeta = createKeyFrameMeta();
   const enableVertexTexture = detail.maxVertexUniforms > 0;
@@ -1067,14 +1041,7 @@ export function getParticleMeshShader (
   if (getConfig(RENDER_PREFER_LOOKUP_TEXTURE)) {
     vertexCurveTexture = true;
   }
-  if (level === 2) {
-    vertexKeyFrameMeta.max = -1;
-    // vertexKeyFrameMeta.index = getSlot(vertexKeyFrameMeta.index);
-    if (fragmentKeyFrameMeta.index > 0) {
-      fragmentKeyFrameMeta.max = -1;
-      // fragmentKeyFrameMeta.index = getSlot(fragmentKeyFrameMeta.index);
-    }
-  }
+
   if (vertexCurveTexture && HALF_FLOAT && enableVertexTexture) {
     vertex_lookup_texture = 1;
   }

--- a/packages/effects-core/src/plugins/particle/particle-system-renderer.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system-renderer.ts
@@ -19,39 +19,14 @@ export class ParticleSystemRenderer extends RendererComponent {
 
   private trailMesh?: TrailMesh;
 
-  constructor (
-    engine: Engine,
-    particleMeshProps?: ParticleMeshProps,
-    trailMeshProps?: TrailMeshProps,
-  ) {
+  constructor (engine: Engine) {
     super(engine);
 
     this.name = 'ParticleSystemRenderer';
-    if (particleMeshProps) {
-      this.particleMesh = new ParticleMesh(engine, particleMeshProps);
-    }
-
-    if (trailMeshProps) {
-      this.trailMesh = new TrailMesh(engine, trailMeshProps);
-    }
-
-    const meshes = [this.particleMesh.mesh];
-
-    this.materials.push(this.particleMesh.mesh.material);
-
-    if (this.trailMesh) {
-      meshes.push(this.trailMesh.mesh);
-      this.materials.push(this.trailMesh.mesh.material);
-    }
-
-    this.meshes = meshes;
   }
 
   override onStart (): void {
     this._priority = this.item.renderOrder;
-    for (const mesh of this.meshes) {
-      mesh.onStart();
-    }
   }
 
   override onUpdate (dt: number): void {
@@ -66,6 +41,28 @@ export class ParticleSystemRenderer extends RendererComponent {
 
     for (const mesh of this.meshes) {
       mesh.render(renderer);
+    }
+  }
+
+  /**
+   * @internal
+   */
+  setup (particleMeshProps: ParticleMeshProps, trailMeshProps: TrailMeshProps | null = null,) {
+    this.meshes = [];
+    this.materials = [];
+
+    this.particleMesh = new ParticleMesh(this.engine, particleMeshProps);
+
+    if (trailMeshProps) {
+      this.trailMesh = new TrailMesh(this.engine, trailMeshProps);
+    }
+
+    this.meshes.push(this.particleMesh.mesh);
+    this.materials.push(this.particleMesh.mesh.material);
+
+    if (this.trailMesh) {
+      this.meshes.push(this.trailMesh.mesh);
+      this.materials.push(this.trailMesh.mesh.material);
     }
   }
 

--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -1,6 +1,6 @@
 import type { Ray } from '@galacean/effects-math/es/core/index';
 import { Euler, Matrix4, Vector2, Vector3 } from '@galacean/effects-math/es/core/index';
-import type { vec2, vec3, vec4 } from '@galacean/effects-specification';
+import type { vec3, vec4 } from '@galacean/effects-specification';
 import * as spec from '@galacean/effects-specification';
 import { Component } from '../../components';
 import { effectsClass } from '../../decorators';
@@ -97,7 +97,6 @@ type TrailOptions = {
   blending: number,
   occlusion: boolean,
   transparentOcclusion: boolean,
-  textureMap?: vec4,
 };
 
 interface ParticleTextureSheetAnimation {
@@ -118,29 +117,7 @@ type ParticleInteraction = {
   radius: number,
 };
 
-export interface ParticleSystemOptions extends spec.ParticleOptions {
-  meshSlots?: number[],
-}
-
-export interface ParticleSystemProps extends Omit<spec.ParticleContent, 'options' | 'renderer' | 'trails' | 'mask'> {
-  options: ParticleSystemOptions,
-  renderer: ParticleSystemRendererOptions,
-  trails?: ParticleTrailProps,
-  mask?: spec.MaskOptions,
-}
-
-// spec.RenderOptions 经过处理
-export interface ParticleSystemRendererOptions extends Required<Omit<spec.RendererOptions, 'texture' | 'anchor' | 'particleOrigin'>> {
-  // mask: number,
-  texture: Texture,
-  anchor?: vec2,
-  particleOrigin?: spec.ParticleOrigin,
-}
-
-export interface ParticleTrailProps extends Omit<spec.ParticleTrail, 'texture' | 'mask'> {
-  texture: Texture,
-  textureMap: vec4,
-  mask?: spec.MaskOptions,
+export interface ParticleSystemProps extends spec.ParticleContent {
 }
 
 // 粒子节点包含的数据
@@ -157,7 +134,6 @@ export class ParticleSystem extends Component implements Maskable {
   textureSheetAnimation?: ParticleTextureSheetAnimation;
   interaction?: ParticleInteraction;
   emissionStopped: boolean;
-  destroyed = false;
   props: ParticleSystemProps;
   time: number;
 
@@ -174,6 +150,9 @@ export class ParticleSystem extends Component implements Maskable {
   private uvs: number[][];
   private basicTransform: ParticleTransform;
   private clickedPoint: LinkNode<ParticleContent>;
+
+  private particleMeshProps: ParticleMeshProps | null = null;
+  private trailMeshProps: TrailMeshProps | null = null;
 
   constructor (
     engine: Engine,
@@ -329,10 +308,19 @@ export class ParticleSystem extends Component implements Maskable {
     this.emission.bursts.forEach(b => b.reset());
     this.frozen = false;
     this.ended = false;
-    this.destroyed = false;
   }
 
   override onStart (): void {
+    if (!this.particleMeshProps) {
+      return;
+    }
+
+    this.renderer = this.item.addComponent(ParticleSystemRenderer);
+
+    this.renderer.setup(this.particleMeshProps, this.trailMeshProps);
+    this.renderer.maskManager = this.maskManager;
+    this.meshes = this.renderer.meshes;
+
     this.startEmit();
     this.initEmitterTransform();
 
@@ -452,7 +440,7 @@ export class ParticleSystem extends Component implements Maskable {
               }
             }
           }
-        } else if (this.item.endBehavior === spec.EndBehavior.restart) {
+        } else if (this.options.looping) {
           updateTrail();
           this.loopStartTime = now - duration;
           this.lastEmitTime -= duration;
@@ -475,14 +463,6 @@ export class ParticleSystem extends Component implements Maskable {
 
           if (endBehavior === spec.EndBehavior.freeze) {
             this.frozen = true;
-          }
-        }
-      } else if (this.item.endBehavior !== spec.EndBehavior.restart) {
-        if (spec.EndBehavior.destroy === this.item.endBehavior) {
-          const node = link.last;
-
-          if (node && (node.content[0]) < this.time) {
-            this.destroyed = true;
           }
         }
       }
@@ -874,7 +854,6 @@ export class ParticleSystem extends Component implements Maskable {
     const props = data as ParticleSystemProps;
 
     this.props = props;
-    this.destroyed = false;
     const cachePrefix = '';
     const { options, positionOverLifetime = {}, shape } = props;
     const gravityModifier = positionOverLifetime?.gravityOverLifetime;
@@ -967,7 +946,8 @@ export class ParticleSystem extends Component implements Maskable {
       startSpeed: createValueGetter(positionOverLifetime.startSpeed || 0),
       startColor: createValueGetter(options.startColor),
       // duration:vfxItem.duration || 1,
-      looping: false,
+      // @ts-expect-error TODO: Update spec
+      looping: options.looping ?? false,
       maxCount: options.maxCount ?? 0,
       gravityModifier: createValueGetter(gravityModifier || 0),
       gravity,
@@ -1003,7 +983,6 @@ export class ParticleSystem extends Component implements Maskable {
 
     const particleMeshProps: ParticleMeshProps = {
       // listIndex: vfxItem.listIndex,
-      meshSlots: options.meshSlots,
       name: this.name,
       matrix: Matrix4.IDENTITY,
       shaderCachePrefix,
@@ -1098,10 +1077,6 @@ export class ParticleSystem extends Component implements Maskable {
         parentAffectsPosition: !!trails.parentAffectsPosition,
       };
 
-      if (trails.mask) {
-        this.maskManager.setMaskOptions(this.engine, trails.mask);
-      }
-
       trailMeshProps = {
         name: 'Trail',
         matrix: Matrix4.IDENTITY,
@@ -1117,7 +1092,6 @@ export class ParticleSystem extends Component implements Maskable {
         lifetime: this.trails.lifetime,
         occlusion: !!trails.occlusion,
         transparentOcclusion: !!trails.transparentOcclusion,
-        textureMap: trails.textureMap,
         mask: this.maskManager.getRefValue(),
         maskMode: this.maskManager.maskMode,
       };
@@ -1130,10 +1104,11 @@ export class ParticleSystem extends Component implements Maskable {
       }
     }
 
-    this.renderer = new ParticleSystemRenderer(this.engine, particleMeshProps, trailMeshProps);
-    this.renderer.item = this.item;
-    this.renderer.maskManager = this.maskManager;
-    this.meshes = this.renderer.meshes;
+    this.particleMeshProps = particleMeshProps;
+
+    if (trailMeshProps) {
+      this.trailMeshProps = trailMeshProps;
+    }
 
     const interaction = props.interaction;
 

--- a/packages/effects-core/src/plugins/particle/trail-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/trail-mesh.ts
@@ -1,7 +1,7 @@
 import type { Matrix4 } from '@galacean/effects-math/es/core/index';
 import { Vector2, Vector3, Vector4 } from '@galacean/effects-math/es/core/index';
 import type * as spec from '@galacean/effects-specification';
-import type { GradientStop, vec3, vec4 } from '@galacean/effects-specification';
+import type { GradientStop, vec3 } from '@galacean/effects-specification';
 import { RENDER_PREFER_LOOKUP_TEXTURE, getConfig } from '../../config';
 import { PLAYER_OPTIONS_ENV_EDITOR } from '../../constants';
 import type { Engine } from '../../engine';
@@ -33,7 +33,6 @@ export type TrailMeshProps = {
   mask: number,
   shaderCachePrefix: string,
   maskMode: number,
-  textureMap: vec4,
   name: string,
 };
 
@@ -73,8 +72,6 @@ export class TrailMesh {
       name,
       occlusion,
       blending,
-      // order,
-      textureMap = [0, 0, 1, 1],
       texture,
       transparentOcclusion,
       minimumVertexDistance,
@@ -225,7 +222,7 @@ export class TrailMesh {
     // TODO: 修改下长度
     material.setVector4('uWidthOverTrail', Vector4.fromArray(uWidthOverTrail));
     material.setVector2('uTexOffset', new Vector2(0, 0));
-    material.setVector4('uTextureMap', Vector4.fromArray(textureMap));
+    material.setVector4('uTextureMap', new Vector4(0, 0, 1, 1));
     material.setVector4('uParams', new Vector4(0, pointCountPerTrail - 1, 0, 0));
     material.setTexture('uMaskTex', uMaskTex);
     material.setVector4('uColorParams', new Vector4(texture ? 1 : 0, +preMulAlpha, 0, +(occlusion && !transparentOcclusion)));

--- a/packages/effects-core/src/vfx-item.ts
+++ b/packages/effects-core/src/vfx-item.ts
@@ -15,7 +15,6 @@ import type {
   BoundingBoxData, HitTestBoxParams, HitTestCustomParams, HitTestSphereParams,
   HitTestTriangleParams,
 } from './plugins';
-import { ParticleSystem } from './plugins';
 import { Transform } from './transform';
 import type { Constructor, Disposable } from './utils';
 import { generateGUID, removeItem } from './utils';
@@ -739,12 +738,6 @@ export class VFXItem extends EffectsObject implements Disposable {
         const component = this.engine.findObject<Component>(componentPath);
 
         this.components.push(component);
-        // TODO ParticleSystemRenderer 现在是动态生成的，后面需要在 json 中单独表示为一个组件
-        if (component instanceof ParticleSystem) {
-          if (!this.components.includes(component.renderer)) {
-            this.components.push(component.renderer);
-          }
-        }
       }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified particle system configuration and public API surface.
  * Removed meshSlots from particle mesh configuration.
  * Deferred particle and trail mesh initialization to an explicit setup call.
  * Trail textures no longer accept a textureMap option; default mapping is used.
  * Particle renderer is no longer implicitly added during item deserialization.
  * End-of-life handling now uses the system-level looping flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->