### PR TITLE
fix: wrong line break for CJK text with space

### DIFF
--- a/packages/effects-core/src/plugins/text/index.ts
+++ b/packages/effects-core/src/plugins/text/index.ts
@@ -1,4 +1,5 @@
 export * from './base-layout';
+export * from './line-break';
 export * from './text-item';
 export * from './text-layout';
 export * from './text-style';

--- a/packages/effects-core/src/plugins/text/line-break.ts
+++ b/packages/effects-core/src/plugins/text/line-break.ts
@@ -1,0 +1,60 @@
+/**
+ * 文本换行机会判定：UAX #14 风格的"换行机会"模型。
+ *
+ * - CJK 表意字 / 假名 / 韩文音节：任意两个字之间都是合法断点（字符级）
+ * - 空格 / 制表符 / NBSP：可断，且断行时被吞掉（不留在行尾 / 行首）
+ * - 西文字母 / 数字：词内不可断；整体超宽时由调用方退化到字符级断（overflow-wrap）
+ *
+ * 不含 kinsoku 禁则（句号 / 逗号不进行首等留作后续）。
+ */
+
+/** 换行机会类型（断点字符之后）：决定断点字符归属及断行时是否吞掉 */
+export type BreakAfter = 'swallow' | 'keep' | false;
+
+/**
+ * 是否为可换行断点字符（空格 / 制表符 / NBSP）。
+ * 断在此字符之前，且断行时该字符被吞掉（不进旧行也不进新行）。
+ * @param ch - 当前字符
+ */
+export function isBreakChar (ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === ' ';
+}
+
+/**
+ * 是否为 CJK 类字符（中文表意字 / 假名 / 韩文音节）。可在其与相邻字符之间换行。
+ * 用码点判定以支持 CJK 扩展 B 等代理对字符（不能用 /u 正则，browserslist 为 iOS 9）。
+ * @param ch - 当前字符（须为完整码点，调用方应使用 Array.from 遍历）
+ */
+export function isCJKLike (ch: string): boolean {
+  const cp = ch.codePointAt(0) ?? 0;
+
+  return (
+    (cp >= 0x3400 && cp <= 0x4DBF) ||    // CJK 统一表意扩展 A
+    (cp >= 0x4E00 && cp <= 0x9FFF) ||    // CJK 统一表意
+    (cp >= 0xF900 && cp <= 0xFAFF) ||    // CJK 兼容表意
+    (cp >= 0x20000 && cp <= 0x2FA1F) ||  // CJK 扩展 B~F + 兼容增补（代理对）
+    (cp >= 0x3040 && cp <= 0x309F) ||    // 平假名
+    (cp >= 0x30A0 && cp <= 0x30FF) ||    // 片假名
+    (cp >= 0x31F0 && cp <= 0x31FF) ||    // 片假名语音扩展
+    (cp >= 0xAC00 && cp <= 0xD7AF)       // 韩文音节
+  );
+}
+
+/**
+ * 计算 prev（已推入的字符）之后是否为换行机会。只看 prev，不看后续字符。
+ * @param prev - 前一字符（已推入旧行）
+ * @returns 'swallow'=prev 是空格类，断行时吞掉 prev；'keep'=prev 是 CJK，prev 留本行末、下行从其后起；false=不可断
+ */
+export function breakOpportunityAfter (prev: string): BreakAfter {
+  // prev 是空格类 → 断在 prev 处，断行时吞掉 prev（不进旧行也不进新行）
+  if (isBreakChar(prev)) {
+    return 'swallow';
+  }
+
+  // prev 是 CJK → prev 留本行末，下行从 prev 之后起（字符级断点，不吞）
+  if (isCJKLike(prev)) {
+    return 'keep';
+  }
+
+  return false;
+}

--- a/packages/effects-core/src/plugins/text/text-item.ts
+++ b/packages/effects-core/src/plugins/text/text-item.ts
@@ -6,6 +6,7 @@ import { MaskableGraphic } from '../../components';
 import { effectsClass } from '../../decorators';
 import type { Engine } from '../../engine';
 import { applyMixins } from '../../utils';
