### PR TITLE
feat: support multiple masks

### DIFF
--- a/packages/effects-core/src/components/base-render-component.ts
+++ b/packages/effects-core/src/components/base-render-component.ts
@@ -5,7 +5,7 @@ import * as spec from '@galacean/effects-specification';
 import type { Engine } from '../engine';
 import { glContext } from '../gl';
 import type { Maskable } from '../material';
-import { MaskMode, Material, getPreMultiAlpha, setBlendMode, setSideMode } from '../material';
+import { Material, getPreMultiAlpha, setBlendMode, setSideMode } from '../material';
 import type { BoundingBoxInfo, BoundingBoxTriangle, HitTestTriangleParams } from '../plugins';
 import type { Renderer } from '../render';
 import { Geometry } from '../render';
@@ -19,6 +19,10 @@ import { extractMinAndMax } from '../math';
  */
 export interface ItemRenderer extends Required<Omit<spec.RendererOptions, 'texture' | 'shape' | 'anchor' | 'particleOrigin' | 'mask'>> {
   texture: Texture,
+  /**
+   * @deprecated 2.10 起此字段无实际意义，仅为兼容老版本读取保留；
+   * 请使用 `MaskProcessor.getMaskReferences()` 获取当前蒙版引用列表
+   */
   mask: number,
 }
 
