### PR TITLE
feat: remove useless bezier error message and export bezier utils

### DIFF
--- a/packages/effects-core/src/math/bezier.ts
+++ b/packages/effects-core/src/math/bezier.ts
@@ -382,19 +382,15 @@ export function buildEasingCurve (leftKeyframe: spec.BezierKeyframeValue, rightK
   }
 
   if (x1 < 0) {
-    console.error('Invalid bezier points, x1 < 0', p0, p1, p2, p3);
     x1 = 0;
   }
   if (x2 < 0) {
-    console.error('Invalid bezier points, x2 < 0', p0, p1, p2, p3);
     x2 = 0;
   }
   if (x1 > 1) {
-    console.error('Invalid bezier points, x1 >= 1', p0, p1, p2, p3);
     x1 = 1;
   }
   if (x2 > 1) {
-    console.error('Invalid bezier points, x2 >= 1', p0, p1, p2, p3);
     x2 = 1;
   }
 

--- a/packages/effects-core/src/math/index.ts
+++ b/packages/effects-core/src/math/index.ts
@@ -8,3 +8,4 @@ export * from './shape/ellipse';
 export * from './shape/poly-star';
 export * from './shape/polygon';
 export * from './shape/shape-path';
+export * from './bezier';


### PR DESCRIPTION
These messages were copied from the Editor Code. The runtime code can simply ignore them.