### PR TITLE
fix: only resize textures when oversize to avoid NPOT regression

### DIFF
--- a/packages/effects-webgl/src/gl-texture.ts
+++ b/packages/effects-webgl/src/gl-texture.ts
@@ -350,8 +350,8 @@ export class GLTexture extends Texture implements Disposable, RestoreHandler {
 
     if (sourceType !== TextureSourceType.video) {
       // 仅在图片超过 maxTextureSize 时才需要缩放上传；
-      // 对于 NPOT + LINEAR / 非 CLAMP_TO_EDGE 这种 WebGL1 受限场景，
-      // 这里保持与历史版本一致不做强制 POT 化（如需 POT 由上层显式处理），
+      // 对于非 2 的幂（non-power-of-two） + LINEAR / 非 CLAMP_TO_EDGE 这种 WebGL1 受限场景，
+      // 这里保持与历史版本一致不做强制 2 的幂（power-of-two）化（如需对齐由上层显式处理），
       // 否则会与旧版渲染结果出现整张纹理级别的差异。
       const isOversize = image.width > maxSize || image.height > maxSize;
 

--- a/packages/effects-webgl/src/gl-texture.ts
+++ b/packages/effects-webgl/src/gl-texture.ts
@@ -343,16 +343,19 @@ export class GLTexture extends Texture implements Disposable, RestoreHandler {
     type: GLenum,
     image: spec.HTMLImageLike,
   ): spec.vec2 {
-    const { sourceType, minFilter, magFilter, wrapS, wrapT } = this.source;
+    const { sourceType } = this.source;
     const maxSize = this.engine.gpuCapability.detail.maxTextureSize ?? 2048;
     let img = image;
     let pooledCanvasAndContext: CanvasAndContext | undefined;
 
     if (sourceType !== TextureSourceType.video) {
-      let shouldResize = minFilter !== gl.NEAREST || magFilter !== gl.NEAREST || wrapS !== gl.CLAMP_TO_EDGE || wrapT !== gl.CLAMP_TO_EDGE;
+      // 仅在图片超过 maxTextureSize 时才需要缩放上传；
+      // 对于 NPOT + LINEAR / 非 CLAMP_TO_EDGE 这种 WebGL1 受限场景，
+      // 这里保持与历史版本一致不做强制 POT 化（如需 POT 由上层显式处理），
+      // 否则会与旧版渲染结果出现整张纹理级别的差异。
+      const isOversize = image.width > maxSize || image.height > maxSize;
 
-      shouldResize = shouldResize || image.width > maxSize || image.height > maxSize;
-      if (shouldResize) {
+      if (isOversize) {
         pooledCanvasAndContext = resizeImageByCanvas(image, maxSize);
         if (pooledCanvasAndContext) {
           img = pooledCanvasAndContext.canvas;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-video images are now downscaled only when they exceed the GPU size limit, reducing unnecessary resizing.
  * Texture handling is more consistent across rendering settings, improving reliability for large images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->