### PR TITLE
fix: register KTX2 loader before loading compressed texture in test

### DIFF
--- a/packages/effects-core/package.json
+++ b/packages/effects-core/package.json
@@ -51,7 +51,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@galacean/effects-specification": "2.8.0",
+    "@galacean/effects-specification": "^2.8.1",
     "@galacean/effects-math": "1.1.0",
     "flatbuffers": "24.3.25",
     "uuid": "9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
       '@galacean/effects-specification':
-        specifier: 2.8.0
-        version: 2.8.0
+        specifier: ^2.8.1
+        version: 2.8.1
       flatbuffers:
         specifier: 24.3.25
         version: 24.3.25
@@ -2235,9 +2235,8 @@ packages:
     resolution: {integrity: sha512-6b1v0jq7sYYizRXWmXGTOiboeOjwVzu0BQ6HigC0GVn50oW4wVWX8lFfOd3HIYhddGareI5IZvjaJZwj69qAcA==}
     engines: {node: '>=10.0.0'}
 
-  /@galacean/effects-specification@2.8.0:
-    resolution: {integrity: sha512-HNwRlXs47mHV/Q/ArLrOA2lOacbdpfok0R9lO2g61tPSjQT5qEnLY9o4h4pAazH1I6ugwajkKbxz6imFaQ6gRQ==}
-    engines: {node: '18', pnpm: '8'}
+  /@galacean/effects-specification@2.8.1:
+    resolution: {integrity: sha512-3KFI8BWcK24RiG8jle6kQiA3x/NAlU4m4r8VY41VCVijk8VHpwxGQhv8KFOmqifPbpA/06N7kTDSwJZSgN9JTw==}
 
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -3041,7 +3040,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@galacean/effects-math': 1.1.0
-      '@galacean/effects-specification': 2.8.0
+      '@galacean/effects-specification': 2.8.1
       '@types/draco3dgltf': 1.4.3
       '@types/ndarray': 1.0.11
       '@types/sharp': 0.31.1

--- a/web-packages/test/unit/src/effects-webgl/gl-texture.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-texture.spec.ts
@@ -21,6 +21,7 @@ describe('webgl/gl-texture', () => {
     engine = new GLEngine(canvas, { glType: 'webgl' });
     renderer = engine.renderer;
     gl = engine.context.gl as WebGLRenderingContext;
+    registerKTX2Loader();
   });
 
   after(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved WebGL texture-loading test initialization to ensure the KTX2 loader is registered consistently during setup.
* **Chores**
  * Updated an internal effects specification dependency to a newer patch version for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->