@@ -273,7 +277,6 @@ export class MaskableGraphic extends RendererComponent implements Maskable {
 
   private configureMaterial (renderer: ItemRenderer): Material {
     const { side, occlusion, blending: blendMode, texture } = renderer;
-    const maskMode = this.maskManager.maskMode;
     const material = this.material;
 
     material.blending = true;
@@ -293,7 +296,6 @@ export class MaskableGraphic extends RendererComponent implements Maskable {
     texParams.x = renderer.occlusion ? +(renderer.transparentOcclusion) : 1;
     texParams.y = preMultiAlpha;
     texParams.z = renderer.renderMode;
-    texParams.w = maskMode;
     material.setVector4('_TexParams', texParams);
 
     if (texParams.x === 0 || (this.maskManager.alphaMaskEnabled)) {
@@ -327,9 +329,9 @@ export class MaskableGraphic extends RendererComponent implements Maskable {
       blending: renderer.blending ?? spec.BlendingMode.ALPHA,
       texture: renderer.texture ? this.engine.findObject<Texture>(renderer.texture) : this.engine.whiteTexture,
       occlusion: !!renderer.occlusion,
-      transparentOcclusion: !!renderer.transparentOcclusion || (this.maskManager.maskMode === MaskMode.MASK),
+      transparentOcclusion: !!renderer.transparentOcclusion || this.maskManager.isMask,
       side: renderer.side ?? spec.SideMode.DOUBLE,
-      mask: this.maskManager.getRefValue(),
+      mask: 1,
     };
 
     this.configureMaterial(this.renderer);

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -7,12 +7,11 @@ import {
   DataType, END_BEHAVIOR_PAUSE, END_BEHAVIOR_PAUSE_AND_DESTROY, EndBehavior, ItemType,
   JSONSceneVersion, ShapePrimitiveType,
 } from '@galacean/effects-specification';
-import { MaskMode } from '../material';
 import { generateGUID } from '../utils';
 import { convertAnchor, ensureFixedNumber, ensureFixedVec3 } from './utils';
 import { getGeometryByShape } from '../shape/geometry';
 
-let currentMaskComponent: string;
+let currentMaskComponentId: string | undefined;
 const componentMap: Map<string, spec.ComponentData> = new Map();
 const itemMap: Map<string, spec.VFXItemData> = new Map();
 
@@ -725,14 +724,19 @@ export function version36Migration (json: JSONScene): JSONScene {
 
   for (const composition of json.compositions) {
     composition.children = [];
+    currentMaskComponentId = undefined;
 
     for (const componentDataPath of composition.components) {
       const componentData = componentMap.get(componentDataPath.id) as spec.ComponentData;
 
       if (componentData.dataType === spec.DataType.CompositionComponent) {
         const compositionComponent = componentData as spec.CompositionComponentData;
+        const compositionItems = compositionComponent.items ?? [];
 
-        for (const itemPath of compositionComponent.items) {
+        currentMaskComponentId = undefined;
+        processMaskItems(compositionItems, itemMap, componentMap);
+
+        for (const itemPath of compositionItems) {
           const item = itemMap.get(itemPath.id) as spec.VFXItemData;
 
           if (item.parentId === undefined) {
@@ -884,11 +888,26 @@ function createGeometryDataByShape (shape: spec.ShapeGeometry, geometryDataName 
 
 export function processContent (composition: spec.CompositionData) {
   //@ts-expect-error
-  for (const item of composition.items) {
+  const items = composition.items;
+
+  if (!Array.isArray(items)) {
+    return;
+  }
+
+  currentMaskComponentId = undefined;
+  processMaskItems(items, itemMap, componentMap);
+}
+
+function processMaskItems (
+  items: { id: string }[],
+  itemMap: Map<string, spec.VFXItemData>,
+  componentMap: Map<string, spec.ComponentData>
+) {
+  for (const item of items) {
     const itemProps = itemMap.get(item.id);
 
     if (!itemProps) {
-      return;
+      continue;
     }
 
     if (
@@ -898,7 +917,8 @@ export function processContent (composition: spec.CompositionData) {
       itemProps.type === spec.ItemType.text ||
       itemProps.type === spec.ItemType.richtext ||
       itemProps.type === spec.ItemType.video ||
-      itemProps.type === spec.ItemType.shape
+      itemProps.type === spec.ItemType.shape ||
+      itemProps.type === spec.ItemType.mesh
     ) {
       const component = componentMap.get(itemProps.components[0].id);
 
@@ -912,26 +932,57 @@ export function processContent (composition: spec.CompositionData) {
 export function processMask (renderContent: any) {
   const renderer = renderContent.renderer;
   const maskMode = renderer?.maskMode;
+  const mask = renderContent.mask;
 
-  if (!maskMode || maskMode === MaskMode.NONE) {
+  // 处理旧版 maskMode（通过 renderer.maskMode 字段）
+  // 旧 JSON 取值：0=NONE, 1=MASK；OBSCURED/REVERSE_OBSCURED 来自 spec.ObscuredMode
+  const LEGACY_MASK_MODE_NONE = 0;
+  const LEGACY_MASK_MODE_MASK = 1;
 
-    return;
-  }
+  if (maskMode && maskMode !== LEGACY_MASK_MODE_NONE) {
+    const alphaMaskEnabled = mask?.alphaMaskEnabled ?? false;
 
-  if (maskMode === MaskMode.MASK) {
+    if (maskMode === LEGACY_MASK_MODE_MASK) {
+      renderContent.mask = {
+        isMask: true,
+        alphaMaskEnabled,
+      };
+      currentMaskComponentId = renderContent.id;
+    } else if (
+      maskMode === spec.ObscuredMode.OBSCURED ||
+      maskMode === spec.ObscuredMode.REVERSE_OBSCURED
+    ) {
+      if (!currentMaskComponentId) {
+        console.warn(`Mask migration: obscured component "${renderContent.id}" has no preceding mask component, skipping.`);
+
+        return;
+      }
+      // 将旧版单蒙版转换为 references 数组格式
+      renderContent.mask = {
+        isMask: false,
+        alphaMaskEnabled,
+        references: [
+          {
+            mask: {
+              'id': currentMaskComponentId,
+            },
+            inverted: maskMode === spec.ObscuredMode.REVERSE_OBSCURED,
+          },
+        ],
+      };
+    }
+  } else if (mask && !mask.references && mask.reference) {
+    // 处理旧版 mask 格式（mask.reference 和 mask.inverted 字段）
+    // 将旧版单蒙版格式转换为 references 数组
     renderContent.mask = {
-      isMask: true,
-    };
-    currentMaskComponent = renderContent.id;
-  } else if (
-    maskMode === spec.ObscuredMode.OBSCURED ||
-    maskMode === spec.ObscuredMode.REVERSE_OBSCURED
-  ) {
-    renderContent.mask = {
-      inverted: maskMode === spec.ObscuredMode.REVERSE_OBSCURED ? true : false,
-      reference: {
-        'id': currentMaskComponent,
-      },
+      isMask: mask.isMask ?? false,
+      alphaMaskEnabled: mask.alphaMaskEnabled ?? false,
+      references: [
+        {
+          mask: mask.reference,
+          inverted: mask.inverted ?? false,
+        },
+      ],
     };
   }
 }

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -7,6 +7,7 @@ import {
   DataType, END_BEHAVIOR_PAUSE, END_BEHAVIOR_PAUSE_AND_DESTROY, EndBehavior, ItemType,
   JSONSceneVersion, ShapePrimitiveType,
 } from '@galacean/effects-specification';
+import { MaskMode } from '../material';
 import { generateGUID } from '../utils';
 import { convertAnchor, ensureFixedNumber, ensureFixedVec3 } from './utils';
 import { getGeometryByShape } from '../shape/geometry';
@@ -726,6 +727,13 @@ export function version36Migration (json: JSONScene): JSONScene {
     composition.children = [];
     currentMaskComponentId = undefined;
 
+    //@ts-expect-error
+    const legacyCompositionItems = composition.items;
+
+    if (Array.isArray(legacyCompositionItems)) {
+      processMaskReferenceItems(legacyCompositionItems, itemMap, componentMap);
+    }
+
     for (const componentDataPath of composition.components) {
       const componentData = componentMap.get(componentDataPath.id) as spec.ComponentData;
 
@@ -733,8 +741,7 @@ export function version36Migration (json: JSONScene): JSONScene {
         const compositionComponent = componentData as spec.CompositionComponentData;
         const compositionItems = compositionComponent.items ?? [];
 
-        currentMaskComponentId = undefined;
-        processMaskItems(compositionItems, itemMap, componentMap);
+        processMaskReferenceItems(compositionItems, itemMap, componentMap);
 
         for (const itemPath of compositionItems) {
           const item = itemMap.get(itemPath.id) as spec.VFXItemData;
@@ -888,17 +895,32 @@ function createGeometryDataByShape (shape: spec.ShapeGeometry, geometryDataName 
 
 export function processContent (composition: spec.CompositionData) {
   //@ts-expect-error
-  const items = composition.items;
+  for (const item of composition.items) {
+    const itemProps = itemMap.get(item.id);
 
-  if (!Array.isArray(items)) {
-    return;
+    if (!itemProps) {
+      return;
+    }
+
+    if (
+      itemProps.type === spec.ItemType.sprite ||
+      itemProps.type === spec.ItemType.particle ||
+      itemProps.type === spec.ItemType.spine ||
+      itemProps.type === spec.ItemType.text ||
+      itemProps.type === spec.ItemType.richtext ||
+      itemProps.type === spec.ItemType.video ||
+      itemProps.type === spec.ItemType.shape
+    ) {
+      const component = componentMap.get(itemProps.components[0].id);
+
+      if (component) {
+        processMask(component);
+      }
+    }
   }
-
-  currentMaskComponentId = undefined;
-  processMaskItems(items, itemMap, componentMap);
 }
 
-function processMaskItems (
+function processMaskReferenceItems (
   items: { id: string }[],
   itemMap: Map<string, spec.VFXItemData>,
   componentMap: Map<string, spec.ComponentData>
@@ -923,7 +945,7 @@ function processMaskItems (
       const component = componentMap.get(itemProps.components[0].id);
 
       if (component) {
-        processMask(component);
+        processMaskReference(component);
       }
     }
   }
@@ -932,46 +954,34 @@ function processMaskItems (
 export function processMask (renderContent: any) {
   const renderer = renderContent.renderer;
   const maskMode = renderer?.maskMode;
+
+  if (!maskMode || maskMode === MaskMode.NONE) {
+
+    return;
+  }
+
+  if (maskMode === MaskMode.MASK) {
+    renderContent.mask = {
+      isMask: true,
+    };
+    currentMaskComponentId = renderContent.id;
+  } else if (
+    maskMode === spec.ObscuredMode.OBSCURED ||
+    maskMode === spec.ObscuredMode.REVERSE_OBSCURED
+  ) {
+    renderContent.mask = {
+      inverted: maskMode === spec.ObscuredMode.REVERSE_OBSCURED ? true : false,
+      reference: {
+        'id': currentMaskComponentId,
+      },
+    };
+  }
+}
+
+function processMaskReference (renderContent: any) {
   const mask = renderContent.mask;
 
-  // 处理旧版 maskMode（通过 renderer.maskMode 字段）
-  // 旧 JSON 取值：0=NONE, 1=MASK；OBSCURED/REVERSE_OBSCURED 来自 spec.ObscuredMode
-  const LEGACY_MASK_MODE_NONE = 0;
-  const LEGACY_MASK_MODE_MASK = 1;
-
-  if (maskMode && maskMode !== LEGACY_MASK_MODE_NONE) {
-    const alphaMaskEnabled = mask?.alphaMaskEnabled ?? false;
-
-    if (maskMode === LEGACY_MASK_MODE_MASK) {
-      renderContent.mask = {
-        isMask: true,
-        alphaMaskEnabled,
-      };
-      currentMaskComponentId = renderContent.id;
-    } else if (
-      maskMode === spec.ObscuredMode.OBSCURED ||
-      maskMode === spec.ObscuredMode.REVERSE_OBSCURED
-    ) {
-      if (!currentMaskComponentId) {
-        console.warn(`Mask migration: obscured component "${renderContent.id}" has no preceding mask component, skipping.`);
-
-        return;
-      }
-      // 将旧版单蒙版转换为 references 数组格式
-      renderContent.mask = {
-        isMask: false,
-        alphaMaskEnabled,
-        references: [
-          {
-            mask: {
-              'id': currentMaskComponentId,
-            },
-            inverted: maskMode === spec.ObscuredMode.REVERSE_OBSCURED,
-          },
-        ],
-      };
-    }
-  } else if (mask && !mask.references && mask.reference) {
+  if (mask && !mask.references && mask.reference) {
     // 处理旧版 mask 格式（mask.reference 和 mask.inverted 字段）
     // 将旧版单蒙版格式转换为 references 数组
     renderContent.mask = {

--- a/packages/effects-core/src/material/mask-ref-manager.ts
+++ b/packages/effects-core/src/material/mask-ref-manager.ts
@@ -1,7 +1,6 @@
 import type { Engine } from '../engine';
 import type * as spec from '@galacean/effects-specification';
 import type { Maskable, MaskReference } from './types';
-import { MaskMode } from './types';
 import type { Renderer } from '../render/renderer';
 import { TextureLoadAction } from '../texture/types';
 import type { RenderPassClearAction } from '../render/render-pass';
@@ -11,6 +10,23 @@ import type { Geometry } from '../render/geometry';
 import type { Matrix4 } from '@galacean/effects-math/es/core/matrix4';
 import type { RendererComponent } from '../components';
 
+// spec 更新后直接使用 spec.MaskReferenceData
+type MaskOptionReference = {
+  mask?: spec.DataPath,
+  inverted?: boolean,
+};
+
+// spec 更新后直接使用 spec.MaskOptions
+type MaskOptions = {
+  isMask?: boolean,
+  alphaMaskEnabled?: boolean,
+  references?: MaskOptionReference[],
+};
+
+// 8 位 stencil buffer 上限为 255；为反向蒙版的 INCR 预留 1 的递增余量，
+// 否则当正向蒙版填满到 255 时，反向 INCR 会饱和、无法排除任何像素。
+const MAX_MASK_REFERENCE_COUNT = 254;
+
 /**
  * @internal
  */
@@ -18,8 +34,6 @@ export class MaskProcessor {
   alphaMaskEnabled = false;
 
   isMask = false;
-  inverted = false;
-  maskMode: MaskMode = MaskMode.NONE;
 
   /**
    * 多个蒙版引用列表，支持正面和反面蒙版
@@ -34,6 +48,8 @@ export class MaskProcessor {
   private stencilClearAction: RenderPassClearAction;
 
   private prevStencilFunc: [number, number] = [0, 0];
+  private prevStencilOpFail: [number, number] = [0, 0];
+  private prevStencilOpZFail: [number, number] = [0, 0];
   private prevStencilOpZPass: [number, number] = [0, 0];
   private prevStencilRef: [number, number] = [0, 0];
   private prevStencilMask: [number, number] = [0, 0];
@@ -53,7 +69,7 @@ export class MaskProcessor {
     if (value) {
       this.maskReferences.push({
         maskable: value,
-        inverted: this.maskMode === MaskMode.REVERSE_OBSCURED,
+        inverted: false,
       });
     }
   }
@@ -63,35 +79,57 @@ export class MaskProcessor {
   }
 
   /**
-   * @deprecated
+   * 设置蒙版选项。
+   *
+   * @param data.references - 蒙版引用列表。
+   *   传入空数组等价于无蒙版。
+   *   超过 254 个引用时，多余部分将被忽略并打印警告。
    */
-  getRefValue (): number {
-    return 1;
-  }
-
-  /**
-   * 设置蒙版选项（兼容旧版单蒙版 API）
-   */
-  setMaskOptions (engine: Engine, data: spec.MaskOptions): void {
-    const { isMask = false, inverted = false, reference, alphaMaskEnabled = false } = data;
+  setMaskOptions (engine: Engine, data: MaskOptions): void {
+    const { isMask = false, references = [], alphaMaskEnabled = false } = data;
 
     this.alphaMaskEnabled = alphaMaskEnabled;
     this.isMask = isMask;
-    this.inverted = inverted;
     this.maskReferences = [];
 
-    if (isMask) {
-      this.maskMode = MaskMode.MASK;
-    } else {
-      this.maskMode = inverted ? MaskMode.REVERSE_OBSCURED : MaskMode.OBSCURED;
-      const maskable = engine.findObject<Maskable>(reference);
+    if (isMask || references.length === 0) {
+      return;
+    }
 
-      if (maskable) {
-        this.maskReferences.push({
-          maskable,
-          inverted,
-        });
+    const seen = new Map<Maskable, boolean>();
+
+    for (const ref of references) {
+      const maskPath = ref.mask;
+
+      if (!maskPath) {
+        continue;
       }
+
+      const maskable = engine.findObject<Maskable>(maskPath);
+
+      if (!maskable) {
+        console.warn(`Mask reference not found: ${JSON.stringify(maskPath)}. Skipping.`);
+        continue;
+      }
+
+      const inverted = ref.inverted ?? false;
+      const existingInverted = seen.get(maskable);
+
+      if (existingInverted !== undefined) {
+        if (existingInverted !== inverted) {
+          console.warn('Same maskable referenced with conflicting inverted flags; keeping the first occurrence.');
+        }
+        continue;
+      }
+
+      if (this.maskReferences.length >= MAX_MASK_REFERENCE_COUNT) {
+        console.warn(`Maximum of ${MAX_MASK_REFERENCE_COUNT} mask references exceeded. Additional masks will be ignored.`);
+
+        break;
+      }
+
+      seen.set(maskable, inverted);
+      this.maskReferences.push({ maskable, inverted });
     }
   }
 
@@ -104,8 +142,8 @@ export class MaskProcessor {
     const exists = this.maskReferences.some(ref => ref.maskable === maskable);
 
     if (!exists) {
-      if (this.maskReferences.length >= 255) {
-        console.warn('Maximum of 255 mask references exceeded. Additional masks will be ignored.');
+      if (this.maskReferences.length >= MAX_MASK_REFERENCE_COUNT) {
+        console.warn(`Maximum of ${MAX_MASK_REFERENCE_COUNT} mask references exceeded. Additional masks will be ignored.`);
 
         return;
       }
@@ -133,6 +171,13 @@ export class MaskProcessor {
   }
 
   /**
+   * 获取当前蒙版引用列表的浅拷贝。
+   */
+  getMaskReferences (): ReadonlyArray<MaskReference> {
+    return this.maskReferences.slice();
+  }
+
+  /**
    * 绘制所有蒙版，被蒙版的元素调用。
    *
    * 使用递增 stencil 计数法实现任意数量蒙版的交集：
@@ -140,13 +185,20 @@ export class MaskProcessor {
    * 2. 反向蒙版渲染，将已通过所有正向蒙版的像素标记为无效
    * 3. 最终只有 stencil == 正向蒙版数量 的像素才通过测试
    *
-   * 最多支持 255 个蒙版引用（受 8 位 stencil buffer 限制）
+   * 最多支持 254 个蒙版引用（8 位 stencil buffer 上限 255，需为反向 INCR 预留 1）
    */
   drawStencilMask (renderer: Renderer, maskedComponent: RendererComponent): void {
     const frameClipMasks = maskedComponent.frameClipMasks;
+    const addedFrameClipMasks: Maskable[] = [];
 
     for (const frameClipMask of frameClipMasks) {
+      const referenceCount = this.maskReferences.length;
+
       this.addMaskReference(frameClipMask, false);
+
+      if (this.maskReferences.length > referenceCount) {
+        addedFrameClipMasks.push(frameClipMask);
+      }
     }
 
     if (this.maskReferences.length > 0) {
@@ -188,7 +240,7 @@ export class MaskProcessor {
       this.setupMaskedMaterial(material);
     }
 
-    for (const frameClipMask of frameClipMasks) {
+    for (const frameClipMask of addedFrameClipMasks) {
       this.removeMaskReference(frameClipMask);
     }
   }
@@ -201,11 +253,11 @@ export class MaskProcessor {
     const prevStencilTest = material.stencilTest;
 
     this.copyStencilArrayValue(this.prevStencilFunc, material.stencilFunc);
+    this.copyStencilArrayValue(this.prevStencilOpFail, material.stencilOpFail);
+    this.copyStencilArrayValue(this.prevStencilOpZFail, material.stencilOpZFail);
     this.copyStencilArrayValue(this.prevStencilOpZPass, material.stencilOpZPass);
     this.copyStencilArrayValue(this.prevStencilRef, material.stencilRef);
     this.copyStencilArrayValue(this.prevStencilMask, material.stencilMask);
-    // const prevStencilOpFail = material.stencilOpFail;
-    // const prevStencilOpZFail = material.stencilOpZFail;
 
     this.setupMaskMaterial(material, maskRef);
     renderer.drawGeometry(geometry, worldMatrix, material, subMeshIndex);
@@ -213,9 +265,9 @@ export class MaskProcessor {
     material.colorMask = previousColorMask;
     material.stencilTest = prevStencilTest;
     material.stencilFunc = this.prevStencilFunc;
+    material.stencilOpFail = this.prevStencilOpFail;
+    material.stencilOpZFail = this.prevStencilOpZFail;
     material.stencilOpZPass = this.prevStencilOpZPass;
-    // material.stencilOpFail = prevStencilOpFail;
-    // material.stencilOpZFail = prevStencilOpZFail;
     material.stencilRef = this.prevStencilRef;
     material.stencilMask = this.prevStencilMask;
   }
@@ -239,9 +291,9 @@ export class MaskProcessor {
     material.stencilMask = [0xFF, 0xFF];
 
     // 通过时递增 stencil 值，不通过时保持不变
+    material.stencilOpFail = [glContext.KEEP, glContext.KEEP];
+    material.stencilOpZFail = [glContext.KEEP, glContext.KEEP];
     material.stencilOpZPass = [glContext.INCR, glContext.INCR];
-    // material.stencilOpFail = [glContext.KEEP, glContext.KEEP];
-    // material.stencilOpZFail = [glContext.KEEP, glContext.KEEP];
 
     material.colorMask = false; // 不写入颜色
   }

--- a/packages/effects-core/src/material/mask-ref-manager.ts
+++ b/packages/effects-core/src/material/mask-ref-manager.ts
@@ -47,13 +47,6 @@ export class MaskProcessor {
 
   private stencilClearAction: RenderPassClearAction;
 
-  private prevStencilFunc: [number, number] = [0, 0];
-  private prevStencilOpFail: [number, number] = [0, 0];
-  private prevStencilOpZFail: [number, number] = [0, 0];
-  private prevStencilOpZPass: [number, number] = [0, 0];
-  private prevStencilRef: [number, number] = [0, 0];
-  private prevStencilMask: [number, number] = [0, 0];
-
   /**
    * @deprecated 使用 maskReferences 替代
    */
@@ -249,27 +242,26 @@ export class MaskProcessor {
    *  绘制几何体蒙版，蒙版元素绘制时调用
    */
   drawGeometryMask (renderer: Renderer, geometry: Geometry, worldMatrix: Matrix4, material: Material, maskRef: number, subMeshIndex = 0): void {
-    const previousColorMask = material.colorMask;
+    const prevColorMask = material.colorMask;
     const prevStencilTest = material.stencilTest;
-
-    this.copyStencilArrayValue(this.prevStencilFunc, material.stencilFunc);
-    this.copyStencilArrayValue(this.prevStencilOpFail, material.stencilOpFail);
-    this.copyStencilArrayValue(this.prevStencilOpZFail, material.stencilOpZFail);
-    this.copyStencilArrayValue(this.prevStencilOpZPass, material.stencilOpZPass);
-    this.copyStencilArrayValue(this.prevStencilRef, material.stencilRef);
-    this.copyStencilArrayValue(this.prevStencilMask, material.stencilMask);
+    const prevStencilFunc = material.stencilFunc;
+    const prevStencilOpFail = material.stencilOpFail;
+    const prevStencilOpZFail = material.stencilOpZFail;
+    const prevStencilOpZPass = material.stencilOpZPass;
+    const prevStencilRef = material.stencilRef;
+    const prevStencilMask = material.stencilMask;
 
     this.setupMaskMaterial(material, maskRef);
     renderer.drawGeometry(geometry, worldMatrix, material, subMeshIndex);
 
-    material.colorMask = previousColorMask;
+    material.colorMask = prevColorMask;
     material.stencilTest = prevStencilTest;
-    material.stencilFunc = this.prevStencilFunc;
-    material.stencilOpFail = this.prevStencilOpFail;
-    material.stencilOpZFail = this.prevStencilOpZFail;
-    material.stencilOpZPass = this.prevStencilOpZPass;
-    material.stencilRef = this.prevStencilRef;
-    material.stencilMask = this.prevStencilMask;
+    material.stencilFunc = prevStencilFunc;
+    material.stencilOpFail = prevStencilOpFail;
+    material.stencilOpZFail = prevStencilOpZFail;
+    material.stencilOpZPass = prevStencilOpZPass;
+    material.stencilRef = prevStencilRef;
+    material.stencilMask = prevStencilMask;
   }
 
   /**
@@ -320,12 +312,4 @@ export class MaskProcessor {
     }
   }
 
-  private copyStencilArrayValue (target: [number, number], source: [number, number] | undefined): void {
-    if (!source) {
-      return;
-    }
-
-    target[0] = source[0];
-    target[1] = source[1];
-  }
 }

--- a/packages/effects-core/src/material/types.ts
+++ b/packages/effects-core/src/material/types.ts
@@ -106,6 +106,10 @@ export interface MaskReference {
   inverted: boolean,
 }
 
+/**
+ * @deprecated 2.10 起蒙版模式不再通过单一枚举表达，runtime 内部已不再使用此枚举。
+ * 仅为兼容旧版本对外导出的接口而保留，请改用 `MaskProcessor` 的多蒙版 API。
+ */
 export enum MaskMode {
   /**
    * 无
@@ -124,3 +128,4 @@ export enum MaskMode {
    */
   REVERSE_OBSCURED = 3,
 }
+

--- a/packages/effects-core/src/material/utils.ts
+++ b/packages/effects-core/src/material/utils.ts
@@ -89,6 +89,10 @@ export function setSideMode (material: Material, side: spec.SideMode) {
   }
 }
 
+/**
+ * @deprecated 2.10 起 runtime 内部已不再通过 `MaskMode` 设置模板测试参数。
+ * 仅为兼容旧版本对外导出的接口而保留，新代码请勿使用。
+ */
 export function setMaskMode (material: Material, maskMode: MaskMode) {
   switch (maskMode) {
     case undefined:
@@ -119,3 +123,4 @@ export function setMaskMode (material: Material, maskMode: MaskMode) {
       console.warn(`MaskMode ${maskMode} not in specification, please set stencil params seperately.`);
   }
 }
+

--- a/packages/effects-core/src/plugins/particle/particle-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/particle-mesh.ts
@@ -85,8 +85,6 @@ export interface ParticleMeshData {
 export interface ParticleMeshProps extends ParticleMeshData {
   renderMode?: number,
   blending?: number,
-  mask: number,
-  maskMode: number,
   side: number,
   transparentOcclusion?: boolean,
   matrix?: Matrix4,

--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -1000,8 +1000,6 @@ export class ParticleSystem extends Component implements Maskable {
       occlusion: !!renderer.occlusion,
       transparentOcclusion: !!renderer.transparentOcclusion,
       maxCount: options.maxCount,
-      mask: this.maskManager.getRefValue(),
-      maskMode: this.maskManager.maskMode,
       forceTarget,
       diffuse: renderer.texture ? this.engine.findObject(renderer.texture) : undefined,
       sizeOverLifetime: sizeOverLifetimeGetter,
@@ -1092,8 +1090,6 @@ export class ParticleSystem extends Component implements Maskable {
         lifetime: this.trails.lifetime,
         occlusion: !!trails.occlusion,
         transparentOcclusion: !!trails.transparentOcclusion,
-        mask: this.maskManager.getRefValue(),
-        maskMode: this.maskManager.maskMode,
       };
 
       if (trails.colorOverLifetime && trails.colorOverLifetime[0] === spec.ValueType.GRADIENT_COLOR) {

--- a/packages/effects-core/src/plugins/particle/trail-mesh.ts
+++ b/packages/effects-core/src/plugins/particle/trail-mesh.ts
@@ -30,9 +30,7 @@ export type TrailMeshProps = {
   occlusion: boolean,
   transparentOcclusion: boolean,
   lifetime: ValueGetter<number>,
-  mask: number,
   shaderCachePrefix: string,
-  maskMode: number,
   name: string,
 };
 

--- a/packages/effects-core/src/plugins/shape/shape-component.ts
+++ b/packages/effects-core/src/plugins/shape/shape-component.ts
@@ -7,7 +7,7 @@ import * as spec from '@galacean/effects-specification';
 import { effectsClass } from '../../decorators';
 import type { Engine } from '../../engine';
 import type { Maskable, MaterialProps } from '../../material';
-import { Material, MaskMode, getPreMultiAlpha, setBlendMode, setSideMode } from '../../material';
+import { Material, getPreMultiAlpha, setBlendMode, setSideMode } from '../../material';
 import type { Renderer } from '../../render';
 import { GLSLVersion, Geometry } from '../../render';
 import type { GradientValue, StrokeAttributes } from '../../math';
@@ -702,7 +702,6 @@ export class ShapeComponent extends RendererComponent implements Maskable {
 
     const renderer = rendererOptions;
     const { side, occlusion, blending: blendMode, texture } = renderer;
-    const maskMode = this.maskManager.maskMode;
 
     material.blending = true;
     material.depthTest = true;
@@ -721,7 +720,6 @@ export class ShapeComponent extends RendererComponent implements Maskable {
     texParams.x = renderer.occlusion ? +(renderer.transparentOcclusion) : 1;
     texParams.y = preMultiAlpha;
     texParams.z = renderer.renderMode;
-    texParams.w = maskMode;
     material.setVector4('_TexParams', texParams);
 
     if (texParams.x === 0 || (this.maskManager.alphaMaskEnabled)) {
@@ -748,9 +746,9 @@ export class ShapeComponent extends RendererComponent implements Maskable {
       blending: renderer.blending ?? spec.BlendingMode.ALPHA,
       texture: renderer.texture ? this.engine.findObject<Texture>(renderer.texture) : this.engine.whiteTexture,
       occlusion: !!renderer.occlusion,
-      transparentOcclusion: !!renderer.transparentOcclusion || (this.maskManager.maskMode === MaskMode.MASK),
+      transparentOcclusion: !!renderer.transparentOcclusion || this.maskManager.isMask,
       side: renderer.side ?? spec.SideMode.DOUBLE,
-      mask: this.maskManager.getRefValue(),
+      mask: 1,
     };
 
     this.strokeCap = data.strokeCap ?? spec.LineCap.Butt;

--- a/plugin-packages/spine/src/slot-group.ts
+++ b/plugin-packages/spine/src/slot-group.ts
@@ -20,10 +20,6 @@ export interface SlotGroupProps {
    * png 是否已经预乘 alpha
    */
   pma: boolean,
-  /**
-   * mask 和 renderer 相关参数
-   */
-  renderOptions: {},
   engine: Engine,
 }
 export class SlotGroup {
@@ -53,10 +49,6 @@ export class SlotGroup {
    * png 是否已经预乘 alpha
    */
   pma: boolean;
-  /**
-   * mask 相关参数
-   */
-  renderOptions: {};
   /**
    * 包含父节点的世界变换
    */
@@ -98,7 +90,6 @@ export class SlotGroup {
     this.transform = props.transform;
     this.listIndex = props.listIndex;
     this.pma = props.pma;
-    this.renderOptions = props.renderOptions;
     this.engine = props.engine;
   }
 
@@ -248,7 +239,6 @@ export class SlotGroup {
             texture,
             name: this.meshName,
             priority: this.listIndex += 0.01,
-            renderOptions: this.renderOptions,
             engine: this.engine,
           });
 

--- a/plugin-packages/spine/src/spine-component.ts
+++ b/plugin-packages/spine/src/spine-component.ts
@@ -2,10 +2,10 @@ import type { AnimationStateListener, SkeletonData, TextureAtlas, TrackEntry } f
 import { AnimationState, AnimationStateData, Physics, Skeleton } from '@esotericsoftware/spine-core';
 import type {
   BinaryAsset, BoundingBoxTriangle, Engine, HitTestTriangleParams, Maskable,
-  Renderer, Texture,
+  MaskMode, Renderer, Texture,
 } from '@galacean/effects';
 import {
-  effectsClass, HitTestType, MaskMode, math, PLAYER_OPTIONS_ENV_EDITOR, RendererComponent,
+  effectsClass, HitTestType, math, PLAYER_OPTIONS_ENV_EDITOR, RendererComponent,
   serialize, spec,
 } from '@galacean/effects';
 import { SlotGroup } from './slot-group';
@@ -84,9 +84,15 @@ export class SpineComponent extends RendererComponent implements Maskable {
   /**
    * renderer 和 mask 数据
    */
-  rendererOptions: Pick<spec.SpineComponent, 'renderer'> & {
-    maskMode: MaskMode,
-    mask: number,
+  rendererOptions: NonNullable<spec.SpineComponent['renderer']> & {
+    /**
+     * @deprecated 2.10 起此字段无实际意义，runtime 不再赋值，仅为兼容旧版本读取保留。
+     */
+    mask?: number,
+    /**
+     * @deprecated 2.10 起此字段无实际意义，runtime 不再赋值，仅为兼容旧版本读取保留。
+     */
+    maskMode?: MaskMode,
   };
   options: spec.PluginSpineOption;
 
@@ -120,17 +126,12 @@ export class SpineComponent extends RendererComponent implements Maskable {
     this.rendererOptions = {
       renderMode: spec.RenderMode.MESH,
       ...data.renderer || {},
-      mask: 0,
-      maskMode: MaskMode.NONE,
     };
     this.item.getHitTestParams = this.getHitTestParams.bind(this);
 
     if (data.mask) {
       this.maskManager.setMaskOptions(this.engine, data.mask);
     }
-
-    this.rendererOptions.maskMode = this.maskManager.maskMode;
-    this.rendererOptions.mask = this.maskManager.getRefValue();
     // 兼容编辑器逻辑
     if (!this.resource || !Object.keys(this.resource).length) {
       return;
@@ -269,7 +270,6 @@ export class SpineComponent extends RendererComponent implements Maskable {
       meshName: this.name,
       transform: this.transform,
       pma: this.pma,
-      renderOptions: this.rendererOptions,
       engine: this.engine,
     });
   }

--- a/plugin-packages/spine/src/spine-mesh.ts
+++ b/plugin-packages/spine/src/spine-mesh.ts
@@ -15,10 +15,6 @@ export interface SpineMeshRenderInfo {
   priority: number,
   blendMode: BlendMode,
   name?: string,
-  renderOptions: {
-    maskMode?: number,
-    mask?: number,
-  },
   engine: Engine,
 }
 
@@ -39,15 +35,14 @@ export class SpineMesh implements Disposable {
   priority: number;
 
   constructor (renderInfo: SpineMeshRenderInfo) {
-    const { blendMode, texture, priority, renderOptions = {}, name = 'MSpine', engine } = renderInfo;
-    const { mask = 0, maskMode = 0 } = renderOptions;
+    const { blendMode, texture, priority, name = 'MSpine', engine } = renderInfo;
 
     this.blendMode = blendMode;
     this.lastTexture = texture;
     this.priority = priority;
     this.engine = engine;
     this.geometry = this.createGeometry();
-    this.material = this.createMaterial(maskMode, mask);
+    this.material = this.createMaterial();
     this.mesh = Mesh.create(
       engine,
       {
@@ -93,7 +88,7 @@ export class SpineMesh implements Disposable {
       });
   }
 
-  createMaterial (maskMode: number, maskOrder: number): Material {
+  createMaterial (): Material {
     const material = Material.create(
       this.engine,
       {

--- a/web-packages/demo/html/multi-mask.html
+++ b/web-packages/demo/html/multi-mask.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>多蒙版遮罩示例 - demo</title>
+  <style>
+    html, body, div, canvas { margin: 0; padding: 0; }
+    .container {
+      width: 375px;
+      height: 812px;
+      background-color: rgba(0,0,0,255);
+    }
+  </style>
+</head>
+<body>
+<div class="container" id="J-container"></div>
+
+<script type="module" src="../src/multi-mask.ts"></script>
+</body>
+</html>

--- a/web-packages/demo/index.html
+++ b/web-packages/demo/index.html
@@ -17,9 +17,10 @@
     <a class="am-list-item" href="html/interactive.html">Interactive</a>
     <a class="am-list-item" href="html/compressed.html">压缩纹理</a>
     <a class="am-list-item" href="html/local-file.html">加载本地文件</a>
+    <a class="am-list-item" href="html/multi-mask.html">多蒙版遮罩</a>
     <a class="am-list-item" href="html/dynamic-image.html">动态换图</a>
     <a class="am-list-item" href="html/dynamic-video.html">动态视频</a>
-    <a class="am-list-item" href="html/render-level.html">分层渲染</a>
+    <a class="am-list-item" href="html/render-level.html">分层渲染</a>  
     <a class="am-list-item" href="html/text.html">文本元素</a>
     <a class="am-list-item" href="html/rich-text.html">富文本元素</a>
     <a class="am-list-item" href="html/dom-content.html">DOM Content 插件</a>

--- a/web-packages/demo/src/multi-mask.ts
+++ b/web-packages/demo/src/multi-mask.ts
@@ -1,0 +1,843 @@
+import type { Composition } from '@galacean/effects';
+import { Player, SpriteComponent, ShapeComponent } from '@galacean/effects';
+
+const container = document.getElementById('J-container');
+
+const json = `{
+  "playerVersion": {
+    "web": "2.8.11",
+    "native": "0.0.1.202311221223"
+  },
+  "images": [
+    {
+      "url": "https://mdn.alipayobjects.com/mars/afts/file/A*ku2GTJV7L3gAAAAARgAAAAgAelB4AQ/original",
+      "id": "ed01efe5c98441d5a22deb34eff6869b",
+      "renderLevel": "B+",
+      "webp": "https://mdn.alipayobjects.com/mars/afts/file/A*E7lJT7ojGesAAAAARpAAAAgAelB4AQ/original"
+    }
+  ],
+  "fonts": [],
+  "version": "3.6",
+  "plugins": [],
+  "type": "ge",
+  "compositions": [
+    {
+      "id": "31ec925ec0414adea5bd2d30b66b881b",
+      "name": "新建合成1",
+      "duration": 5,
+      "startTime": 0,
+      "endBehavior": 4,
+      "previewSize": [
+        750,
+        1624
+      ],
+      "camera": {
+        "fov": 60,
+        "far": 40,
+        "near": 0.1,
+        "clipMode": 1,
+        "position": [
+          0,
+          0,
+          8
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ]
+      },
+      "components": [
+        {
+          "id": "3ccdf734937843b98af0c918a8c393ae"
+        }
+      ]
+    }
+  ],
+  "components": [
+    {
+      "id": "3ccdf734937843b98af0c918a8c393ae",
+      "item": {
+        "id": "31ec925ec0414adea5bd2d30b66b881b"
+      },
+      "dataType": "CompositionComponent",
+      "items": [
+        {
+          "id": "43fe4b6a6fd7428898d471c58538232c"
+        },
+        {
+          "id": "e88a85b56204488d8ed5802076ca4eb9"
+        },
+        {
+          "id": "ccc03eabfa5c417a95cbf3e713925322"
+        }
+      ],
+      "timelineAsset": {
+        "id": "806e24e78d7647309aadda35bb3765b2"
+      },
+      "sceneBindings": [
+        {
+          "key": {
+            "id": "830d5930c44d4efab62267e8916b2343"
+          },
+          "value": {
+            "id": "43fe4b6a6fd7428898d471c58538232c"
+          }
+        },
+        {
+          "key": {
+            "id": "62f4fedb1e644f0daaa05c4b0c252149"
+          },
+          "value": {
+            "id": "e88a85b56204488d8ed5802076ca4eb9"
+          }
+        },
+        {
+          "key": {
+            "id": "cc7c0a7b5a4a41528db192c955bd6034"
+          },
+          "value": {
+            "id": "ccc03eabfa5c417a95cbf3e713925322"
+          }
+        }
+      ]
+    },
+    {
+      "id": "64b76dba8928479ba09e586397ed0171",
+      "item": {
+        "id": "43fe4b6a6fd7428898d471c58538232c"
+      },
+      "type": 2,
+      "dataType": "ShapeComponent",
+      "xRadius": 5.3571,
+      "yRadius": 3.7384,
+      "fills": [
+        {
+          "type": 0,
+          "color": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          }
+        }
+      ],
+      "strokes": [],
+      "strokeWidth": 0,
+      "strokeCap": 0,
+      "strokeJoin": 0,
+      "renderer": {
+        "renderMode": 1
+      },
+      "mask": {
+        "isMask": true,
+        "alphaMaskEnabled": false
+      }
+    },
+    {
+      "id": "b8d9e6dbd27f4e049a32ae78825d438c",
+      "item": {
+        "id": "e88a85b56204488d8ed5802076ca4eb9"
+      },
+      "type": 1,
+      "dataType": "ShapeComponent",
+      "width": 20.8118,
+      "height": 11.3309,
+      "roundness": 0,
+      "fills": [
+        {
+          "type": 0,
+          "color": {
+            "r": 0.03137,
+            "g": 0.01569,
+            "b": 0.3412,
+            "a": 1
+          }
+        }
+      ],
+      "strokes": [],
+      "strokeWidth": 0,
+      "strokeCap": 0,
+      "strokeJoin": 0,
+      "renderer": {
+        "renderMode": 1
+      },
+      "mask": {
+        "isMask": true,
+        "alphaMaskEnabled": false
+      }
+    },
+    {
+      "id": "d0e9461a95a24ff4a3e2c3100814f5c4",
+      "item": {
+        "id": "ccc03eabfa5c417a95cbf3e713925322"
+      },
+      "dataType": "SpriteComponent",
+      "options": {
+        "startColor": [
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "renderer": {
+        "renderMode": 1,
+        "texture": {
+          "id": "7113dc2ed8b54cebafeae57f7c4faa98"
+        }
+      },
+      "mask": {
+        "isMask": false,
+        "references": [
+          {
+            "mask": {
+              "id": "b8d9e6dbd27f4e049a32ae78825d438c"
+            },
+            "inverted": false
+          },
+          {
+            "mask": {
+              "id": "64b76dba8928479ba09e586397ed0171"
+            },
+            "inverted": false
+          }
+        ]
+      },
+      "splits": [
+        [
+          0,
+          0,
+          0.513671875,
+          0.513671875,
+          0
+        ]
+      ]
+    }
+  ],
+  "geometries": [],
+  "materials": [],
+  "items": [
+    {
+      "id": "43fe4b6a6fd7428898d471c58538232c",
+      "name": "ellipse_3",
+      "duration": 5,
+      "type": "shape",
+      "visible": true,
+      "endBehavior": 0,
+      "delay": 0,
+      "renderLevel": "B+",
+      "components": [
+        {
+          "id": "64b76dba8928479ba09e586397ed0171"
+        }
+      ],
+      "transform": {
+        "position": {
+          "x": 0,
+          "y": 1.7536,
+          "z": 0
+        },
+        "eulerHint": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "anchor": {
+          "x": 0,
+          "y": 0
+        },
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
+        }
+      },
+      "dataType": "VFXItemData"
+    },
+    {
+      "id": "e88a85b56204488d8ed5802076ca4eb9",
+      "name": "rectangle_5",
+      "duration": 5,
+      "type": "shape",
+      "visible": true,
+      "endBehavior": 0,
+      "delay": 0,
+      "renderLevel": "B+",
+      "components": [
+        {
+          "id": "b8d9e6dbd27f4e049a32ae78825d438c"
+        }
+      ],
+      "transform": {
+        "position": {
+          "x": 0,
+          "y": -2.7349,
+          "z": 0
+        },
+        "eulerHint": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "anchor": {
+          "x": 0,
+          "y": 0
+        },
+        "scale": {
+          "x": 0.4704,
+          "y": 0.6871,
+          "z": 1
+        }
+      },
+      "dataType": "VFXItemData"
+    },
+    {
+      "id": "ccc03eabfa5c417a95cbf3e713925322",
+      "name": "经典五福",
+      "duration": 5,
+      "type": "1",
+      "visible": true,
+      "endBehavior": 0,
+      "delay": 0,
+      "renderLevel": "B+",
+      "components": [
+        {
+          "id": "d0e9461a95a24ff4a3e2c3100814f5c4"
+        }
+      ],
+      "transform": {
+        "position": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "eulerHint": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "anchor": {
+          "x": 0,
+          "y": 0
+        },
+        "size": {
+          "x": 6.4719,
+          "y": 6.549
+        },
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
+        }
+      },
+      "dataType": "VFXItemData"
+    }
+  ],
+  "shaders": [],
+  "bins": [],
+  "textures": [
+    {
+      "id": "7113dc2ed8b54cebafeae57f7c4faa98",
+      "source": {
+        "id": "ed01efe5c98441d5a22deb34eff6869b"
+      },
+      "flipY": true
+    }
+  ],
+  "animations": [],
+  "miscs": [
+    {
+      "id": "806e24e78d7647309aadda35bb3765b2",
+      "dataType": "TimelineAsset",
+      "tracks": [
+        {
+          "id": "830d5930c44d4efab62267e8916b2343"
+        },
+        {
+          "id": "62f4fedb1e644f0daaa05c4b0c252149"
+        },
+        {
+          "id": "cc7c0a7b5a4a41528db192c955bd6034"
+        }
+      ]
+    },
+    {
+      "id": "0d9fb8e965784061a4198d912396d039",
+      "dataType": "ActivationPlayableAsset"
+    },
+    {
+      "id": "236999972a50472f960460eaa7f2db96",
+      "dataType": "TransformPlayableAsset",
+      "positionOverLifetime": {}
+    },
+    {
+      "id": "e97b723aaeaa4e6ea031dd38452ee11b",
+      "dataType": "ActivationTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 0,
+          "duration": 5,
+          "endBehavior": 0,
+          "asset": {
+            "id": "0d9fb8e965784061a4198d912396d039"
+          }
+        }
+      ]
+    },
+    {
+      "id": "fb74db9d4c47418d81c70a9e59d6a108",
+      "dataType": "TransformTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 0,
+          "duration": 5,
+          "endBehavior": 0,
+          "asset": {
+            "id": "236999972a50472f960460eaa7f2db96"
+          }
+        }
+      ]
+    },
+    {
+      "id": "830d5930c44d4efab62267e8916b2343",
+      "dataType": "ObjectBindingTrack",
+      "children": [
+        {
+          "id": "e97b723aaeaa4e6ea031dd38452ee11b"
+        },
+        {
+          "id": "fb74db9d4c47418d81c70a9e59d6a108"
+        }
+      ],
+      "clips": []
+    },
+    {
+      "id": "661bfcd2b221482fa20f5bc466163e8b",
+      "dataType": "ActivationPlayableAsset"
+    },
+    {
+      "id": "a204989b0dde405982ac0cd128dc8d1a",
+      "dataType": "TransformPlayableAsset",
+      "positionOverLifetime": {}
+    },
+    {
+      "id": "c7db73aef86c40c5ab2a5de31552d52e",
+      "dataType": "ActivationTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 0,
+          "duration": 5,
+          "endBehavior": 0,
+          "asset": {
+            "id": "661bfcd2b221482fa20f5bc466163e8b"
+          }
+        }
+      ]
+    },
+    {
+      "id": "94e40fce31a04cb7ad69d92a9bd70b4c",
+      "dataType": "TransformTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 0,
+          "duration": 5,
+          "endBehavior": 0,
+          "asset": {
+            "id": "a204989b0dde405982ac0cd128dc8d1a"
+          }
+        }
+      ]
+    },
+    {
+      "id": "62f4fedb1e644f0daaa05c4b0c252149",
+      "dataType": "ObjectBindingTrack",
+      "children": [
+        {
+          "id": "c7db73aef86c40c5ab2a5de31552d52e"
+        },
+        {
+          "id": "94e40fce31a04cb7ad69d92a9bd70b4c"
+        }
+      ],
+      "clips": []
+    },
+    {
+      "id": "bf3d80d697bc49b8b15ef4f9a596f2b1",
+      "dataType": "ActivationPlayableAsset"
+    },
+    {
+      "id": "d92ac9de77ed4fedba748db246a91a31",
+      "dataType": "TransformPlayableAsset",
+      "positionOverLifetime": {}
+    },
+    {
+      "id": "330359cb95e844efbb0d456d9d6be795",
+      "dataType": "SpriteColorPlayableAsset",
+      "startColor": [
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "id": "1412032de4bf47f185e10d0fcd94c4ec",
+      "dataType": "ActivationTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 0,
+          "duration": 5,
+          "endBehavior": 0,
+          "asset": {
+            "id": "bf3d80d697bc49b8b15ef4f9a596f2b1"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c317bdd348a14fcc9761573f1c21dbc7",
+      "dataType": "TransformTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 0,
+          "duration": 5,
+          "endBehavior": 0,
+          "asset": {
+            "id": "d92ac9de77ed4fedba748db246a91a31"
+          }
+        }
+      ]
+    },
+    {
+      "id": "8ef3c047a7fd4acd88dc0c01a7665fed",
+      "dataType": "SpriteColorTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 0,
+          "duration": 5,
+          "endBehavior": 0,
+          "asset": {
+            "id": "330359cb95e844efbb0d456d9d6be795"
+          }
+        }
+      ]
+    },
+    {
+      "id": "cc7c0a7b5a4a41528db192c955bd6034",
+      "dataType": "ObjectBindingTrack",
+      "children": [
+        {
+          "id": "1412032de4bf47f185e10d0fcd94c4ec"
+        },
+        {
+          "id": "c317bdd348a14fcc9761573f1c21dbc7"
+        },
+        {
+          "id": "8ef3c047a7fd4acd88dc0c01a7665fed"
+        }
+      ],
+      "clips": []
+    }
+  ],
+  "compositionId": "31ec925ec0414adea5bd2d30b66b881b"
+}
+`;
+
+let currentPlayer: Player | null = null;
+
+const legacyJsonUrl = 'https://mdn.alipayobjects.com/mars/afts/file/A*JtRGQoWcN8UAAAAAQGAAAAgAelB4AQ';
+const rectangleMaskId = 'b8d9e6dbd27f4e049a32ae78825d438c';
+const ellipseMaskId = '64b76dba8928479ba09e586397ed0171';
+const wufuComponentId = 'd0e9461a95a24ff4a3e2c3100814f5c4';
+const buttonStyle = 'background:#4a90d9;color:#fff;border:none;padding:6px 12px;border-radius:4px;cursor:pointer;font-size:14px;';
+const activeButtonStyle = 'background:#f5a623;color:#111;border:none;padding:6px 12px;border-radius:4px;cursor:pointer;font-size:14px;';
+
+type MaskRefOptions = {
+  id: string,
+  inverted?: boolean,
+};
+
+type MaskDemoComponents = {
+  rectangle: ShapeComponent,
+  ellipse: ShapeComponent,
+  wufu: SpriteComponent,
+};
+
+function resetPlayer () {
+  if (currentPlayer) {
+    currentPlayer.dispose();
+  }
+
+  currentPlayer = new Player({
+    container,
+    interactive: true,
+    transparentBackground: true,
+    onError: (err, ...args) => {
+      console.error(err.message);
+    },
+  });
+}
+
+function cloneSceneJSON (): any {
+  return JSON.parse(json);
+}
+
+function getWufuComponentData (sceneData: any): any {
+  return sceneData.components.find((component: any) => component.id === wufuComponentId);
+}
+
+function createMaskReference (options: MaskRefOptions): any {
+  return {
+    mask: {
+      id: options.id,
+    },
+    inverted: !!options.inverted,
+  };
+}
+
+function createSceneWithReferences (references: MaskRefOptions[]): any {
+  const sceneData = cloneSceneJSON();
+  const wufuComponent = getWufuComponentData(sceneData);
+
+  wufuComponent.mask = {
+    isMask: false,
+    references: references.map(createMaskReference),
+  };
+
+  return sceneData;
+}
+
+function createSceneWithLegacyReference (id: string, inverted = false): any {
+  const sceneData = cloneSceneJSON();
+  const wufuComponent = getWufuComponentData(sceneData);
+
+  wufuComponent.mask = {
+    isMask: false,
+    reference: {
+      id,
+    },
+    inverted,
+  };
+
+  return sceneData;
+}
+
+async function loadSceneData (sceneData: any): Promise<Composition> {
+  resetPlayer();
+
+  const composition = await currentPlayer?.loadScene(sceneData);
+
+  if (!composition) {
+    throw new Error('Load scene failed.');
+  }
+
+  return composition;
+}
+
+function getMaskDemoComponents (composition: Composition): MaskDemoComponents {
+  const rectangleItem = composition.getItemByName('rectangle_5');
+  const ellipseItem = composition.getItemByName('ellipse_3');
+  const wufuItem = composition.getItemByName('经典五福');
+
+  if (!rectangleItem || !ellipseItem || !wufuItem) {
+    throw new Error('Missing demo items.');
+  }
+
+  const rectangle = rectangleItem.getComponent(ShapeComponent);
+  const ellipse = ellipseItem.getComponent(ShapeComponent);
+  const wufu = wufuItem.getComponent(SpriteComponent);
+
+  if (!rectangle || !ellipse || !wufu) {
+    throw new Error('Missing demo components.');
+  }
+
+  rectangle.maskManager.isMask = true;
+  ellipse.maskManager.isMask = true;
+
+  return {
+    rectangle,
+    ellipse,
+    wufu,
+  };
+}
+
+async function loadWithDynamicMask (configure: (components: MaskDemoComponents) => void): Promise<void> {
+  const composition = await loadSceneData(cloneSceneJSON());
+  const components = getMaskDemoComponents(composition);
+
+  components.wufu.maskManager.clearMaskReferences();
+  configure(components);
+}
+
+async function loadWithOldJson (): Promise<void> {
+  resetPlayer();
+  await currentPlayer?.loadScene(legacyJsonUrl);
+}
+
+async function runMaskCase (run: () => Promise<unknown>, expectedText: string, button: HTMLButtonElement): Promise<void> {
+  expectedEl.textContent = expectedText;
+  statusEl.textContent = '加载中...';
+  setActiveButton(button);
+
+  try {
+    await run();
+    statusEl.textContent = '已加载';
+  } catch (error) {
+    statusEl.textContent = '加载失败，请查看控制台';
+    console.error('multi-mask demo failed:', error);
+  }
+}
+
+const controlPanel = document.createElement('div');
+
+controlPanel.style.cssText = 'position:fixed;top:10px;left:10px;max-width:350px;display:flex;flex-direction:column;gap:8px;background:rgba(0,0,0,0.7);color:#fff;padding:8px 12px;border-radius:4px;font-size:14px;z-index:9999;';
+
+const modeRow = document.createElement('div');
+
+modeRow.style.cssText = 'display:flex;align-items:center;gap:8px;flex-wrap:wrap;';
+
+const legacyRow = document.createElement('div');
+
+legacyRow.style.cssText = 'display:flex;flex-direction:column;gap:4px;line-height:1.5;';
+
+const expectedEl = document.createElement('span');
+const statusEl = document.createElement('span');
+
+expectedEl.textContent = '';
+statusEl.textContent = '';
+
+legacyRow.appendChild(expectedEl);
+legacyRow.appendChild(statusEl);
+
+controlPanel.appendChild(modeRow);
+controlPanel.appendChild(legacyRow);
+
+document.body.appendChild(controlPanel);
+
+const buttons: HTMLButtonElement[] = [];
+
+function setActiveButton (activeButton: HTMLButtonElement): void {
+  for (const button of buttons) {
+    button.style.cssText = button === activeButton ? activeButtonStyle : buttonStyle;
+  }
+}
+
+const maskCases = [
+  {
+    label: '旧 JSON 兼容',
+    expected: '预期：图片只显示旧数据里的矩形遮罩区域',
+    run: loadWithOldJson,
+  },
+  {
+    label: 'JSON 单矩形',
+    expected: '预期：图片只显示矩形区域',
+    run: () => loadSceneData(createSceneWithReferences([{ id: rectangleMaskId }])),
+  },
+  {
+    label: 'JSON 交集',
+    expected: '预期：图片只显示矩形和椭圆的交集区域',
+    run: () => loadSceneData(createSceneWithReferences([{ id: rectangleMaskId }, { id: ellipseMaskId }])),
+  },
+  {
+    label: 'JSON 反向',
+    expected: '预期：图片显示矩形区域，但挖掉椭圆区域',
+    run: () => loadSceneData(createSceneWithReferences([{ id: rectangleMaskId }, { id: ellipseMaskId, inverted: true }])),
+  },
+  {
+    label: 'JSON 仅反向',
+    expected: '预期：图片显示在椭圆外侧，椭圆区域被排除',
+    run: () => loadSceneData(createSceneWithReferences([{ id: ellipseMaskId, inverted: true }])),
+  },
+  {
+    label: 'JSON 空引用',
+    expected: '预期：references 为空数组等价于无蒙版，图片完整显示',
+    run: () => loadSceneData(createSceneWithReferences([])),
+  },
+  {
+    label: 'JSON 引用缺失',
+    expected: '预期：引用不存在的 id 被跳过并打印警告，图片只显示矩形区域',
+    run: () => loadSceneData(createSceneWithReferences([
+      { id: rectangleMaskId },
+      { id: 'non-existent-mask-id' },
+    ])),
+  },
+  {
+    label: '旧 reference',
+    expected: '预期：使用旧 mask.reference 字段，图片只显示矩形区域',
+    run: () => loadSceneData(createSceneWithLegacyReference(rectangleMaskId)),
+  },
+  {
+    label: '动态交集',
+    expected: '预期：通过 addMaskReference 动态添加，图片只显示矩形和椭圆交集',
+    run: () => loadWithDynamicMask(({ rectangle, ellipse, wufu }) => {
+      wufu.maskManager.addMaskReference(rectangle);
+      wufu.maskManager.addMaskReference(ellipse);
+    }),
+  },
+  {
+    label: '动态移除',
+    expected: '预期：先添加两个蒙版再移除椭圆，图片只显示矩形区域',
+    run: () => loadWithDynamicMask(({ rectangle, ellipse, wufu }) => {
+      wufu.maskManager.addMaskReference(rectangle);
+      wufu.maskManager.addMaskReference(ellipse);
+      wufu.maskManager.removeMaskReference(ellipse);
+    }),
+  },
+  {
+    label: '动态清空',
+    expected: '预期：添加后 clearMaskReferences，图片完整显示',
+    run: () => loadWithDynamicMask(({ rectangle, ellipse, wufu }) => {
+      wufu.maskManager.addMaskReference(rectangle);
+      wufu.maskManager.addMaskReference(ellipse);
+      wufu.maskManager.clearMaskReferences();
+    }),
+  },
+  {
+    label: '动态反向',
+    expected: '预期：先移除再反向添加椭圆，图片显示矩形区域但挖掉椭圆',
+    run: () => loadWithDynamicMask(({ rectangle, ellipse, wufu }) => {
+      wufu.maskManager.addMaskReference(rectangle);
+      wufu.maskManager.addMaskReference(ellipse);
+      wufu.maskManager.removeMaskReference(ellipse);
+      wufu.maskManager.addMaskReference(ellipse, true);
+    }),
+  },
+  {
+    label: '重复 add',
+    expected: '预期：重复添加同一矩形不会更新 inverted，图片仍只显示矩形区域',
+    run: () => loadWithDynamicMask(({ rectangle, wufu }) => {
+      wufu.maskManager.addMaskReference(rectangle);
+      wufu.maskManager.addMaskReference(rectangle, true);
+    }),
+  },
+  {
+    label: 'JSON 去重',
+    expected: '预期：references 内重复引用同一矩形会被去重，图片只显示矩形区域',
+    run: () => loadSceneData(createSceneWithReferences([
+      { id: rectangleMaskId },
+      { id: rectangleMaskId },
+    ])),
+  },
+];
+
+for (const maskCase of maskCases) {
+  const button = document.createElement('button');
+
+  button.textContent = maskCase.label;
+  button.style.cssText = buttonStyle;
+  button.onclick = () => runMaskCase(maskCase.run, maskCase.expected, button);
+  buttons.push(button);
+  modeRow.appendChild(button);
+}
+
+(async () => {
+  buttons[0].click();
+})();

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -1,246 +1,33 @@
+import type { Composition } from '@galacean/effects';
 import { Player } from '@galacean/effects';
 import '@galacean/effects-plugin-multimedia';
 
-const json = `{
-  "playerVersion": {
-    "web": "2.6.0",
-    "native": "0.0.1.202311221223"
-  },
-  "images": [],
-  "fonts": [],
-  "version": "3.3",
-  "shapes": [],
-  "plugins": [
-    "video"
-  ],
-  "type": "ge",
-  "compositions": [
-    {
-      "id": "90d8fafaf2db4bb09d85d0805da15632",
-      "name": "刷剧",
-      "duration": 3.67,
-      "endBehavior": 0,
-      "previewSize": [750, 1624],
-      "camera": {
-        "fov": 60,
-        "far": 40,
-        "near": 0.1,
-        "clipMode": 1,
-        "position": [0, 0, 8],
-        "rotation": [0, 0, 0]
-      },
-      "sceneBindings": [
-        {
-          "key": {
-            "id": "fdc939b293b241da86f87ed949dd301c"
-          },
-          "value": {
-            "id": "61995ad967654622a2d0b38444540cc3"
-          }
-        }
-      ],
-      "timelineAsset": {
-        "id": "a37092b85e4f4309a5138ae755437159"
-      },
-      "items": [
-        {
-          "id": "61995ad967654622a2d0b38444540cc3"
-        }
-      ],
-      "startTime": 0
-    }
-  ],
-  "components": [
-    {
-      "id": "fe4c8335fd564e96b167ef1475d7a230",
-      "item": {
-        "id": "61995ad967654622a2d0b38444540cc3"
-      },
-      "dataType": "VideoComponent",
-      "options": {
-        "startColor": [1, 1, 1, 1],
-        "muted": true,
-        "video": {
-          "id": "e38870f6cc7c4a689b07ea6adb33d3a0"
-        },
-        "volume": 1,
-        "playbackRate": 1,
-        "transparent": true
-      },
-      "renderer": {
-        "renderMode": 1,
-        "texture": {
-          "id": "e688285a65e446679b21dce4d07cef18"
-        }
-      }
-    }
-  ],
-  "geometries": [],
-  "materials": [],
-  "items": [
-    {
-      "id": "61995ad967654622a2d0b38444540cc3",
-      "name": "video_2",
-      "duration": 3.6667,
-      "type": "video",
-      "visible": true,
-      "endBehavior": 0,
-      "delay": 0,
-      "renderLevel": "B+",
-      "components": [
-        {
-          "id": "fe4c8335fd564e96b167ef1475d7a230"
-        }
-      ],
-      "transform": {
-        "position": {
-          "x": 0,
-          "y": 0,
-          "z": 0
-        },
-        "eulerHint": {
-          "x": 0,
-          "y": 0,
-          "z": 0
-        },
-        "anchor": {
-          "x": 0,
-          "y": 0
-        },
-        "size": {
-          "x": 9.2272,
-          "y": 15.8638
-        },
-        "scale": {
-          "x": 1,
-          "y": 1,
-          "z": 1
-        }
-      },
-      "dataType": "VFXItemData"
-    }
-  ],
-  "shaders": [],
-  "bins": [],
-  "textures": [
-    {
-      "id": "e688285a65e446679b21dce4d07cef18",
-      "source": {
-        "id": "e38870f6cc7c4a689b07ea6adb33d3a0"
-      },
-      "flipY": true
-    }
-  ],
-  "miscs": [
-    {
-      "id": "a37092b85e4f4309a5138ae755437159",
-      "dataType": "TimelineAsset",
-      "tracks": [
-        {
-          "id": "fdc939b293b241da86f87ed949dd301c"
-        }
-      ]
-    },
-    {
-      "id": "0733d8fd69364be9aa870371eab47396",
-      "dataType": "ActivationPlayableAsset"
-    },
-    {
-      "id": "5a80b4db21ba4cddb32af23c1c063eb3",
-      "dataType": "TransformPlayableAsset",
-      "positionOverLifetime": {
-
-      }
-    },
-    {
-      "id": "a43e46972361480da6d9ba8b3d28f3bf",
-      "dataType": "SpriteColorPlayableAsset",
-      "startColor": [1, 1, 1, 1]
-    },
-    {
-      "id": "bd2c1b14a4fe42fe8a3a5780200ce262",
-      "dataType": "ActivationTrack",
-      "children": [],
-      "clips": [
-        {
-          "start": 0,
-          "duration": 3.6667,
-          "endBehavior": 0,
-          "asset": {
-            "id": "0733d8fd69364be9aa870371eab47396"
-          }
-        }
-      ]
-    },
-    {
-      "id": "cae6956db3ad41669835dfa08120eebc",
-      "dataType": "TransformTrack",
-      "children": [],
-      "clips": [
-        {
-          "start": 0,
-          "duration": 3.6667,
-          "endBehavior": 0,
-          "asset": {
-            "id": "5a80b4db21ba4cddb32af23c1c063eb3"
-          }
-        }
-      ]
-    },
-    {
-      "id": "27775d50e1f944718d67662982c62fcf",
-      "dataType": "SpriteColorTrack",
-      "children": [],
-      "clips": [
-        {
-          "start": 0,
-          "duration": 3.6667,
-          "endBehavior": 0,
-          "asset": {
-            "id": "a43e46972361480da6d9ba8b3d28f3bf"
-          }
-        }
-      ]
-    },
-    {
-      "id": "fdc939b293b241da86f87ed949dd301c",
-      "dataType": "ObjectBindingTrack",
-      "children": [
-        {
-          "id": "bd2c1b14a4fe42fe8a3a5780200ce262"
-        },
-        {
-          "id": "cae6956db3ad41669835dfa08120eebc"
-        },
-        {
-          "id": "27775d50e1f944718d67662982c62fcf"
-        }
-      ],
-      "clips": []
-    }
-  ],
-  "compositionId": "90d8fafaf2db4bb09d85d0805da15632",
-  "videos": [
-    {
-      "id": "e38870f6cc7c4a689b07ea6adb33d3a0",
-      "hevc": {
-          "url": "http://vod.alipayobjects.com/VIDEO_CONVERT/afts/video/A*Sd-lQ4WM73AAAAAAgBAAAAgAesF2AQ/720P_h265?t=MhDiXxh9eg_NmXTpMp7COqaWShflfMHNlzZp8IsNe5wDAAAAAAAAAABpMmVA",
-          "codec": "L63"
-        },
-      "url": "https://mdn.alipayobjects.com/graph_jupiter/afts/file/A*j8OtQY4vpr0AAAAAgBAAAAgAesF2AQ"
-    }
-  ]
-}`;
 const container = document.getElementById('J-container');
 
-(async () => {
-  const player = new Player({
-    container,
-    pixelRatio: window.devicePixelRatio,
-    onError: (err, ...args) => {
-      console.error('biz', err.message);
-    },
-  });
+const sceneUrls = [
+  'https://mdn.alipayobjects.com/mars/afts/file/A*T--xQLRquWIAAAAAQDAAAAgAelB4AQ',
+  'https://mdn.alipayobjects.com/mars/afts/file/A*0bhFRY1b4_oAAAAAQDAAAAgAelB4AQ',
+  'https://mdn.alipayobjects.com/mars/afts/file/A*S65MSZtdKdMAAAAAQDAAAAgAelB4AQ',
+];
 
-  await player.loadScene(JSON.parse(json), { useHevcVideo: true });
+(async () => {
+  try {
+    const player = new Player({ container });
+    let prev: Composition | undefined;
+
+    for (const url of sceneUrls) {
+      const composition = await player.loadScene(url);
+
+      prev?.dispose();
+      prev = composition;
+
+      await new Promise<void>(resolve => {
+        composition.on('end', () => resolve());
+      });
+    }
+
+    prev?.dispose();
+  } catch (e) {
+    console.error('biz', e);
+  }
 })();

--- a/web-packages/test/unit/src/effects-core/mask-processor.spec.ts
+++ b/web-packages/test/unit/src/effects-core/mask-processor.spec.ts
@@ -1,5 +1,5 @@
 import type { Engine, Renderer } from '@galacean/effects-core';
-import { MaskProcessor, MaskMode, glContext, SpriteComponent, math, VFXItem, Material } from '@galacean/effects-core';
+import { MaskProcessor, glContext, SpriteComponent, math, VFXItem, Material } from '@galacean/effects-core';
 import { GLEngine, GLGeometry } from '@galacean/effects-webgl';
 
 const { expect } = chai;
@@ -80,8 +80,6 @@ describe('core/material//mask-ref-manager', () => {
 
       expect(mp.alphaMaskEnabled).to.eql(false);
       expect(mp.isMask).to.eql(false);
-      expect(mp.inverted).to.eql(false);
-      expect(mp.maskMode).to.eql(MaskMode.NONE);
     });
 
   });
@@ -227,6 +225,21 @@ describe('core/material//mask-ref-manager', () => {
       expect(material.stencilTest).to.eql(false);
     });
 
+    it('should not remove existing references that are also frame clip masks', () => {
+      const mp = new MaskProcessor();
+      const sprite = createMaskableSprite(engine);
+      const material = new Material(engine, { shader: { vertex: vs, fragment: fs } });
+      const component = createSpriteRendererComponent(engine, [material]);
+
+      mp.addMaskReference(sprite);
+      component.frameClipMasks = [sprite];
+
+      mp.drawStencilMask(renderer, component);
+
+      expect(mp.getMaskReferences().length).to.eql(1);
+      expect(mp.getMaskReferences()[0].maskable).to.equal(sprite);
+    });
+
     it('should setup multiple materials', () => {
       const mp = new MaskProcessor();
       const sprite = createMaskableSprite(engine);
@@ -286,6 +299,8 @@ describe('core/material//mask-ref-manager', () => {
       material.colorMask = true;
       material.stencilTest = false;
       material.stencilFunc = [glContext.ALWAYS, glContext.ALWAYS];
+      material.stencilOpFail = [glContext.REPLACE, glContext.REPLACE];
+      material.stencilOpZFail = [glContext.DECR, glContext.DECR];
       material.stencilOpZPass = [glContext.KEEP, glContext.KEEP];
       material.stencilRef = [0, 0];
       material.stencilMask = [0xFF, 0xFF];
@@ -297,6 +312,8 @@ describe('core/material//mask-ref-manager', () => {
       expect(material.colorMask).to.eql(true);
       expect(material.stencilTest).to.eql(false);
       expect(material.stencilFunc).to.deep.equals([glContext.ALWAYS, glContext.ALWAYS]);
+      expect(material.stencilOpFail).to.deep.equals([glContext.REPLACE, glContext.REPLACE]);
+      expect(material.stencilOpZFail).to.deep.equals([glContext.DECR, glContext.DECR]);
       expect(material.stencilOpZPass).to.deep.equals([glContext.KEEP, glContext.KEEP]);
       expect(material.stencilRef).to.deep.equals([0, 0]);
       expect(material.stencilMask).to.deep.equals([0xFF, 0xFF]);
@@ -308,35 +325,86 @@ describe('core/material//mask-ref-manager', () => {
   // ==================== setMaskOptions ====================
 
   describe('setMaskOptions', () => {
-    it('should set maskMode to MASK when isMask is true', () => {
+    it('should set isMask to true when isMask is passed', () => {
       const mp = new MaskProcessor();
 
-      mp.setMaskOptions(engine, { isMask: true, reference: dummyRef });
+      mp.setMaskOptions(engine, { isMask: true });
 
       expect(mp.isMask).to.eql(true);
-      expect(mp.maskMode).to.eql(MaskMode.MASK);
     });
 
-    it('should set maskMode to OBSCURED when isMask is false and inverted is false', () => {
+    it('should handle references array with single forward mask', () => {
       const mp = new MaskProcessor();
+      const existingMask = engine.findObject<SpriteComponent>(dummyRef);
 
-      mp.setMaskOptions(engine, { isMask: false, inverted: false, reference: dummyRef });
+      mp.setMaskOptions(engine, {
+        isMask: false,
+        references: [{ mask: dummyRef, inverted: false }],
+      });
 
-      expect(mp.maskMode).to.eql(MaskMode.OBSCURED);
+      expect(mp.getMaskReferences().length).to.eql(1);
+      expect(mp.getMaskReferences()[0].inverted).to.eql(false);
     });
 
-    it('should set maskMode to REVERSE_OBSCURED when inverted is true', () => {
+    it('should handle references array with single reverse mask', () => {
+      const mp = new MaskProcessor();
+      const existingMask = engine.findObject<SpriteComponent>(dummyRef);
+
+      mp.setMaskOptions(engine, {
+        isMask: false,
+        references: [{ mask: dummyRef, inverted: true }],
+      });
+
+      expect(mp.getMaskReferences().length).to.eql(1);
+      expect(mp.getMaskReferences()[0].inverted).to.eql(true);
+    });
+
+    it('should skip references without mask path', () => {
       const mp = new MaskProcessor();
 
-      mp.setMaskOptions(engine, { isMask: false, inverted: true, reference: dummyRef });
+      mp.setMaskOptions(engine, {
+        isMask: false,
+        references: [{ inverted: false }],
+      });
 
-      expect(mp.maskMode).to.eql(MaskMode.REVERSE_OBSCURED);
+      expect(mp.getMaskReferences().length).to.eql(0);
+    });
+
+    it('should warn and cap when mask references exceed the stencil limit', () => {
+      const mp = new MaskProcessor();
+      const references = Array.from({ length: 256 }, (_, i) => {
+        const id = `cap-mask-${i}`;
+        const sprite = createMaskableSprite(engine, id);
+
+        sprite.setInstanceId(id);
+
+        return { mask: { id }, inverted: false };
+      });
+
+      mp.setMaskOptions(engine, {
+        isMask: false,
+        references,
+      });
+
+      expect(mp.getMaskReferences().length).to.eql(254);
+    });
+
+    it('should deduplicate references pointing to the same maskable', () => {
+      const mp = new MaskProcessor();
+      const references = Array.from({ length: 5 }, () => ({ mask: dummyRef, inverted: false }));
+
+      mp.setMaskOptions(engine, {
+        isMask: false,
+        references,
+      });
+
+      expect(mp.getMaskReferences().length).to.eql(1);
     });
 
     it('should set alphaMaskEnabled', () => {
       const mp = new MaskProcessor();
 
-      mp.setMaskOptions(engine, { alphaMaskEnabled: true, reference: dummyRef });
+      mp.setMaskOptions(engine, { alphaMaskEnabled: true });
 
       expect(mp.alphaMaskEnabled).to.eql(true);
     });
@@ -351,7 +419,7 @@ describe('core/material//mask-ref-manager', () => {
       mp.addMaskReference(sprite1);
       mp.addMaskReference(sprite2);
 
-      mp.setMaskOptions(engine, { isMask: true, reference: dummyRef });
+      mp.setMaskOptions(engine, { isMask: true });
       mp.drawStencilMask(renderer, component);
       expect(material.stencilTest).to.eql(false);
     });


### PR DESCRIPTION
Summary
Add support for multiple mask references per component, replacing the previous single-mask model. A component can now be clipped by multiple masks simultaneously (intersection of forward masks, with optional inverted masks to punch holes).

Core Changes (effects-core)
* MaskProcessor (mask-ref-manager.ts): Refactored to manage a list of MaskReference[] instead of a single maskable. 
* Supports forward/inverted masks, deduplication, reference count capping (254 max), and per-frame stencil rendering with multi-pass write.
* setMaskOptions: Accepts the new references[] array format. Resolves mask paths via engine.findObject, warns on missing references, and deduplicates by maskable identity.
* Migration (migration.ts): Converts legacy formats to the new references[] structure:
* Old renderer.maskMode (MASK/OBSCURED/REVERSE_OBSCURED) → resolved via sequential traversal with currentMaskComponentId
* Old mask.reference + mask.inverted → wrapped into references[{ mask, inverted }]
* Backward compatibility: MaskMode enum and setMaskMode() function retained with @deprecated 2.10 annotations — old users importing these symbols will not get compile errors on upgrade.
* Dead code cleanup: Removed unused mask/maskMode fields from ParticleMeshProps, TrailMeshProps (were written but never read).

Spine Plugin (plugin-packages/spine)
* SpineComponent.rendererOptions: Type updated to match runtime reality (flat structure). Added mask?/maskMode? as optional @deprecated 2.10 fields for backward compatibility.
* SpineMesh / SlotGroup: Removed the dead renderOptions pass-through chain entirely (SpineMeshRenderInfo.renderOptions → SlotGroup.renderOptions → constructor params → createMaterial args were all unused).

Demo & Tests
* New multi-mask demo (web-packages/demo): 14 interactive cases covering JSON declarations (single/intersection/inverted/empty/missing-ref/dedup), legacy format migration, and dynamic API (addMaskReference/removeMaskReference/clearMaskReferences). IDs resolved dynamically by item name for portability across different JSON files.
* Unit tests (mask-processor.spec.ts): Added tests for setMaskOptions with references array, deduplication, stencil limit capping, and re-initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-mask rendering via reference-based mask options, including dynamic add/remove/clear behavior.
  * Added a standalone multi-mask demo showcasing reference and legacy handling.
* **Deprecations**
  * Deprecated single `MaskMode`/mask-mode runtime usage in favor of the multi-mask reference API, with updated JSDoc guidance.
  * Mask-related props were removed from particle and trail components; legacy mask fields in the spine layer are now marked deprecated.
* **Bug Fixes**
  * Improved stencil/material state preservation during mask passes.
  * More robust legacy mask migration and missing/duplicate reference handling.
* **Tests**
  * Updated and expanded mask processor unit tests for the new reference-based model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->