### PR TITLE
fix: item transform animation did not continue playing when the end behavior is forward

### DIFF
--- a/packages/effects-core/src/plugins/timeline/playables/transform-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/transform-playable.ts
@@ -160,7 +160,7 @@ export class TransformPlayable extends Playable {
     const duration = this.getDuration();
     let life = this.time / duration;
 
-    life = life < 0 ? 0 : (life > 1 ? 1 : life);
+    life = life < 0 ? 0 : life;
 
     if (this.sizeXOverLifetime) {
       tempSize.x = this.sizeXOverLifetime.getValue(life);


### PR DESCRIPTION
…ehavior is forward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved animation interpolation behavior in effects timeline to properly handle transformations (size, rotation, translation) when animations exceed their expected duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->