### PR TITLE
fix(dom-content): decode HTML entities before fetch

### DIFF
--- a/plugin-packages/dom-content/src/dom-to-texture.ts
+++ b/plugin-packages/dom-content/src/dom-to-texture.ts
@@ -288,20 +288,29 @@ const DISALLOWED_PROTOCOLS = ['javascript', 'vbscript'];
 const SAFE_DATA_PREFIXES = ['data:image/', 'data:font/', 'data:application/font', 'data:application/x-font'];
 
 /**
+ * 解码 HTML 实体（数字和常用命名实体），不做其他变换。
+ * 用于把从 HTML 字面字符串提取出的 URL 还原为 fetch 时浏览器实际会发起的 URL。
+ *
+ * 必须做这一步，否则 `<img src="...?a=1&amp;b=2">` 提取到的字面 `&amp;` 会被直接
+ * 拼进 XHR 请求，CDN 收到 `?a=1&amp;b=2` 视作 query 参数名 `amp;b`，普遍返回 404。
+ */
+function decodeHtmlEntities (value: string): string {
+  return value
+    .replace(/&#x([0-9a-fA-F]+);?/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/&#(\d+);?/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)))
+    .replace(/&(amp|lt|gt|quot|apos);/gi, (match, name) => {
+      const map: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: '\'' };
+
+      return map[name.toLowerCase()] ?? match;
+    });
+}
+
+/**
  * 规范化 URL 属性值：解码 HTML 实体和百分号编码，
  * 移除控制字符和空白，转小写后检查是否包含危险协议
  */
 function normalizeUrlAttr (value: string): string {
-  let normalized = value;
-
-  // 解码 HTML 实体（数字和命名）
-  normalized = normalized.replace(/&#x([0-9a-fA-F]+);?/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
-  normalized = normalized.replace(/&#(\d+);?/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)));
-  normalized = normalized.replace(/&(amp|lt|gt|quot|apos);/gi, (match, name) => {
-    const map: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: '\'' };
-
-    return map[name.toLowerCase()] ?? match;
-  });
+  let normalized = decodeHtmlEntities(value);
 
   // 解码百分号编码
   try { normalized = decodeURIComponent(normalized); } catch { /* 忽略无效编码 */ }
@@ -644,7 +653,11 @@ export async function inlineImageSources (html: string): Promise<string> {
   }
 
   await promisePool(urls.map(url => async () => {
-    try { urlToBase64.set(url, await fetchAsBase64(url)); } catch (e) { logger.warn(`inlineImageSources: Failed to fetch "${url}".`, e); }
+    // fetch 前必须解码 HTML 实体，否则 URL 含 &amp; 等会被字面拼进请求，
+    // 导致 CDN 返回 404；Map key 仍用原始字符串，replaceUrls 才能精准匹配 HTML 原文。
+    const fetchUrl = decodeHtmlEntities(url);
+
+    try { urlToBase64.set(url, await fetchAsBase64(fetchUrl)); } catch (e) { logger.warn(`inlineImageSources: Failed to fetch "${fetchUrl}". ${FETCH_FAIL_HINT}`, e); }
   }), MAX_FETCH_CONCURRENCY);
 
   return replaceUrls(html, urlToBase64);
@@ -680,7 +693,9 @@ export async function inlineFontSources (html: string): Promise<string> {
   }
 
   await promisePool(urls.map(url => async () => {
-    try { urlToBase64.set(url, await fetchAsBase64(url)); } catch (e) { logger.warn(`inlineFontSources: Failed to fetch font "${url}".`, e); }
+    const fetchUrl = decodeHtmlEntities(url);
+
+    try { urlToBase64.set(url, await fetchAsBase64(fetchUrl)); } catch (e) { logger.warn(`inlineFontSources: Failed to fetch font "${fetchUrl}". ${FETCH_FAIL_HINT}`, e); }
   }), MAX_FETCH_CONCURRENCY);
 
   return replaceUrls(html, urlToBase64);
@@ -879,10 +894,14 @@ function replaceAttrsInSection (
       const base64 = urlToBase64.get(value);
 
       if (base64) {
-        out += section.slice(nameStart, valueStart) + base64 + (quote ?? '') + section.slice(attrEnd, attrEnd);
-        // 上一行末尾追加的 '' 是为了清晰；attrEnd 之后的内容由外层循环继续处理
-        // 注意：当 quote 不为 null 时，前缀 section.slice(nameStart, valueStart) 已经包含开引号；
-        // 我们追加 base64 + 闭合引号 即可。
+        if (quote === null) {
+          // 原属性无引号时必须补引号：base64 含 ;,/=+ 等字符，无引号会被 HTML parser
+          // 在首个 ; 或空白处截断 src 值，导致图片加载失败。
+          out += section.slice(nameStart, valueStart) + '"' + base64 + '"';
+        } else {
+          // 有引号时 section.slice(nameStart, valueStart) 已包含开引号，只需追加闭合引号。
+          out += section.slice(nameStart, valueStart) + base64 + quote;
+        }
         i = attrEnd;
         continue;
       }
@@ -937,6 +956,11 @@ export function extractSVGDefs (html: string): string {
 const MAX_FETCH_CONCURRENCY = 6; // 最大并发获取数
 const MAX_RESOURCE_BYTES = 10 * 1024 * 1024; // 单个资源最大 10MB
 const MAX_URLS = 100; // 单次内联处理的最大 URL 数量
+
+/** 内联资源 fetch 失败时附加的排查 hint，覆盖业务最常踩的三种原因 */
+const FETCH_FAIL_HINT
+  = '可能原因: (1) 资源服务器未开启 CORS（需 Access-Control-Allow-Origin 响应头）; '
+  + '(2) URL 不可访问 (404 / 403); (3) 网络异常。';
 
 /** 有界并发执行异步任务 */
 async function promisePool<T> (tasks: (() => Promise<T>)[], concurrency: number): Promise<T[]> {

--- a/plugin-packages/dom-content/src/dom-to-texture.ts
+++ b/plugin-packages/dom-content/src/dom-to-texture.ts
@@ -298,8 +298,14 @@ function decodeHtmlEntities (value: string): string {
   return value
     .replace(/&#x([0-9a-fA-F]+);?/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
     .replace(/&#(\d+);?/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)))
-    .replace(/&(amp|lt|gt|quot|apos);/gi, (match, name) => {
-      const map: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: '\'' };
+    .replace(/&([a-zA-Z]+);/gi, (match, name) => {
+      const map: Record<string, string> = {
+        amp: '&', lt: '<', gt: '>', quot: '"', apos: '\'',
+        // 安全相关：协议分隔符和空白字符，防止绕过 isDangerousUrl 检查
+        colon: ':', semi: ';',
+        tab: '\t', newline: '\n',
+        nbsp: '\u00A0',
+      };
 
       return map[name.toLowerCase()] ?? match;
     });

--- a/web-packages/test/unit/src/effects-core/plugins/dom-content/dom-content.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/dom-content/dom-content.spec.ts
@@ -30,12 +30,12 @@ function stubXHRCapture (mode: 'error' | 'success'): { urls: string[], restore: 
   const tinyPng = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
 
   class MockXHR {
-    onloadHandler: ((e: any) => void) | null = null;
-    onerrorHandler: ((e: any) => void) | null = null;
+    onloadHandler: ((e: Event) => void) | null = null;
+    onerrorHandler: ((e: Event) => void) | null = null;
     status = 0;
     response: Blob | null = null;
     responseType: XMLHttpRequestResponseType = '';
-    addEventListener (event: string, handler: (e: any) => void) {
+    addEventListener (event: string, handler: (e: Event) => void) {
       if (event === 'load') { this.onloadHandler = handler; }
       if (event === 'error') { this.onerrorHandler = handler; }
     }

--- a/web-packages/test/unit/src/effects-core/plugins/dom-content/dom-content.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/dom-content/dom-content.spec.ts
@@ -18,6 +18,46 @@ async function waitFor (predicate: () => boolean, timeout = 2000, interval = 50)
   throw new Error(`waitFor timed out after ${timeout}ms`);
 }
 
+/**
+ * 拦截 XMLHttpRequest，捕获 open 时传入的 URL；mode 决定 send 后触发的事件。
+ * - 'error' 模式：模拟网络失败，inlineImageSources 走 catch，HTML 原文保留
+ * - 'success' 模式：返回一段最小 PNG Blob，让 base64 替换路径完整跑一遍
+ */
+function stubXHRCapture (mode: 'error' | 'success'): { urls: string[], restore: () => void } {
+  const urls: string[] = [];
+  const OriginalXHR = globalThis.XMLHttpRequest;
+  // 最小 PNG 头字节，让 FileReader 能产出 data:image/png;base64,...
+  const tinyPng = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+
+  class MockXHR {
+    onloadHandler: ((e: any) => void) | null = null;
+    onerrorHandler: ((e: any) => void) | null = null;
+    status = 0;
+    response: Blob | null = null;
+    responseType: XMLHttpRequestResponseType = '';
+    addEventListener (event: string, handler: (e: any) => void) {
+      if (event === 'load') { this.onloadHandler = handler; }
+      if (event === 'error') { this.onerrorHandler = handler; }
+    }
+    open (_method: string, url: string) { urls.push(url); }
+    send () {
+      setTimeout(() => {
+        if (mode === 'success') {
+          this.status = 200;
+          this.response = new Blob([tinyPng], { type: 'image/png' });
+          this.onloadHandler?.(new Event('load'));
+        } else {
+          this.onerrorHandler?.(new Event('error'));
+        }
+      }, 0);
+    }
+  }
+
+  globalThis.XMLHttpRequest = MockXHR as unknown as typeof XMLHttpRequest;
+
+  return { urls, restore: () => { globalThis.XMLHttpRequest = OriginalXHR; } };
+}
+
 describe('plugin/dom-content', () => {
   let player: Player;
 
@@ -303,6 +343,40 @@ describe('plugin/dom-content', () => {
 
     it('should handle empty HTML', async () => {
       expect(await inlineImageSources('')).to.equal('');
+    });
+
+    it('should HTML-decode entity-encoded URLs before fetching', async () => {
+      // Bug fix: <img src="...?a=1&amp;b=2"> 的 src 提取出字面 "&amp;"，
+      // 若直接拿去 fetch，CDN 收到 "amp;b=2" 视为非法参数名，普遍返回 404。
+      const captured = stubXHRCapture('error');
+
+      try {
+        const html = '<img src="https://example.com/img.png?a=1&amp;b=2" />';
+        const result = await inlineImageSources(html);
+
+        expect(captured.urls).to.have.lengthOf(1);
+        expect(captured.urls[0]).to.equal('https://example.com/img.png?a=1&b=2');
+        // 替换路径以原始字符串为 key，fetch 失败时 HTML 原文保留
+        expect(result).to.include('&amp;');
+      } finally {
+        captured.restore();
+      }
+    });
+
+    it('should keep src wrapped in quotes after base64 replacement for unquoted attributes', async () => {
+      // Bug fix: <img src=https://...> 无引号时，base64 含 ;,/= 等字符
+      // 若不补引号会被 HTML parser 在首个分号处截断，导致 src 失效。
+      const captured = stubXHRCapture('success');
+
+      try {
+        const html = '<img src=https://example.com/x.png />';
+        const result = await inlineImageSources(html);
+
+        expect(result).to.match(/src="data:image\/png;base64,[^"]+"/);
+        expect(result).to.not.match(/src=data:/);
+      } finally {
+        captured.restore();
+      }
     });
   });
 


### PR DESCRIPTION
- Extract decodeHtmlEntities() and call it before fetchAsBase64 so that entity-encoded URLs like '?a=1&amp;b=2' are decoded to '?a=1&b=2', preventing CDN 404 caused by literal '&amp;' in the request.
- Wrap base64 value in quotes when the original attribute had no quotes; without quotes the HTML parser truncates at the first ';' inside the base64 string, breaking the image source.
- Add FETCH_FAIL_HINT to fetch error logs for easier debugging.
- Add unit tests for HTML entity decoding and unquoted attribute quoting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTML entity decoding in image and font URLs so encoded query parameters (e.g., `&amp;`) are properly handled before inlining.
  * Ensured replaced base64 data URLs are properly quoted to prevent HTML parsing/truncation.
  * Enhanced inlining failure messages with clearer hints about common causes.

* **Tests**
  * Added tests covering entity-encoded query handling and attribute-quoting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->