### PR TITLE
fix: editor gizmo null frame buffer setting issue

### DIFF
--- a/plugin-packages/editor-gizmo/src/gizmo-component.ts
+++ b/plugin-packages/editor-gizmo/src/gizmo-component.ts
@@ -883,10 +883,6 @@ class DrawGizmoBehindPass extends RenderPass {
     renderer.clear({ depthAction: TextureLoadAction.clear });
     renderer.renderMeshes(this.meshes);
   }
-
-  override configure (renderer: Renderer): void {
-    renderer.setFramebuffer(this.framebuffer);
-  }
 }
 
 class DrawGizmoFrontPass extends RenderPass {
@@ -899,10 +895,6 @@ class DrawGizmoFrontPass extends RenderPass {
   override execute (renderer: Renderer): void {
     renderer.renderMeshes(this.meshes);
   }
-
-  override configure (renderer: Renderer): void {
-    renderer.setFramebuffer(this.framebuffer);
-  }
 }
 
 class DrawGizmoEditorPass extends RenderPass {
@@ -914,9 +906,5 @@ class DrawGizmoEditorPass extends RenderPass {
 
   override execute (renderer: Renderer): void {
     renderer.renderMeshes(this.meshes);
-  }
-
-  override configure (renderer: Renderer): void {
-    renderer.setFramebuffer(this.framebuffer);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified gizmo rendering configuration while maintaining existing behavior and visual output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->