### PR TITLE
feat: default to preferred KTX2 and HEVC assets

### DIFF
--- a/packages/effects-core/src/asset-manager.ts
+++ b/packages/effects-core/src/asset-manager.ts
@@ -109,11 +109,15 @@ export class AssetManager implements Disposable {
   }
 
   updateOptions (options: SceneLoadOptions = {}) {
-    this.options = options;
-    if (!options.pluginData) {
-      options.pluginData = {};
+    this.options = {
+      ...options,
+      useCompressedTexture: options.useCompressedTexture ?? true,
+      useHevcVideo: options.useHevcVideo ?? true,
+    };
+    if (!this.options.pluginData) {
+      this.options.pluginData = {};
     }
-    const { timeout = 10 } = options;
+    const { timeout = 10 } = this.options;
 
     this.timeout = timeout;
   }
@@ -284,7 +288,19 @@ export class AssetManager implements Disposable {
     canUseKTX2 = false,
   ): Promise<ImageLike[]> {
     const { useCompressedTexture, variables, disableWebP, disableAVIF } = this.options;
+    const isKTX2LoaderRegistered = textureLoaderRegistry.has('ktx2');
+    const canUseCompressedTexture = useCompressedTexture && canUseKTX2 && isKTX2LoaderRegistered;
     const baseUrl = this.baseUrl;
+
+    if (
+      useCompressedTexture &&
+      canUseKTX2 &&
+      !isKTX2LoaderRegistered &&
+      images.some(img => 'ktx2' in img && img.ktx2)
+    ) {
+      logger.error('KTX2 texture exists but KTX2 loader is not registered. Import "@galacean/effects-plugin-ktx2" to enable compressed textures.');
+    }
+
     const jobs = images.map(async (img, idx: number) => {
       const { url: png, webp, avif } = img;
       const { ktx2 } = img as spec.CompressedImage;
@@ -295,7 +311,7 @@ export class AssetManager implements Disposable {
       // eslint-disable-next-line compat/compat
       const avifURL = (!disableAVIF && avif) ? new URL(avif, baseUrl).href : undefined;
       // eslint-disable-next-line compat/compat
-      const ktx2URL = (ktx2 && useCompressedTexture && canUseKTX2) ? new URL(ktx2, baseUrl).href : undefined;
+      const ktx2URL = (ktx2 && canUseCompressedTexture) ? new URL(ktx2, baseUrl).href : undefined;
 
       const id = img.id;
 

--- a/packages/effects-core/src/asset-manager.ts
+++ b/packages/effects-core/src/asset-manager.ts
@@ -288,17 +288,17 @@ export class AssetManager implements Disposable {
     canUseKTX2 = false,
   ): Promise<ImageLike[]> {
     const { useCompressedTexture, variables, disableWebP, disableAVIF } = this.options;
-    const isKTX2LoaderRegistered = textureLoaderRegistry.has('ktx2');
-    const canUseCompressedTexture = useCompressedTexture && canUseKTX2 && isKTX2LoaderRegistered;
+    const isKTX2PluginRegistered = !!pluginLoaderMap.ktx2;
+    const canUseCompressedTexture = useCompressedTexture && canUseKTX2 && isKTX2PluginRegistered;
     const baseUrl = this.baseUrl;
 
     if (
       useCompressedTexture &&
       canUseKTX2 &&
-      !isKTX2LoaderRegistered &&
+      !isKTX2PluginRegistered &&
       images.some(img => 'ktx2' in img && img.ktx2)
     ) {
-      logger.error('KTX2 texture exists but KTX2 loader is not registered. Import "@galacean/effects-plugin-ktx2" to enable compressed textures.');
+      logger.error('The plugin \'ktx2\' not found.' + getPluginUsageInfo('ktx2'));
     }
 
     const jobs = images.map(async (img, idx: number) => {

--- a/packages/effects-core/src/asset-manager.ts
+++ b/packages/effects-core/src/asset-manager.ts
@@ -298,7 +298,7 @@ export class AssetManager implements Disposable {
       !isKTX2PluginRegistered &&
       images.some(img => 'ktx2' in img && img.ktx2)
     ) {
-      logger.error('The plugin \'ktx2\' not found.' + getPluginUsageInfo('ktx2'));
+      logger.warn('The plugin \'ktx2\' is not found, unable to use compressed textures.' + getPluginUsageInfo('ktx2'));
     }
 
     const jobs = images.map(async (img, idx: number) => {

--- a/packages/effects-core/src/scene.ts
+++ b/packages/effects-core/src/scene.ts
@@ -80,14 +80,17 @@ export interface SceneLoadOptions {
   variables?: spec.TemplateVariables,
 
   /**
-   * 是否使用压缩纹理
-   * @default undefined
+   * 是否优先使用压缩纹理
+   * 当资源存在且当前环境支持时使用，否则回退到普通图片
+   * 需要注册 KTX2 loader，例如 import '@galacean/effects-plugin-ktx2'
+   * @default true
    */
   useCompressedTexture?: boolean,
 
   /**
-   * 是否使用 Hevc 视频
-   * @default undefined
+   * 是否优先使用 Hevc 视频
+   * 当资源存在且当前环境支持时使用，否则回退到普通视频
+   * @default true
    */
   useHevcVideo?: boolean,
 

--- a/web-packages/demo/src/single.ts
+++ b/web-packages/demo/src/single.ts
@@ -3,23 +3,31 @@ import '@galacean/effects-plugin-multimedia';
 
 const json = `{
   "playerVersion": {
-    "web": "2.6.0",
+    "web": "2.8.11",
     "native": "0.0.1.202311221223"
   },
-  "images": [],
+  "images": [
+    {
+      "id": "8bfab36a62674e12b8f8cc95b985ab9a",
+      "ktx2": "https://mdn.alipayobjects.com/mars/afts/file/A*p0YpQ4WXpwEAAAAAgCAAAAgAelB4AQ/original",
+      "url": "https://mdn.alipayobjects.com/mars/afts/file/A*e92yR4jH0bgAAAAAgCAAAAgAelB4AQ/original",
+      "renderLevel": "B+",
+      "webp": "https://mdn.alipayobjects.com/mars/afts/file/A*t6ZdSJH1Q6kAAAAAgCAAAAgAelB4AQ/original"
+    }
+  ],
   "fonts": [],
-  "version": "3.3",
-  "shapes": [],
+  "version": "3.6",
   "plugins": [
     "video"
   ],
   "type": "ge",
   "compositions": [
     {
-      "id": "90d8fafaf2db4bb09d85d0805da15632",
-      "name": "刷剧",
-      "duration": 3.67,
-      "endBehavior": 0,
+      "id": "78efce1a1ebf4f558bec31267906dd70",
+      "name": "新建合成1 (10)",
+      "duration": 9,
+      "startTime": 0,
+      "endBehavior": 2,
       "previewSize": [750, 1624],
       "camera": {
         "fov": 60,
@@ -29,39 +37,61 @@ const json = `{
         "position": [0, 0, 8],
         "rotation": [0, 0, 0]
       },
-      "sceneBindings": [
+      "components": [
         {
-          "key": {
-            "id": "fdc939b293b241da86f87ed949dd301c"
-          },
-          "value": {
-            "id": "61995ad967654622a2d0b38444540cc3"
-          }
+          "id": "b260bad0652d4a66941b02e8e39f02e0"
         }
-      ],
-      "timelineAsset": {
-        "id": "a37092b85e4f4309a5138ae755437159"
-      },
-      "items": [
-        {
-          "id": "61995ad967654622a2d0b38444540cc3"
-        }
-      ],
-      "startTime": 0
+      ]
     }
   ],
   "components": [
     {
-      "id": "fe4c8335fd564e96b167ef1475d7a230",
+      "id": "b260bad0652d4a66941b02e8e39f02e0",
       "item": {
-        "id": "61995ad967654622a2d0b38444540cc3"
+        "id": "78efce1a1ebf4f558bec31267906dd70"
+      },
+      "dataType": "CompositionComponent",
+      "items": [
+        {
+          "id": "8a5ddb1e0c604a12b1ed7f1570549e64"
+        },
+        {
+          "id": "0b6b424423c944a188a334eb5b5b4c44"
+        }
+      ],
+      "timelineAsset": {
+        "id": "3029e959591644cba72e13c677c9fd52"
+      },
+      "sceneBindings": [
+        {
+          "key": {
+            "id": "6adab07c7ffe4ccda73e45f4a7fd51a8"
+          },
+          "value": {
+            "id": "8a5ddb1e0c604a12b1ed7f1570549e64"
+          }
+        },
+        {
+          "key": {
+            "id": "23f3a18d60df46b9b8d9ec1a289bdeb7"
+          },
+          "value": {
+            "id": "0b6b424423c944a188a334eb5b5b4c44"
+          }
+        }
+      ]
+    },
+    {
+      "id": "1c92a2986cff4a868b1cfe6874aaf784",
+      "item": {
+        "id": "8a5ddb1e0c604a12b1ed7f1570549e64"
       },
       "dataType": "VideoComponent",
       "options": {
         "startColor": [1, 1, 1, 1],
         "muted": true,
         "video": {
-          "id": "e38870f6cc7c4a689b07ea6adb33d3a0"
+          "id": "017d5e0b1e3c44a3a07f39152a1b33b3"
         },
         "volume": 1,
         "playbackRate": 1,
@@ -70,7 +100,23 @@ const json = `{
       "renderer": {
         "renderMode": 1,
         "texture": {
-          "id": "e688285a65e446679b21dce4d07cef18"
+          "id": "96b1d1de56e44da79f7fc319f2dfd979"
+        }
+      }
+    },
+    {
+      "id": "3fdc3d2a703c4ca5a4ac5dd7dccd8396",
+      "item": {
+        "id": "0b6b424423c944a188a334eb5b5b4c44"
+      },
+      "dataType": "SpriteComponent",
+      "options": {
+        "startColor": [1, 1, 1, 1]
+      },
+      "renderer": {
+        "renderMode": 1,
+        "texture": {
+          "id": "fdcfbcc360d34d5caa3181b732601d4f"
         }
       }
     }
@@ -79,17 +125,17 @@ const json = `{
   "materials": [],
   "items": [
     {
-      "id": "61995ad967654622a2d0b38444540cc3",
+      "id": "8a5ddb1e0c604a12b1ed7f1570549e64",
       "name": "video_2",
-      "duration": 3.6667,
+      "duration": 8,
       "type": "video",
       "visible": true,
-      "endBehavior": 0,
+      "endBehavior": 4,
       "delay": 0,
       "renderLevel": "B+",
       "components": [
         {
-          "id": "fe4c8335fd564e96b167ef1475d7a230"
+          "id": "1c92a2986cff4a868b1cfe6874aaf784"
         }
       ],
       "transform": {
@@ -108,8 +154,49 @@ const json = `{
           "y": 0
         },
         "size": {
-          "x": 9.2272,
-          "y": 15.8638
+          "x": 8.8589,
+          "y": 17.2255
+        },
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
+        }
+      },
+      "dataType": "VFXItemData"
+    },
+    {
+      "id": "0b6b424423c944a188a334eb5b5b4c44",
+      "name": "KTX2",
+      "duration": 9,
+      "type": "1",
+      "visible": true,
+      "endBehavior": 0,
+      "delay": 7.5,
+      "renderLevel": "B+",
+      "components": [
+        {
+          "id": "3fdc3d2a703c4ca5a4ac5dd7dccd8396"
+        }
+      ],
+      "transform": {
+        "position": {
+          "x": -0.08448,
+          "y": -5.1823,
+          "z": 0
+        },
+        "eulerHint": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "anchor": {
+          "x": 0,
+          "y": 0
+        },
+        "size": {
+          "x": 9.8594,
+          "y": 10.2448
         },
         "scale": {
           "x": 1,
@@ -124,113 +211,211 @@ const json = `{
   "bins": [],
   "textures": [
     {
-      "id": "e688285a65e446679b21dce4d07cef18",
+      "id": "fdcfbcc360d34d5caa3181b732601d4f",
       "source": {
-        "id": "e38870f6cc7c4a689b07ea6adb33d3a0"
+        "id": "8bfab36a62674e12b8f8cc95b985ab9a"
+      },
+      "flipY": true
+    },
+    {
+      "id": "96b1d1de56e44da79f7fc319f2dfd979",
+      "source": {
+        "id": "017d5e0b1e3c44a3a07f39152a1b33b3"
       },
       "flipY": true
     }
   ],
+  "animations": [],
   "miscs": [
     {
-      "id": "a37092b85e4f4309a5138ae755437159",
+      "id": "3029e959591644cba72e13c677c9fd52",
       "dataType": "TimelineAsset",
       "tracks": [
         {
-          "id": "fdc939b293b241da86f87ed949dd301c"
+          "id": "6adab07c7ffe4ccda73e45f4a7fd51a8"
+        },
+        {
+          "id": "23f3a18d60df46b9b8d9ec1a289bdeb7"
         }
       ]
     },
     {
-      "id": "0733d8fd69364be9aa870371eab47396",
+      "id": "a0b69032f60a4346a1a9b6499f2a2fd1",
       "dataType": "ActivationPlayableAsset"
     },
     {
-      "id": "5a80b4db21ba4cddb32af23c1c063eb3",
+      "id": "21c585d0aca545e3ba13f7b08c64a4ac",
       "dataType": "TransformPlayableAsset",
       "positionOverLifetime": {
 
       }
     },
     {
-      "id": "a43e46972361480da6d9ba8b3d28f3bf",
+      "id": "16a37a8747c842e0ac92ede7ae3fa8a8",
       "dataType": "SpriteColorPlayableAsset",
       "startColor": [1, 1, 1, 1]
     },
     {
-      "id": "bd2c1b14a4fe42fe8a3a5780200ce262",
+      "id": "19c20d69876b4da99d1613bcf66e295e",
       "dataType": "ActivationTrack",
       "children": [],
       "clips": [
         {
           "start": 0,
-          "duration": 3.6667,
-          "endBehavior": 0,
+          "duration": 8,
+          "endBehavior": 4,
           "asset": {
-            "id": "0733d8fd69364be9aa870371eab47396"
+            "id": "a0b69032f60a4346a1a9b6499f2a2fd1"
           }
         }
       ]
     },
     {
-      "id": "cae6956db3ad41669835dfa08120eebc",
+      "id": "f16e32eea16d4e31840c6282455df69c",
       "dataType": "TransformTrack",
       "children": [],
       "clips": [
         {
           "start": 0,
-          "duration": 3.6667,
-          "endBehavior": 0,
+          "duration": 8,
+          "endBehavior": 4,
           "asset": {
-            "id": "5a80b4db21ba4cddb32af23c1c063eb3"
+            "id": "21c585d0aca545e3ba13f7b08c64a4ac"
           }
         }
       ]
     },
     {
-      "id": "27775d50e1f944718d67662982c62fcf",
+      "id": "6b8b53dd6d6f45439373d17be2afc10a",
       "dataType": "SpriteColorTrack",
       "children": [],
       "clips": [
         {
           "start": 0,
-          "duration": 3.6667,
-          "endBehavior": 0,
+          "duration": 8,
+          "endBehavior": 4,
           "asset": {
-            "id": "a43e46972361480da6d9ba8b3d28f3bf"
+            "id": "16a37a8747c842e0ac92ede7ae3fa8a8"
           }
         }
       ]
     },
     {
-      "id": "fdc939b293b241da86f87ed949dd301c",
+      "id": "6adab07c7ffe4ccda73e45f4a7fd51a8",
       "dataType": "ObjectBindingTrack",
       "children": [
         {
-          "id": "bd2c1b14a4fe42fe8a3a5780200ce262"
+          "id": "19c20d69876b4da99d1613bcf66e295e"
         },
         {
-          "id": "cae6956db3ad41669835dfa08120eebc"
+          "id": "f16e32eea16d4e31840c6282455df69c"
         },
         {
-          "id": "27775d50e1f944718d67662982c62fcf"
+          "id": "6b8b53dd6d6f45439373d17be2afc10a"
+        }
+      ],
+      "clips": []
+    },
+    {
+      "id": "38b72ff096084b7f8c571a3610f0eb85",
+      "dataType": "ActivationPlayableAsset"
+    },
+    {
+      "id": "f737145f18f84069a44017d4ca9cf8d9",
+      "dataType": "TransformPlayableAsset",
+      "positionOverLifetime": {
+
+      }
+    },
+    {
+      "id": "f7523b49adfe4354896dc333e326d9ba",
+      "dataType": "SpriteColorPlayableAsset",
+      "startColor": [1, 1, 1, 1],
+      "colorOverLifetime": {
+        "opacity": [21, [
+            [4, [-0.003333, 0]
+            ],
+            [4, [0.1667, 1.01]
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "id": "1dcd90ce75ff46fd82ef12028d9e90ff",
+      "dataType": "ActivationTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 7.5,
+          "duration": 9,
+          "endBehavior": 0,
+          "asset": {
+            "id": "38b72ff096084b7f8c571a3610f0eb85"
+          }
+        }
+      ]
+    },
+    {
+      "id": "584d2de073054bc391db4226be8550fb",
+      "dataType": "TransformTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 7.5,
+          "duration": 9,
+          "endBehavior": 0,
+          "asset": {
+            "id": "f737145f18f84069a44017d4ca9cf8d9"
+          }
+        }
+      ]
+    },
+    {
+      "id": "d41e5b2c076b4cc897e25fdc7b348e88",
+      "dataType": "SpriteColorTrack",
+      "children": [],
+      "clips": [
+        {
+          "start": 7.5,
+          "duration": 9,
+          "endBehavior": 0,
+          "asset": {
+            "id": "f7523b49adfe4354896dc333e326d9ba"
+          }
+        }
+      ]
+    },
+    {
+      "id": "23f3a18d60df46b9b8d9ec1a289bdeb7",
+      "dataType": "ObjectBindingTrack",
+      "children": [
+        {
+          "id": "1dcd90ce75ff46fd82ef12028d9e90ff"
+        },
+        {
+          "id": "584d2de073054bc391db4226be8550fb"
+        },
+        {
+          "id": "d41e5b2c076b4cc897e25fdc7b348e88"
         }
       ],
       "clips": []
     }
   ],
-  "compositionId": "90d8fafaf2db4bb09d85d0805da15632",
+  "compositionId": "78efce1a1ebf4f558bec31267906dd70",
   "videos": [
     {
-      "id": "e38870f6cc7c4a689b07ea6adb33d3a0",
+      "id": "017d5e0b1e3c44a3a07f39152a1b33b3",
+      "url": "https://mdn.alipayobjects.com/graph_jupiter/afts/file/A*j8OtQY4vpr0AAAAAgBAAAAgAesF2AQ",
       "hevc": {
-          "url": "http://vod.alipayobjects.com/VIDEO_CONVERT/afts/video/A*Sd-lQ4WM73AAAAAAgBAAAAgAesF2AQ/720P_h265?t=MhDiXxh9eg_NmXTpMp7COqaWShflfMHNlzZp8IsNe5wDAAAAAAAAAABpMmVA",
-          "codec": "L63"
-        },
-      "url": "https://mdn.alipayobjects.com/graph_jupiter/afts/file/A*j8OtQY4vpr0AAAAAgBAAAAgAesF2AQ"
+        "codec": "hev1.1.0.L93.B0",
+        "url": "https://mdn.alipayobjects.com/mars/afts/video/A*-gO7Q5A8aOMAAAAAgLAAAAgAesF2AQ/540P_h265"
+      }
     }
   ]
 }`;
+
 const container = document.getElementById('J-container');
 
 (async () => {
@@ -242,5 +427,5 @@ const container = document.getElementById('J-container');
     },
   });
 
-  await player.loadScene(JSON.parse(json), { useHevcVideo: true });
+  await player.loadScene(JSON.parse(json));
 })();

--- a/web-packages/test/unit/src/effects-core/asset-manager.spec.ts
+++ b/web-packages/test/unit/src/effects-core/asset-manager.spec.ts
@@ -12,6 +12,31 @@ describe('core/asset-manager', () => {
     assetManager?.dispose();
   });
 
+  it('default use compressed texture and hevc video', () => {
+    assetManager = new AssetManager();
+
+    expect(assetManager.options.useCompressedTexture).to.eql(true);
+    expect(assetManager.options.useHevcVideo).to.eql(true);
+
+    assetManager.updateOptions({
+      useCompressedTexture: undefined,
+      useHevcVideo: undefined,
+    });
+
+    expect(assetManager.options.useCompressedTexture).to.eql(true);
+    expect(assetManager.options.useHevcVideo).to.eql(true);
+  });
+
+  it('can disable compressed texture and hevc video', () => {
+    assetManager = new AssetManager({
+      useCompressedTexture: false,
+      useHevcVideo: false,
+    });
+
+    expect(assetManager.options.useCompressedTexture).to.eql(false);
+    expect(assetManager.options.useHevcVideo).to.eql(false);
+  });
+
   it('scene renderLevel is right when pass options', async () => {
     assetManager = new AssetManager({
       renderLevel: spec.RenderLevel.B,


### PR DESCRIPTION
## Summary

Default scene loading now prefers optimized assets when available: compressed textures and HEVC videos are enabled by default, while still allowing callers to explicitly disable them.

## Changes

- Default `SceneLoadOptions.useCompressedTexture` and `useHevcVideo` to `true`.
- Preserve explicit `false` values for both options.
- Use KTX2 compressed textures only when:
  - the scene has a `ktx2` asset,
  - the runtime supports KTX2,
  - the KTX2 loader has been registered.
- If KTX2 assets exist but `@galacean/effects-plugin-ktx2` has not been imported, fall back to the normal image and log an error.
- Update `SceneLoadOptions` docs to describe the new defaults and KTX2 plugin requirement.
- Add unit coverage for default enabled behavior and explicit disabling.
- Update the `single` demo page with cases for compressed texture / non-compressed texture and HEVC / non-HEVC loading without passing load options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compressed textures and HEVC video are now preferred by default, with safer option merging and consistent default preservation.
  * Improved KTX2 compressed-texture handling, including clearer errors when KTX2 data is present but support isn’t available.
  * Per-image compressed-texture URL generation now reflects actual capability.
* **New Features**
  * Updated the web demo scene (assets, compositions, and playback configuration).
* **Documentation**
  * Refreshed `SceneLoadOptions` guidance to describe compression/video as “prefer” options, with updated default documentation.
* **Tests**
  * Added unit tests covering default and custom compression option behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->