+import { breakOpportunityAfter } from './line-break';
 import { TextLayout } from './text-layout';
 import { TextStyle } from './text-style';
 import { TextComponentBase } from './text-component-base';
@@ -36,9 +37,6 @@ interface CharInfo {
 
 /** 检测字符串是否包含需要 RTL 和连写排版的字符（阿拉伯语等） */
 const HAS_RTL_OR_JOINING = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
-
-/** 可换行断点：空格、制表符等 */
-const IS_BREAK_CHAR = (ch: string) => ch === ' ' || ch === '\t' || ch === '\u00A0';
 
 export interface TextComponent extends TextComponentBase { }
 
@@ -177,14 +175,15 @@ export class TextComponent extends MaskableGraphic {
     let lineCount = 1;
     let x = 0;
     let charCountInLine = 0;
+    // 使用码点遍历，正确处理 emoji 与 CJK 扩展 B 等代理对字符
+    const chars = Array.from(text);
 
     if (context) {
       context.font = this.getFontDesc(this.textStyle.fontSize);
     }
 
     if (overflow === spec.TextOverflow.display) {
-      for (let i = 0; i < text.length; i++) {
-        const str = text[i];
+      for (const str of chars) {
         const textMetrics = context?.measureText(str)?.width ?? 0;
 
         if (str === '\n') {
@@ -205,12 +204,11 @@ export class TextComponent extends MaskableGraphic {
     }
 
     if (this.textLayout.keepWordIntact) {
-      // 单词完整换行：优先在空格处断行，避免从单词中间断开
+      // 单词完整换行：优先在换行机会处断行（空格吞断 / CJK 字间可断），避免从西文词中间断开
       let lastBreakX = 0;
       let countAtBreak = 0;
 
-      for (let i = 0; i < text.length; i++) {
-        const str = text[i];
+      for (const str of chars) {
         const textMetrics = context?.measureText(str)?.width ?? 0;
 
         if (str === '\n') {
@@ -247,15 +245,16 @@ export class TextComponent extends MaskableGraphic {
         x += textMetrics;
         charCountInLine++;
 
-        if (IS_BREAK_CHAR(str)) {
+        // 记换行机会：str 之后可断（空格 swallow / CJK keep）。lastBreakX 含 str 宽度（str 留本行末）
+        if (breakOpportunityAfter(str) !== false) {
           lastBreakX = x;
           countAtBreak = charCountInLine;
         }
       }
     } else {
       // 逐字符换行：允许在任意字符处断开
-      for (let i = 0; i < text.length; i++) {
-        const str = text[i];
+      for (let i = 0; i < chars.length; i++) {
+        const str = chars[i];
         const textMetrics = context?.measureText(str)?.width ?? 0;
 
         if (charCountInLine > 0) {
@@ -379,8 +378,11 @@ export class TextComponent extends MaskableGraphic {
       let charOffsetX: number[] = [];
 
       if (layout.keepWordIntact) {
-        // 单词完整换行：优先在空格处断行，避免从单词中间断开
+        // 单词完整换行：优先在换行机会处断行（空格吞断 / CJK 字间可断），避免从西文词中间断开。
+        // lastBreakIdx 指向断点字符在 charsArray 中的索引；breakSwallow=true 时该字符被吞（空格），
+        // false 时该字符留本行末（CJK），下行均从 lastBreakIdx+1 起。
         let lastBreakIdx = -1;
+        let breakSwallow = false;
 
         for (let i = 0; i < char.length; i++) {
           const str = char[i];
@@ -398,6 +400,7 @@ export class TextComponent extends MaskableGraphic {
             charsArray = [];
             charOffsetX = [];
             lastBreakIdx = -1;
+            breakSwallow = false;
             continue;
           }
 
@@ -406,9 +409,11 @@ export class TextComponent extends MaskableGraphic {
 
           if (willWidth > baseWidth && charsArray.length > 0) {
             if (lastBreakIdx > 0) {
-              // 在空格处换行
-              const lineChars = charsArray.slice(0, lastBreakIdx);
-              const lineOffsets = charOffsetX.slice(0, lastBreakIdx);
+              // 在换行机会处断行：swallow 取 [0,lastBreakIdx)（吞掉断点字符），
+              // keep 取 [0,lastBreakIdx]（断点字符留本行末），下行均从 lastBreakIdx+1 起。
+              const endIdx = breakSwallow ? lastBreakIdx : lastBreakIdx + 1;
+              const lineChars = charsArray.slice(0, endIdx);
+              const lineOffsets = charOffsetX.slice(0, endIdx);
               const lineWidth = lineChars.length > 0
                 ? lineOffsets[lineOffsets.length - 1] + context.measureText(lineChars[lineChars.length - 1]).width
                 : 0;
@@ -431,6 +436,7 @@ export class TextComponent extends MaskableGraphic {
                 x += context.measureText(charsArray[j]).width;
               }
               lastBreakIdx = -1;
+              breakSwallow = false;
             } else {
               charsInfo.push({
                 y,
@@ -443,6 +449,7 @@ export class TextComponent extends MaskableGraphic {
               charsArray = [];
               charOffsetX = [];
               lastBreakIdx = -1;
+              breakSwallow = false;
             }
           }
 
@@ -453,8 +460,13 @@ export class TextComponent extends MaskableGraphic {
           charsArray.push(str);
           x += textMetrics.width;
 
-          if (IS_BREAK_CHAR(str)) {
+          // 记换行机会：str 之后可断。lastBreakIdx 指向 str（charsArray 末尾），
+          // swallow=吞 str（空格），keep=str 留本行末（CJK）。
+          const opp = breakOpportunityAfter(str);
+
+          if (opp !== false) {
             lastBreakIdx = charsArray.length - 1;
+            breakSwallow = opp === 'swallow';
           }
         }
       } else {

--- a/web-packages/test/unit/src/effects-core/index.ts
+++ b/web-packages/test/unit/src/effects-core/index.ts
@@ -11,6 +11,8 @@ import './plugins/shape';
 import './plugins/particle';
 // plugin sprite
 import './plugins/sprite';
+// plugin text
+import './plugins/text';
 import './asset-manager.spec';
 import './texture.spec';
 import './transform.spec';

--- a/web-packages/test/unit/src/effects-core/plugins/text/index.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/text/index.ts
@@ -1,0 +1,2 @@
+import './text-item.spec';
+import './line-break.spec';

--- a/web-packages/test/unit/src/effects-core/plugins/text/line-break.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/text/line-break.spec.ts
@@ -1,0 +1,79 @@
+import { breakOpportunityAfter, isBreakChar, isCJKLike } from '@galacean/effects';
+
+const { expect } = chai;
+
+// 用码点构造控制字符，避免源码字面反斜杠转义
+const TAB = String.fromCharCode(9);
+const NBSP = String.fromCharCode(160);
+const NEWLINE = String.fromCharCode(10);
+// CJK 扩展 B 首字 U+20000（代理对）
+const CJK_EXT_B = String.fromCodePoint(0x20000);
+const EMOJI = String.fromCodePoint(0x1F600);
+
+describe('core/plugins/text/line-break', () => {
+  describe('isBreakChar', () => {
+    it('空格 / 制表符 / NBSP 视为断点字符', () => {
+      expect(isBreakChar(' ')).to.be.true;
+      expect(isBreakChar(TAB)).to.be.true;
+      expect(isBreakChar(NBSP)).to.be.true;
+    });
+
+    it('其他字符不是断点字符', () => {
+      expect(isBreakChar('a')).to.be.false;
+      expect(isBreakChar('您')).to.be.false;
+      expect(isBreakChar('0')).to.be.false;
+      expect(isBreakChar(NEWLINE)).to.be.false;
+    });
+  });
+
+  describe('isCJKLike', () => {
+    it('中文 / 假名 / 韩文音节视为 CJK', () => {
+      expect(isCJKLike('您')).to.be.true;
+      expect(isCJKLike('あ')).to.be.true; // 平假名
+      expect(isCJKLike('ア')).to.be.true; // 片假名
+      expect(isCJKLike('가')).to.be.true; // 韩文音节
+    });
+
+    it('CJK 扩展 B 代理对视为 CJK', () => {
+      expect(isCJKLike(CJK_EXT_B)).to.be.true;
+    });
+
+    it('拉丁 / 数字 / emoji / 标点不是 CJK', () => {
+      expect(isCJKLike('a')).to.be.false;
+      expect(isCJKLike('0')).to.be.false;
+      expect(isCJKLike(EMOJI)).to.be.false;
+      expect(isCJKLike('。')).to.be.false; // CJK 标点 U+3002 不纳入
+      expect(isCJKLike(' ')).to.be.false;
+    });
+  });
+
+  describe('breakOpportunityAfter', () => {
+    it('prev 是空格类 → swallow（断行时吞掉 prev）', () => {
+      expect(breakOpportunityAfter(' ')).to.equal('swallow');
+      expect(breakOpportunityAfter(TAB)).to.equal('swallow');
+      expect(breakOpportunityAfter(NBSP)).to.equal('swallow');
+    });
+
+    it('prev 是 CJK → keep（prev 留本行末，下行从其后起）', () => {
+      expect(breakOpportunityAfter('您')).to.equal('keep');
+      expect(breakOpportunityAfter('あ')).to.equal('keep');
+      expect(breakOpportunityAfter('가')).to.equal('keep');
+      expect(breakOpportunityAfter(CJK_EXT_B)).to.equal('keep');
+    });
+
+    it('prev 是拉丁 / 数字 / emoji / 标点 → false（不可断）', () => {
+      expect(breakOpportunityAfter('a')).to.equal(false);
+      expect(breakOpportunityAfter('0')).to.equal(false);
+      expect(breakOpportunityAfter('.')).to.equal(false);
+      expect(breakOpportunityAfter(EMOJI)).to.equal(false);
+      expect(breakOpportunityAfter('。')).to.equal(false);
+    });
+
+    it('只看 prev，西文→CJK 的断点在 CJK 之后而非之前', () => {
+      // prev='0'（西文）即使后面将出现 CJK，也不在此处设断点
+      expect(breakOpportunityAfter('0')).to.equal(false);
+      // prev=CJK 时设 keep 断点，CJK 留本行末
+      expect(breakOpportunityAfter('您')).to.equal('keep');
+    });
+  });
+});

--- a/web-packages/test/unit/src/effects-core/plugins/text/text-item.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/text/text-item.spec.ts
@@ -1,0 +1,107 @@
+import { spec, Engine, TextComponent, TextLayout, TextStyle } from '@galacean/effects';
+
+const { expect } = chai;
+
+describe('core/plugins/text/text-item', () => {
+  let engine: Engine;
+  let textComponent: TextComponent;
+
+  beforeEach(() => {
+    engine = new Engine(document.createElement('canvas'));
+    textComponent = new TextComponent(engine);
+  });
+
+  afterEach(() => {
+    textComponent.dispose();
+    engine.dispose();
+  });
+
+  it('构造后持有默认值', () => {
+    expect(textComponent.isDirty).to.be.true;
+    expect(textComponent.lineCount).to.equal(0);
+    expect(textComponent.textStyle).to.be.an.instanceOf(TextStyle);
+    expect(textComponent.canvas).to.be.an.instanceOf(HTMLCanvasElement);
+    expect(textComponent.context).to.be.an.instanceOf(CanvasRenderingContext2D);
+    expect(textComponent.textLayout).to.be.an.instanceOf(TextLayout);
+    // 默认 props 的 text 为"默认文本"，非空串
+    expect(textComponent.text).to.equal('默认文本');
+  });
+
+  it('updateWithOptions 写入样式与布局', () => {
+    const options: spec.TextContentOptions = {
+      fontSize: 16,
+      fontWeight: spec.TextWeight.bold,
+      fontStyle: spec.FontStyle.italic,
+      text: 'Hello, World!',
+      textAlign: spec.TextAlignment.middle,
+      textColor: [1, 0, 0, 1],
+      fontFamily: 'Arial',
+    };
+
+    textComponent.updateWithOptions(options);
+
+    expect(textComponent.textStyle.fontSize).to.equal(options.fontSize);
+    expect(textComponent.textStyle.textWeight).to.equal(options.fontWeight);
+    expect(textComponent.textStyle.fontStyle).to.equal(options.fontStyle);
+    expect(textComponent.text).to.equal(options.text);
+    expect(textComponent.textLayout.textAlign).to.equal(options.textAlign);
+    expect(textComponent.textStyle.textColor).to.deep.equal(options.textColor);
+    expect(textComponent.textStyle.fontFamily).to.equal(options.fontFamily);
+  });
+
+  // 换行集成测试：打桩 measureText 返回固定宽度（CJK=10 / 西文与标点=5 / 空格=3），
+  // letterSpace 默认 0、keepWordIntact 默认 true。通过调整 textLayout.width 吸收 fontOffset，
+  // 使 getLineCount 内部 width = textLayout.width + fontOffset 等于目标值，得到确定性行数。
+  describe('getLineCount 换行机会', () => {
+    type MeasureFn = (text: string) => TextMetrics;
+
+    const stubMeasure: MeasureFn = s => {
+      const cp = s.codePointAt(0) ?? 0;
+      let width = 5;
+
+      if (s === ' ') {
+        width = 3;
+      } else if (
+        (cp >= 0x3400 && cp <= 0x9FFF) // CJK 统一表意 + 扩展 A
+        || (cp >= 0x3040 && cp <= 0x30FF) // 假名
+        || (cp >= 0xAC00 && cp <= 0xD7AF) // 韩文音节
+        || cp >= 0x20000 // CJK 扩展 B+（代理对）
+      ) {
+        width = 10;
+      }
+
+      return { width } as unknown as TextMetrics;
+    };
+
+    /** 设置目标排版宽度（吸收 fontOffset），并打桩 measureText */
+    const setup = (targetWidth: number): void => {
+      textComponent.updateWithOptions({ text: '', fontSize: 16 });
+      // 吸收 fontOffset：getLineCount 内 width = textLayout.width + fontOffset
+      textComponent.textLayout.width = targetWidth - textComponent.textStyle.fontOffset;
+      // 打桩测量，避免依赖系统字体
+      (textComponent.context as CanvasRenderingContext2D).measureText = stubMeasure;
+    };
+
+    it('纯 CJK 文本在字间断行（每行 2 字 → 2 行）', () => {
+      setup(25); // 放得下 2 个 CJK（20），第 3 字超宽
+      expect(textComponent.getLineCount('您去领取')).to.equal(2);
+    });
+
+    it('空格处断行时空格被吞掉（a 与 b 分两行）', () => {
+      setup(10); // a(5)+空格(3)=8 放得下，加 b(5) 超宽
+      expect(textComponent.getLineCount('a b')).to.equal(2);
+    });
+
+    it('CJK 字间断行不拆西文词（ab您 / cd 两行，您留本行末）', () => {
+      setup(20); // ab您 = 5+5+10 = 20 刚好
+      expect(textComponent.getLineCount('ab您cd')).to.equal(2);
+    });
+
+    it('长 CJK 文本多行换行，不整体端走后半句', () => {
+      // 回归用例：原实现只认空格断点，会把"去领取支付人群"整体端到第二行。
+      // 升级换行机会模型后 CJK 字间断，行数明显增多。
+      setup(40);
+      expect(textComponent.getLineCount('您有0.01元券 去领取支付人群')).to.equal(4);
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text wrapping to handle Unicode code points and CJK-style line breaks more naturally.
  * Added support for break opportunities that either keep or swallow trailing spaces at wrap points.

* **Bug Fixes**
  * Fixed line counting and text rendering for mixed Latin, CJK, and whitespace content.
  * Reduced incorrect wrapping behavior for multi-line text, including edge cases around spaces and punctuation.

* **Tests**
  * Added unit coverage for line-break rules and text wrapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->