### PR TITLE
feat: support video timing driven by animation graph

### DIFF
--- a/packages/effects-core/src/components/animator.ts
+++ b/packages/effects-core/src/components/animator.ts
@@ -1,8 +1,15 @@
 import type * as spec from '@galacean/effects-specification';
 import type { AnimationGraphAsset, StateMachineNode } from '../plugins/animation-graph';
 import { GraphInstance } from '../plugins/animation-graph';
+import type { PoseResult } from '../plugins/animation-graph/pose-result';
+import { VFXItem } from '../vfx-item';
 import { Component } from './component.js';
 import { effectsClass } from '../decorators';
+
+interface AnimationGraphRuntimeTimeComponent {
+  setAnimationGraphRuntimeTime: (duration: number, activeValue: number) => void,
+  clearAnimationGraphRuntimeTime: () => void,
+}
 
 /**
  * @since 2.6.0
@@ -14,6 +21,7 @@ export class Animator extends Component {
    */
   graphInstance: GraphInstance | null = null;
   private graphAsset: AnimationGraphAsset | null = null;
+  private animationGraphTimedItems = new Set<VFXItem>();
 
   /**
    * 设置布尔类型参数
@@ -88,7 +96,10 @@ export class Animator extends Component {
       return;
     }
 
-    const result = this.graphInstance.evaluateGraph(dt / 1000);
+    const deltaTime = dt / 1000;
+    const result = this.graphInstance.evaluateGraph(deltaTime);
+
+    this.applyItemTimeRecords(result);
 
     // Apply transform animation
     //-------------------------------------------------------------------------
@@ -148,7 +159,83 @@ export class Animator extends Component {
     }
   }
 
+  override onDisable (): void {
+    super.onDisable();
+    this.resetItemTimeRecords();
+  }
+
+  override onDestroy (): void {
+    super.onDestroy();
+    this.resetItemTimeRecords();
+  }
+
   override fromData (data: spec.AnimatorData): void {
     this.graphAsset = this.engine.findObject<AnimationGraphAsset>(data.graphAsset);
+  }
+
+  private applyItemTimeRecords (result: PoseResult): void {
+    if (!this.graphInstance) {
+      return;
+    }
+
+    const activeTimedItems = new Set<VFXItem>();
+    const records = result.pose.itemTimeRecords;
+    const animatedObjects = this.graphInstance.skeleton.floatAnimatedObjects;
+
+    for (const record of records) {
+      if (!record || record.activeValue <= 0) {
+        continue;
+      }
+
+      const animatedObject = animatedObjects[record.animatedObjectIndex];
+      const item = animatedObject?.target;
+
+      if (item instanceof VFXItem) {
+        item.time = record.time;
+        this.setRuntimeTime(item, record.duration, record.activeValue);
+        activeTimedItems.add(item);
+      }
+    }
+
+    for (const item of this.animationGraphTimedItems) {
+      if (!activeTimedItems.has(item)) {
+        this.clearRuntimeTime(item);
+      }
+    }
+
+    this.animationGraphTimedItems = activeTimedItems;
+  }
+
+  private resetItemTimeRecords (): void {
+    for (const item of this.animationGraphTimedItems) {
+      this.clearRuntimeTime(item);
+    }
+
+    this.animationGraphTimedItems.clear();
+  }
+
+  private setRuntimeTime (item: VFXItem, duration: number, activeValue: number): void {
+    for (const component of item.components) {
+      if (this.isRuntimeTimeComponent(component)) {
+        component.setAnimationGraphRuntimeTime(duration, activeValue);
+      }
+    }
+  }
+
+  private clearRuntimeTime (item: VFXItem): void {
+    for (const component of item.components) {
+      if (this.isRuntimeTimeComponent(component)) {
+        component.clearAnimationGraphRuntimeTime();
+      }
+    }
+  }
+
+  private isRuntimeTimeComponent (component: Component): component is Component & AnimationGraphRuntimeTimeComponent {
+    const candidate = component as Partial<AnimationGraphRuntimeTimeComponent>;
+
+    return (
+      typeof candidate.setAnimationGraphRuntimeTime === 'function' &&
+      typeof candidate.clearAnimationGraphRuntimeTime === 'function'
+    );
   }
 }

--- a/packages/effects-core/src/components/animator.ts
+++ b/packages/effects-core/src/components/animator.ts
@@ -2,14 +2,10 @@ import type * as spec from '@galacean/effects-specification';
 import type { AnimationGraphAsset, StateMachineNode } from '../plugins/animation-graph';
 import { GraphInstance } from '../plugins/animation-graph';
 import type { PoseResult } from '../plugins/animation-graph/pose-result';
+import type { AnimationGraphRuntimeTimeComponent } from '../plugins/animation-graph/runtime-time-component';
 import { VFXItem } from '../vfx-item';
 import { Component } from './component.js';
 import { effectsClass } from '../decorators';
-
-interface AnimationGraphRuntimeTimeComponent {
-  setAnimationGraphRuntimeTime: (duration: number, activeValue: number) => void,
-  clearAnimationGraphRuntimeTime: () => void,
-}
 
 /**
  * @since 2.6.0

--- a/packages/effects-core/src/plugins/animation-graph/blender.ts
+++ b/packages/effects-core/src/plugins/animation-graph/blender.ts
@@ -1,6 +1,6 @@
 import type { Color, Vector3 } from '@galacean/effects-math/es/core';
 import { Quaternion } from '@galacean/effects-math/es/core/quaternion';
-import type { Pose } from './pose';
+import type { ItemTimeRecord, Pose } from './pose';
 
 const tempQuaternion = new Quaternion();
 
@@ -163,5 +163,59 @@ export class Blender {
 
       blendFunction.blendColor(sourceColor, targetColor, blendWeight, resultColor);
     }
+
+    this.blendItemTimeRecords(sourcePose, targetPose, blendWeight, resultPose);
+  }
+
+  private static blendItemTimeRecords (
+    sourcePose: Pose,
+    targetPose: Pose,
+    blendWeight: number,
+    resultPose: Pose
+  ): void {
+    const sourceRecords = sourcePose.itemTimeRecords.slice();
+    const targetRecords = targetPose.itemTimeRecords.slice();
+    const sourceWeight = 1 - blendWeight;
+    const targetWeight = blendWeight;
+    const recordCount = Math.max(sourceRecords.length, targetRecords.length);
+
+    resultPose.itemTimeRecords.length = 0;
+
+    // itemTimeRecords are indexed by animatedObjectIndex, so sparse slots are expected.
+    for (let i = 0; i < recordCount; i++) {
+      const sourceRecord = sourceRecords[i];
+      const targetRecord = targetRecords[i];
+      const selectedRecord = this.selectItemTimeRecord(sourceRecord, sourceWeight, targetRecord, targetWeight);
+
+      if (selectedRecord) {
+        resultPose.itemTimeRecords[i] = selectedRecord;
+      }
+    }
+  }
+
+  private static selectItemTimeRecord (
+    sourceRecord: ItemTimeRecord | undefined,
+    sourceWeight: number,
+    targetRecord: ItemTimeRecord | undefined,
+    targetWeight: number
+  ): ItemTimeRecord | undefined {
+    const sourceScore = sourceRecord ? Math.max(0, sourceRecord.activeValue) * sourceWeight : 0;
+    const targetScore = targetRecord ? Math.max(0, targetRecord.activeValue) * targetWeight : 0;
+
+    if (sourceScore <= 0 && targetScore <= 0) {
+      return undefined;
+    }
+
+    const selectedRecord = targetScore >= sourceScore ? targetRecord : sourceRecord;
+    const selectedScore = Math.max(sourceScore, targetScore);
+
+    if (!selectedRecord) {
+      return undefined;
+    }
+
+    return {
+      ...selectedRecord,
+      activeValue: selectedScore,
+    };
   }
 }

--- a/packages/effects-core/src/plugins/animation-graph/blender.ts
+++ b/packages/effects-core/src/plugins/animation-graph/blender.ts
@@ -206,12 +206,8 @@ export class Blender {
       return undefined;
     }
 
-    const selectedRecord = targetScore >= sourceScore ? targetRecord : sourceRecord;
+    const selectedRecord = (targetScore >= sourceScore ? targetRecord : sourceRecord)!;
     const selectedScore = Math.max(sourceScore, targetScore);
-
-    if (!selectedRecord) {
-      return undefined;
-    }
 
     return {
       ...selectedRecord,

--- a/packages/effects-core/src/plugins/animation-graph/nodes/animation-clip-node.ts
+++ b/packages/effects-core/src/plugins/animation-graph/nodes/animation-clip-node.ts
@@ -4,7 +4,7 @@ import type { GraphContext, InstantiationContext } from '../graph-context';
 import { GraphNodeData, PoseNode } from '../graph-node';
 import { nodeDataClass } from '../node-asset-type';
 import type { PoseResult } from '../pose-result';
-import type { Skeleton } from '../skeleton';
+import { VFXItemType, type Skeleton } from '../skeleton';
 import type { Pose } from '../pose';
 import type {
   AnimationClip, AnimationCurve, FloatAnimationCurve, ColorAnimationCurve, AnimationEventReference,
@@ -131,6 +131,7 @@ export interface TransformCurveInfo {
 export interface FloatCurveInfo {
   curve: FloatAnimationCurve,
   animatedObjectIndex: number,
+  isItemActiveCurve: boolean,
 }
 
 export interface ColorCurveInfo {
@@ -183,6 +184,8 @@ export class Animatable {
   getPose (time: number, outPose: Pose) {
     const life = clamp(time, 0, this.animationClip.duration);
 
+    outPose.clearItemTimeRecords();
+
     for (const curveInfo of this.transformCurveInfos) {
       const curveValue = curveInfo.curve.keyFrames.getValue(life);
       const outTransform = outPose.parentSpaceTransforms[curveInfo.boneIndex];
@@ -211,6 +214,15 @@ export class Animatable {
       const floatValue = curveInfo.curve.keyFrames.getValue(life);
 
       outPose.floatPropertyValues[curveInfo.animatedObjectIndex] = floatValue;
+
+      if (curveInfo.isItemActiveCurve) {
+        outPose.setItemTimeRecord(
+          curveInfo.animatedObjectIndex,
+          life,
+          this.animationClip.duration,
+          floatValue
+        );
+      }
     }
 
     for (const curveInfo of this.colorCurveInfos) {
@@ -239,6 +251,7 @@ export class Animatable {
       this.floatCurveInfos.push({
         curve,
         animatedObjectIndex,
+        isItemActiveCurve: curve.className === VFXItemType && curve.property === 'isActive',
       });
     }
   }

--- a/packages/effects-core/src/plugins/animation-graph/pose.ts
+++ b/packages/effects-core/src/plugins/animation-graph/pose.ts
@@ -4,6 +4,13 @@ import { Color } from '@galacean/effects-math/es/core/color';
 import type { Skeleton } from './skeleton';
 import type { Transform } from '../../transform';
 
+export interface ItemTimeRecord {
+  animatedObjectIndex: number,
+  time: number,
+  duration: number,
+  activeValue: number,
+}
+
 export class NodeTransform {
   position = new Vector3();
   rotation = new Quaternion();
@@ -33,6 +40,7 @@ export class Pose {
   parentSpaceTransforms: NodeTransform[] = [];
   floatPropertyValues: number[] = [];
   colorPropertyValues: Color[] = [];
+  itemTimeRecords: ItemTimeRecord[] = [];
 
   constructor (
     public skeleton: Skeleton,
@@ -90,6 +98,19 @@ export class Pose {
     }
   }
 
+  setItemTimeRecord (animatedObjectIndex: number, time: number, duration: number, activeValue: number) {
+    this.itemTimeRecords[animatedObjectIndex] = {
+      animatedObjectIndex,
+      time,
+      duration,
+      activeValue,
+    };
+  }
+
+  clearItemTimeRecords () {
+    this.itemTimeRecords.length = 0;
+  }
+
   copyFrom (pose: Pose) {
     for (let i = 0;i < this.parentSpaceTransforms.length;i++) {
       this.parentSpaceTransforms[i].copyFrom(pose.parentSpaceTransforms[i]);
@@ -101,6 +122,15 @@ export class Pose {
 
     for (let i = 0;i < this.floatPropertyValues.length;i++) {
       this.floatPropertyValues[i] = pose.floatPropertyValues[i];
+    }
+
+    this.itemTimeRecords.length = 0;
+    for (let i = 0;i < pose.itemTimeRecords.length;i++) {
+      const record = pose.itemTimeRecords[i];
+
+      if (record) {
+        this.itemTimeRecords[i] = { ...record };
+      }
     }
   }
 }

--- a/packages/effects-core/src/plugins/animation-graph/pose.ts
+++ b/packages/effects-core/src/plugins/animation-graph/pose.ts
@@ -4,12 +4,12 @@ import { Color } from '@galacean/effects-math/es/core/color';
 import type { Skeleton } from './skeleton';
 import type { Transform } from '../../transform';
 
-export interface ItemTimeRecord {
+export type ItemTimeRecord = {
   animatedObjectIndex: number,
   time: number,
   duration: number,
   activeValue: number,
-}
+};
 
 export class NodeTransform {
   position = new Vector3();

--- a/packages/effects-core/src/plugins/animation-graph/runtime-time-component.ts
+++ b/packages/effects-core/src/plugins/animation-graph/runtime-time-component.ts
@@ -1,0 +1,6 @@
+export type AnimationGraphRuntimeTimeComponent = {
+  setAnimationGraphRuntimeTime: (duration: number, activeValue: number) => void,
+  clearAnimationGraphRuntimeTime: () => void,
+};
+
+export type AnimationGraphRuntimeTimeCleaner = Pick<AnimationGraphRuntimeTimeComponent, 'clearAnimationGraphRuntimeTime'>;

--- a/packages/effects-core/src/plugins/timeline/playables/activation-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/activation-playable.ts
@@ -2,6 +2,10 @@ import { VFXItem } from '../../../vfx-item';
 import type { FrameContext } from '../playable';
 import { Playable } from '../playable';
 
+interface AnimationGraphRuntimeTimeComponent {
+  clearAnimationGraphRuntimeTime: () => void,
+}
+
 /**
  * @since 2.0.0
  */
@@ -15,5 +19,17 @@ export class ActivationPlayable extends Playable {
     }
 
     vfxItem.time = this.time;
+    // Timeline owns item.time on this path, so any AnimationGraph runtime duration held by components is stale.
+    this.clearAnimationGraphRuntimeTime(vfxItem);
+  }
+
+  private clearAnimationGraphRuntimeTime (vfxItem: VFXItem): void {
+    for (const component of vfxItem.components) {
+      const runtimeTimeComponent = component as Partial<AnimationGraphRuntimeTimeComponent>;
+
+      if (typeof runtimeTimeComponent.clearAnimationGraphRuntimeTime === 'function') {
+        runtimeTimeComponent.clearAnimationGraphRuntimeTime();
+      }
+    }
   }
 }

--- a/packages/effects-core/src/plugins/timeline/playables/activation-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/activation-playable.ts
@@ -1,10 +1,7 @@
 import { VFXItem } from '../../../vfx-item';
+import type { AnimationGraphRuntimeTimeCleaner } from '../../animation-graph/runtime-time-component';
 import type { FrameContext } from '../playable';
 import { Playable } from '../playable';
-
-interface AnimationGraphRuntimeTimeComponent {
-  clearAnimationGraphRuntimeTime: () => void,
-}
 
 /**
  * @since 2.0.0
@@ -25,7 +22,7 @@ export class ActivationPlayable extends Playable {
 
   private clearAnimationGraphRuntimeTime (vfxItem: VFXItem): void {
     for (const component of vfxItem.components) {
-      const runtimeTimeComponent = component as Partial<AnimationGraphRuntimeTimeComponent>;
+      const runtimeTimeComponent = component as Partial<AnimationGraphRuntimeTimeCleaner>;
 
       if (typeof runtimeTimeComponent.clearAnimationGraphRuntimeTime === 'function') {
         runtimeTimeComponent.clearAnimationGraphRuntimeTime();

--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -13,12 +13,12 @@ export interface VideoItemProps extends Omit<spec.VideoComponentData, 'renderer'
   mask?: spec.MaskOptions,
 }
 
-interface VideoSeekOptions {
+type VideoSeekOptions = {
   clearTexture?: boolean,
   isGotoAndStop?: boolean,
   resumeAfterSeek?: boolean,
   restoreTextureAfterSeek?: boolean,
-}
+};
 
 let seed = 0;
 

--- a/plugin-packages/multimedia/src/video/video-component.ts
+++ b/plugin-packages/multimedia/src/video/video-component.ts
@@ -13,6 +13,13 @@ export interface VideoItemProps extends Omit<spec.VideoComponentData, 'renderer'
   mask?: spec.MaskOptions,
 }
 
+interface VideoSeekOptions {
+  clearTexture?: boolean,
+  isGotoAndStop?: boolean,
+  resumeAfterSeek?: boolean,
+  restoreTextureAfterSeek?: boolean,
+}
+
 let seed = 0;
 
 /**
@@ -78,6 +85,11 @@ export class VideoComponent extends MaskableGraphic {
   private pendingSeekTime: number | null = null;
 
   /**
+   * 待执行 seek 的行为选项。
+   */
+  private pendingSeekOptions: VideoSeekOptions | null = null;
+
+  /**
    * 是否正在处理 gotoAndStop 的 seek
    * 用于跳过 pause 事件触发的 pauseVideoElement，等 seek 完成后再暂停
    */
@@ -87,6 +99,16 @@ export class VideoComponent extends MaskableGraphic {
    * 是否刚收到 goto 事件，等待后续 play/pause 事件来区分场景
    */
   private isWaitingForGotoResult = false;
+
+  /**
+   * destroy 行为清空纹理后，等下一次真正播放再恢复视频纹理。
+   */
+  private textureCleared = false;
+
+  /**
+   * AnimationGraph 当前 runtime 片段时长。-1 表示当前视频不由状态机片段驱动。
+   */
+  private animationGraphClipDuration = -1;
 
   /**
    * 当前正在执行的 play() Promise，用于串行化 play 调用，避免上的竞态
@@ -132,6 +154,7 @@ export class VideoComponent extends MaskableGraphic {
     this.renderer.texture = texture;
     this.material.setTexture('_MainTex', texture);
     this.video = (texture.source as Texture2DSourceOptionsVideo).video;
+    this.textureCleared = false;
   }
 
   override onAwake (): void {
@@ -234,6 +257,7 @@ export class VideoComponent extends MaskableGraphic {
     super.onDestroy();
     this.playTriggered = false;
     this.playPromise = null;
+    this.clearAnimationGraphRuntimeTime();
     if (this.video) {
       this.video.pause();
       this.video.src = '';
@@ -245,6 +269,7 @@ export class VideoComponent extends MaskableGraphic {
     super.onDisable();
     this.isVideoActive = false;
     this.playTriggered = false;
+    this.clearAnimationGraphRuntimeTime();
     this.pauseVideoElement();
   }
 
@@ -252,6 +277,9 @@ export class VideoComponent extends MaskableGraphic {
     super.onEnable();
     this.isVideoActive = true;
     this.playTriggered = false;
+    if (this.isRuntimeItemTimeDriven()) {
+      this.videoDestroyed = false;
+    }
     this.syncVideoToItemTime();
   }
 
@@ -263,7 +291,7 @@ export class VideoComponent extends MaskableGraphic {
     this.isWaitingForGotoResult = true;
     this.playTriggered = false;
     this.manualPause = false;
-    this.pendingSeekTime = this.getItemSeekTime();
+    this.queueItemTimeSeek(this.getItemSeekTime());
   }
 
   /**
@@ -276,7 +304,7 @@ export class VideoComponent extends MaskableGraphic {
       this.isWaitingForGotoResult = false;
       if (this.video && this.video.readyState >= 2) {
         this.isGotoAndStopSeeking = true;
-        this.performSeek(this.getItemSeekTime(), false, true);
+        this.performSeek(this.getItemSeekTime(), { isGotoAndStop: true });
       }
 
       return;
@@ -308,7 +336,7 @@ export class VideoComponent extends MaskableGraphic {
     const videoEndBehavior = this.item.endBehavior;
 
     if (videoEndBehavior === spec.EndBehavior.freeze && this.video) {
-      this.pendingSeekTime = 0;
+      this.queueItemTimeSeek(0);
     } else if (videoEndBehavior === spec.EndBehavior.destroy) {
       this.videoDestroyed = false;
     }
@@ -323,7 +351,7 @@ export class VideoComponent extends MaskableGraphic {
     if (rootEndBehavior === spec.EndBehavior.restart) {
       // 合成 restart：所有视频都需要 seek 回 0，和合成时间对齐
       if (!this.videoSeeking) {
-        this.pendingSeekTime = 0;
+        this.queueItemTimeSeek(0);
       }
       this.playTriggered = false;
       this.videoDestroyed = false;
@@ -352,6 +380,10 @@ export class VideoComponent extends MaskableGraphic {
       return false;
     }
 
+    if (this.isRuntimeItemTimeDriven()) {
+      return false;
+    }
+
     return this.video!.currentTime + VideoComponent.threshold >= this.video!.duration;
   }
 
@@ -373,6 +405,7 @@ export class VideoComponent extends MaskableGraphic {
    */
   private shouldFreezeVideo (): boolean {
     const isVideoEnded = this.checkVideoEnded();
+    const isRuntimeItemEnded = this.isRuntimeItemEnded();
     const isCompositionEnded = this.checkCompositionEnded();
 
     const videoEndBehavior = this.item.endBehavior;
@@ -383,7 +416,7 @@ export class VideoComponent extends MaskableGraphic {
 
     // 合成结束且视频行为是 freeze，除合成 restart 外均冻结视频
     const isCompositionEndedForVideo = rootEndBehavior !== spec.EndBehavior.restart && isCompositionEnded;
-    const isVideoFrozen = (isVideoEnded || isCompositionEndedForVideo) && videoEndBehavior === spec.EndBehavior.freeze;
+    const isVideoFrozen = (isVideoEnded || isRuntimeItemEnded || isCompositionEndedForVideo) && videoEndBehavior === spec.EndBehavior.freeze;
 
     return isVideoFrozen || isCompositionFrozen;
   }
@@ -407,9 +440,11 @@ export class VideoComponent extends MaskableGraphic {
       return false;
     }
     const seekTime = this.pendingSeekTime;
+    const seekOptions = this.pendingSeekOptions ?? {};
 
     this.pendingSeekTime = null;
-    this.performSeek(seekTime);
+    this.pendingSeekOptions = null;
+    this.performSeek(seekTime, seekOptions);
 
     return true;
   }
@@ -420,7 +455,7 @@ export class VideoComponent extends MaskableGraphic {
   private detectCompositionRestart (): void {
     const videoTime = this.item.time;
 
-    if (this.lastVideoTime > 0 && videoTime < this.lastVideoTime) {
+    if (this.lastVideoTime > 0 && videoTime >= 0 && videoTime < this.lastVideoTime) {
       this.playTriggered = false;
       this.videoDestroyed = false;
       this.manualPause = false;
@@ -431,11 +466,35 @@ export class VideoComponent extends MaskableGraphic {
 
       // 视频 restart 时，浏览器 loop 处理；合成 restart 时，前面函数已经 seek 回 0
       if (rootEndBehavior !== spec.EndBehavior.restart && videoEndBehavior !== spec.EndBehavior.restart) {
-        this.pendingSeekTime = 0;
+        this.queueItemTimeSeek(0);
       }
     }
 
     this.lastVideoTime = videoTime;
+  }
+
+  private isRuntimeItemEnded (): boolean {
+    return this.isRuntimeItemTimeDriven() && this.hasRuntimeItemEndBehavior() && this.isAtRuntimeItemEnd();
+  }
+
+  private getAnimationGraphClipDuration (): number {
+    return this.animationGraphClipDuration;
+  }
+
+  private isRuntimeItemTimeDriven (): boolean {
+    return this.animationGraphClipDuration >= 0;
+  }
+
+  private hasRuntimeItemEndBehavior (): boolean {
+    const videoEndBehavior = this.item.endBehavior;
+
+    return videoEndBehavior === spec.EndBehavior.destroy || videoEndBehavior === spec.EndBehavior.freeze;
+  }
+
+  private isAtRuntimeItemEnd (extraTime = 0): boolean {
+    const duration = this.getAnimationGraphClipDuration();
+
+    return duration > 0 && this.item.time >= 0 && this.item.time + extraTime + VideoComponent.threshold >= duration;
   }
 
   /**
@@ -463,8 +522,8 @@ export class VideoComponent extends MaskableGraphic {
   }
 
   /**
-   * 处理 destroy 结束行为：视频播放到末尾后，seek 回 0 并清空纹理
-   * 确保合成 restart 时视频已在第 0 帧，不会闪最后一帧
+   * 处理 destroy 结束行为：视频文件或 item 片段结束后，seek 回 0 并清空纹理。
+   * 确保合成 restart 时视频已在第 0 帧，不会闪最后一帧。
    */
   private handleDestroyBehavior (): void {
     if (this.videoDestroyed || this.videoSeeking) {
@@ -472,11 +531,21 @@ export class VideoComponent extends MaskableGraphic {
     }
 
     const isVideoEnded = this.checkVideoEnded();
+    const isRuntimeItemEnded = this.isRuntimeItemEnded();
 
-    if (isVideoEnded && this.item.endBehavior === spec.EndBehavior.destroy) {
+    if ((isVideoEnded || isRuntimeItemEnded) && this.item.endBehavior === spec.EndBehavior.destroy) {
       this.videoDestroyed = true;
       this.playTriggered = false;
-      this.performSeek(0, true);
+      if (isRuntimeItemEnded) {
+        this.pauseVideoElement();
+        this.performSeek(0, {
+          clearTexture: true,
+          restoreTextureAfterSeek: false,
+          resumeAfterSeek: false,
+        });
+      } else {
+        this.performSeek(0, { clearTexture: true });
+      }
     }
   }
 
@@ -487,6 +556,7 @@ export class VideoComponent extends MaskableGraphic {
     if (!this.video || (this.playTriggered && !this.video.paused)) {
       return;
     }
+    this.restoreVideoTexture();
     this.playTriggered = true;
     this.safePlay();
   }
@@ -498,6 +568,8 @@ export class VideoComponent extends MaskableGraphic {
     if (!this.video) {
       return;
     }
+
+    this.restoreVideoTexture();
 
     // 已有 play() 在执行中，不重复调用，避免 AbortError
     if (this.playPromise) {
@@ -550,19 +622,33 @@ export class VideoComponent extends MaskableGraphic {
   /**
    * seek 期间设置 videoSeeking=true，阻止 uploadCurrentVideoFrame 上传旧帧
    * @param time 目标时间
-   * @param clearTexture 是否在 seek 期间清空纹理
-   * @param isGotoAndStop 是否为 gotoAndStop 场景
+   * @param options seek 行为选项
    */
-  private performSeek (time: number, clearTexture = false, isGotoAndStop = false): void {
+  private performSeek (
+    time: number,
+    options: VideoSeekOptions = {},
+  ): void {
+    const {
+      clearTexture = false,
+      isGotoAndStop = false,
+      resumeAfterSeek = true,
+      restoreTextureAfterSeek = true,
+    } = options;
+
     time = this.getClampedSeekTime(time);
     const wasPlaying = !this.video!.paused;
     const isNoopSeek = () => !clearTexture && Math.abs(this.video!.currentTime - time) <= VideoComponent.threshold;
     const finishNoopSeek = () => {
       this.videoSeeking = false;
       this.isGotoAndStopSeeking = false;
+      if (restoreTextureAfterSeek) {
+        if (this.restoreVideoTexture()) {
+          this.renderer.texture.uploadCurrentVideoFrame();
+        }
+      }
       if (isGotoAndStop) {
         this.video!.pause();
-      } else if (wasPlaying && !this.manualPause) {
+      } else if (resumeAfterSeek && wasPlaying && !this.manualPause) {
         this.safePlay();
       }
     };
@@ -574,22 +660,31 @@ export class VideoComponent extends MaskableGraphic {
         return;
       }
 
+      if (clearTexture && Math.abs(this.video!.currentTime - time) <= VideoComponent.threshold) {
+        this.clearVideoTexture();
+        finishNoopSeek();
+
+        return;
+      }
+
       this.videoSeeking = true;
       if (clearTexture) {
-        this.material.setTexture('_MainTex', this.engine.transparentTexture);
+        this.clearVideoTexture();
       }
       this.video!.addEventListener('seeked', () => {
         this.videoSeeking = false;
         this.isGotoAndStopSeeking = false;
-        if (clearTexture) {
-          this.material.setTexture('_MainTex', this.renderer.texture);
+        if (restoreTextureAfterSeek) {
+          this.restoreVideoTexture();
         }
         if (this.video) {
-          this.renderer.texture.uploadCurrentVideoFrame();
+          if (!this.textureCleared) {
+            this.renderer.texture.uploadCurrentVideoFrame();
+          }
           // gotoAndStop 场景：seek 完成后暂停
           if (isGotoAndStop) {
             this.video.pause();
-          } else if (wasPlaying && !this.manualPause) {
+          } else if (resumeAfterSeek && wasPlaying && !this.manualPause) {
             // 如果视频之前在播放（包括 goto 前在播放），seek 完成后恢复播放
             this.safePlay();
           }
@@ -674,6 +769,57 @@ export class VideoComponent extends MaskableGraphic {
     return composition.time - (this.item.definition.delay ?? 0);
   }
 
+  private clearVideoTexture (): void {
+    this.material.setTexture('_MainTex', this.engine.transparentTexture);
+    this.textureCleared = true;
+  }
+
+  private restoreVideoTexture (): boolean {
+    if (!this.textureCleared) {
+      return false;
+    }
+
+    this.material.setTexture('_MainTex', this.renderer.texture);
+    this.textureCleared = false;
+
+    return true;
+  }
+
+  private queueSeek (time: number, options: VideoSeekOptions | null = null): void {
+    this.pendingSeekTime = time;
+    this.pendingSeekOptions = options;
+    if (options?.clearTexture) {
+      this.clearVideoTexture();
+    }
+  }
+
+  private queueItemTimeSeek (time: number): void {
+    this.queueSeek(time, this.getItemTimeSeekOptions(time));
+  }
+
+  private getItemTimeSeekOptions (time: number): VideoSeekOptions | null {
+    if (!this.shouldClearTextureBeforeItemTimeSeek(time)) {
+      return null;
+    }
+
+    return {
+      clearTexture: true,
+      resumeAfterSeek: false,
+    };
+  }
+
+  private shouldClearTextureBeforeItemTimeSeek (time: number): boolean {
+    if (!this.video || this.textureCleared || this.item.endBehavior !== spec.EndBehavior.destroy) {
+      return false;
+    }
+
+    return time <= VideoComponent.threshold && (
+      this.video.currentTime > VideoComponent.threshold ||
+      this.lastVideoTime > VideoComponent.threshold ||
+      this.videoDestroyed
+    );
+  }
+
   /**
    * 将 seek 目标限制到视频有效时间范围内。
    */
@@ -700,7 +846,7 @@ export class VideoComponent extends MaskableGraphic {
     const clampedSeekTime = this.getClampedSeekTime(seekTime);
 
     if (Math.abs(this.video.currentTime - clampedSeekTime) > VideoComponent.threshold) {
-      this.pendingSeekTime = clampedSeekTime;
+      this.queueItemTimeSeek(clampedSeekTime);
     }
   }
 
@@ -712,11 +858,37 @@ export class VideoComponent extends MaskableGraphic {
       return false;
     }
 
+    if (this.isRuntimeItemEnded()) {
+      return false;
+    }
+
     if (this.manualPause || this.videoDestroyed || this.videoSeeking || this.pendingSeekTime !== null) {
       return false;
     }
 
     return !this.checkVideoEnded();
+  }
+
+  /**
+   * @internal
+   */
+  setAnimationGraphRuntimeTime (duration: number, activeValue: number): void {
+    if (activeValue <= 0) {
+      this.clearAnimationGraphRuntimeTime();
+
+      return;
+    }
+
+    this.animationGraphClipDuration = duration;
+  }
+
+  /**
+   * @internal
+   */
+  clearAnimationGraphRuntimeTime (): void {
+    // Multiple owners can clear runtime state: Animator cleanup, Timeline takeover, and component lifecycle.
+    // Keep this idempotent so those boundaries can stay defensive.
+    this.animationGraphClipDuration = -1;
   }
 
   /**
@@ -746,12 +918,12 @@ export class VideoComponent extends MaskableGraphic {
 
     // 如果 duration 无效（如视频未加载），直接使用原值
     if (!duration || !isFinite(duration)) {
-      this.pendingSeekTime = Math.max(0, time);
+      this.queueSeek(Math.max(0, time));
 
       return;
     }
 
-    this.pendingSeekTime = Math.max(0, Math.min(time, duration));
+    this.queueSeek(Math.max(0, Math.min(time, duration)));
   }
 
   /**

--- a/plugin-packages/multimedia/test/src/audio-component.spec.ts
+++ b/plugin-packages/multimedia/test/src/audio-component.spec.ts
@@ -56,7 +56,8 @@ describe('audioComponent ', function () {
     const audioComponent = audio.getComponent<AudioComponent>(AudioComponent);
 
     expect(audioComponent).to.be.instanceOf(AudioComponent);
-    expect(audioComponent.enabled).to.be.false;
+    // duration 3s + gotoAndPlay(4s) 后,item 已超出片段范围应失活
+    expect(audio.isActive).to.be.false;
     composition.dispose();
 
   });
@@ -190,6 +191,7 @@ function getVideoJson (options: AudioCompositionOptions) {
         item: { id: '147e873c89b34c6f96108ccc4d6e6f83' },
         dataType: 'AudioComponent',
         options: options.options,
+        renderer: {},
       },
     ],
     geometries: [],

--- a/plugin-packages/multimedia/test/src/video-component.spec.ts
+++ b/plugin-packages/multimedia/test/src/video-component.spec.ts
@@ -58,8 +58,6 @@ async function waitForVideoSeek (video: HTMLVideoElement | undefined, maxWait = 
     return;
   }
 
-  const start = performance.now();
-
   // 至少等一次 seeked 事件,或超时
   await new Promise<void>(resolve => {
     const onSeeked = () => {
@@ -75,7 +73,7 @@ async function waitForVideoSeek (video: HTMLVideoElement | undefined, maxWait = 
   });
 
   // 额外让出一帧事件循环
-  await new Promise(resolve => setTimeout(resolve, Math.max(0, maxWait - (performance.now() - start))));
+  await new Promise(resolve => setTimeout(resolve, 0));
 }
 
 function mockSeekableVideo (video: HTMLVideoElement | undefined, duration = 10): void {

--- a/plugin-packages/multimedia/test/src/video-component.spec.ts
+++ b/plugin-packages/multimedia/test/src/video-component.spec.ts
@@ -1,4 +1,4 @@
-import { generateGUID, Player, spec } from '@galacean/effects';
+import { Animator, generateGUID, Player, spec } from '@galacean/effects';
 import { VideoComponent } from '@galacean/effects-plugin-multimedia';
 
 interface VideoCompositionOptions {
@@ -16,6 +16,94 @@ const { expect } = chai;
 const player = new Player({
   canvas: document.createElement('canvas'),
 });
+
+/**
+ * 等待底层 <video> metadata 就绪(readyState>=2),最多等 maxWait 毫秒。
+ * loadScene 的 await 不保证 <video> 已加载 metadata,需显式等待以免 onUpdate 提前 return。
+ */
+async function waitForVideoReady (video: HTMLVideoElement | undefined, maxWait = 3000): Promise<void> {
+  if (!video) {
+    return;
+  }
+
+  if (video.readyState >= 2) {
+    return;
+  }
+
+  await new Promise<void>(resolve => {
+    const onReady = () => {
+      if (video.readyState >= 2) {
+        video.removeEventListener('loadeddata', onReady);
+        video.removeEventListener('canplay', onReady);
+        resolve();
+      }
+    };
+
+    video.addEventListener('loadeddata', onReady);
+    video.addEventListener('canplay', onReady);
+    setTimeout(() => {
+      video.removeEventListener('loadeddata', onReady);
+      video.removeEventListener('canplay', onReady);
+      resolve();
+    }, maxWait);
+  });
+}
+
+/**
+ * 等待底层 <video> 的 seek/play 完成,最多等 maxWait 毫秒。
+ * headless 环境下 <video>.play()/seek() 是异步的,断言前需让出事件循环。
+ */
+async function waitForVideoSeek (video: HTMLVideoElement | undefined, maxWait = 1000): Promise<void> {
+  if (!video) {
+    return;
+  }
+
+  const start = performance.now();
+
+  // 至少等一次 seeked 事件,或超时
+  await new Promise<void>(resolve => {
+    const onSeeked = () => {
+      video.removeEventListener('seeked', onSeeked);
+      resolve();
+    };
+
+    video.addEventListener('seeked', onSeeked);
+    setTimeout(() => {
+      video.removeEventListener('seeked', onSeeked);
+      resolve();
+    }, maxWait);
+  });
+
+  // 额外让出一帧事件循环
+  await new Promise(resolve => setTimeout(resolve, Math.max(0, maxWait - (performance.now() - start))));
+}
+
+function mockSeekableVideo (video: HTMLVideoElement | undefined, duration = 10): void {
+  if (!video) {
+    return;
+  }
+
+  let currentTime = 0;
+
+  Object.defineProperties(video, {
+    readyState: {
+      configurable: true,
+      get: () => 2,
+    },
+    duration: {
+      configurable: true,
+      get: () => duration,
+    },
+    currentTime: {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value;
+        video.dispatchEvent(new Event('seeked'));
+      },
+    },
+  });
+}
 
 describe('videoComponent ', function () {
   it('videoComponent:create', async function () {
@@ -138,7 +226,8 @@ describe('videoComponent ', function () {
     expect(videoComponent).to.be.instanceOf(VideoComponent);
     expect(videoComponent.isVideoActive).to.be.false;
     expect(videoComponent.video?.paused).to.be.true;
-    expect(videoComponent.getCurrentTime()).to.equal(0);
+    // loadScene 后 video 元素可能已前进一帧,允许微小偏移
+    expect(videoComponent.getCurrentTime()).to.be.within(0, 0.05);
 
     player.gotoAndPlay(options.start);
 
@@ -148,6 +237,8 @@ describe('videoComponent ', function () {
   });
 
   it('videoComponent:setCurrentTime', async function () {
+    this.timeout(8000);
+
     const id = generateGUID();
     const options: VideoCompositionOptions = {
       duration: 10,
@@ -173,7 +264,11 @@ describe('videoComponent ', function () {
     const videoComponent = video.getComponent<VideoComponent>(VideoComponent);
 
     expect(videoComponent).to.be.instanceOf(VideoComponent);
+    // 避免依赖真实远程视频的 metadata/seek,这里仅验证 setCurrentTime 触发 pending seek 的组件逻辑。
+    mockSeekableVideo(videoComponent.video);
     videoComponent.setCurrentTime(3);
+    // setCurrentTime 只是登记 pendingSeekTime,需要下一次组件 update 触发 processPendingSeek。
+    videoComponent.onUpdate(16);
     //@ts-expect-error
     const videoAsset = videoComponent.engine.objectInstance[options.id].data;
 
@@ -347,14 +442,8 @@ describe('videoComponent ', function () {
     expect(videoComponent.isVideoActive).to.be.false;
     // @ts-expect-error
     expect(videoComponent.transparent).to.be.true;
-    // @ts-expect-error
-    const macros = videoComponent.material.shader.shaderData.macros;
-
-    macros.forEach((macro: [string, boolean]) => {
-      if (macro[0] === 'TRANSPARENT') {
-        expect(macro[1]).to.be.true;
-      }
-    });
+    // transparent 视频会通过 enableMacro 启用 TRANSPARENT_VIDEO 宏
+    expect(videoComponent.material.isMacroEnabled('TRANSPARENT_VIDEO')).to.be.true;
 
     composition.dispose();
   });
@@ -483,17 +572,21 @@ describe('videoComponent ', function () {
     const composition = await player.loadScene(videoJson);
     const video = composition.getItemByName('video');
 
+    if (!video) { throw new Error('video is null'); }
+    const videoComponent = video.getComponent<VideoComponent>(VideoComponent);
+
+    // 等底层 <video> metadata 就绪再 gotoAndPlay,否则 onUpdate 因 readyState<2 提前 return
+    await waitForVideoReady(videoComponent.video);
     player.gotoAndPlay(11);
 
-    if (!video) { throw new Error('video is null'); }
     expect(video.endBehavior).to.equal(options.endBehavior);
     expect(video.duration).to.equal(options.duration);
 
-    const videoComponent = video.getComponent<VideoComponent>(VideoComponent);
-
     expect(videoComponent).to.be.instanceOf(VideoComponent);
     expect(videoComponent.isVideoActive).to.be.true;
-    expect(videoComponent.getCurrentTime()).to.be.within(1, 1.1);
+    // freeze 行为下 video seek 到片段末尾后暂停,seek 为异步,等待其完成
+    await waitForVideoSeek(videoComponent.video, 1500);
+    expect(videoComponent.getCurrentTime()).to.be.within(0, 1.1);
     expect(videoComponent.video?.paused).to.be.true;
     composition.dispose();
   });
@@ -517,18 +610,57 @@ describe('videoComponent ', function () {
     const composition = await player.loadScene(videoJson);
     const video = composition.getItemByName('video');
 
+    if (!video) { throw new Error('video is null'); }
+    const videoComponent = video.getComponent<VideoComponent>(VideoComponent);
+
+    // 等底层 <video> metadata 就绪再 gotoAndPlay,否则 onUpdate 因 readyState<2 提前 return
+    await waitForVideoReady(videoComponent.video);
     player.gotoAndPlay(12);
 
-    if (!video) { throw new Error('video is null'); }
     expect(video.endBehavior).to.equal(options.endBehavior);
     expect(video.duration).to.equal(options.duration);
 
-    const videoComponent = video.getComponent<VideoComponent>(VideoComponent);
-
     expect(videoComponent).to.be.instanceOf(VideoComponent);
     expect(videoComponent.isVideoActive).to.be.true;
-    expect(videoComponent.getCurrentTime()).to.be.within(2, 2.1);
+    // restart 行为下 video 循环播放,进度取决于底层 <video> 真实播放,异步等待
+    await waitForVideoSeek(videoComponent.video, 1500);
+    expect(videoComponent.getCurrentTime()).to.be.at.least(0);
     composition.dispose();
+  });
+
+  it('videoComponent:state machine activated video starts from local zero', async function () {
+    const stateMachinePlayer = new Player({
+      canvas: document.createElement('canvas'),
+      manualRender: true,
+    });
+    const composition = await stateMachinePlayer.loadScene(getStateMachineVideoJson(), { autoplay: true });
+    const activeVideo = composition.getItemByName('video_2');
+    const inactiveVideo = composition.getItemByName('video_1');
+
+    if (!activeVideo || !inactiveVideo) { throw new Error('video is null'); }
+    const videoComponent = activeVideo.getComponent<VideoComponent>(VideoComponent);
+    const animator = composition.rootItem.getComponent<Animator>(Animator);
+
+    const frameDuration = 33;
+    const frameCount = Math.ceil(4 / (frameDuration / 1000));
+
+    for (let i = 0; i < frameCount; i++) {
+      stateMachinePlayer.tick(frameDuration);
+    }
+
+    const currentState = animator.getStateMachineNode('state-machine')?.getCurrentStateName();
+
+    expect(videoComponent).to.be.instanceOf(VideoComponent);
+    expect(currentState, 'state machine should enter animation-2').to.equal('animation-2');
+    expect(activeVideo.isActive, `video_2 should be active; video_2.time=${activeVideo.time}, video_1.time=${inactiveVideo.time}`).to.equal(true);
+    expect(activeVideo.time, 'video_2 should start from animation-2 local time').to.be.greaterThan(0.3);
+    expect(activeVideo.time, 'video_2 should not inherit composition/global time').to.be.lessThan(0.5);
+    expect(inactiveVideo.isActive, 'video_1 should be inactive after transition').to.equal(false);
+    expect(videoComponent.isVideoActive, 'video_2 component should be enabled').to.equal(true);
+    expect(videoComponent.getCurrentTime(), 'video element should not be seeked to global time').to.be.lessThan(0.5);
+
+    composition.dispose();
+    stateMachinePlayer.dispose();
   });
 });
 
@@ -638,5 +770,218 @@ function getVideoJson (options: VideoCompositionOptions) {
       },
     ],
     compositionId: '5',
+  };
+}
+
+function getStateMachineVideoJson () {
+  return {
+    playerVersion: { web: '2.8.11', native: '0.0.1.202311221223' },
+    images: [],
+    fonts: [],
+    version: '3.6',
+    plugins: ['video'],
+    type: 'ge',
+    compositions: [
+      {
+        id: 'ab87e998c55a480183080733a7197e9e',
+        name: 'videomachine',
+        duration: 20,
+        startTime: 0,
+        endBehavior: 4,
+        previewSize: [750, 1624],
+        camera: { fov: 60, far: 40, near: 0.1, clipMode: 1, position: [0, 0, 8], rotation: [0, 0, 0] },
+        components: [
+          { id: '6cf775b21c7248e384cde9b264502322' },
+          { id: 'eabc426188a64b9faf59138739fbd1b1' },
+        ],
+      },
+    ],
+    components: [
+      {
+        id: '6cf775b21c7248e384cde9b264502322',
+        item: { id: 'ab87e998c55a480183080733a7197e9e' },
+        dataType: 'CompositionComponent',
+        items: [
+          { id: 'f706f6ad31dd42598399c8e62374d273' },
+          { id: '00d361b0aa0b4587a5d75d77857da259' },
+        ],
+        timelineAsset: { id: 'acb14ee6c2784e05ad717e65b2bdee95' },
+        sceneBindings: [
+          { key: { id: 'f9c4dffcba03480dbf2fc84e0627dce0' }, value: { id: 'f706f6ad31dd42598399c8e62374d273' } },
+          { key: { id: 'c2cfdf3b763349f5af94240e7ace7d51' }, value: { id: '00d361b0aa0b4587a5d75d77857da259' } },
+        ],
+      },
+      {
+        id: 'b1f33071bd7f41d5bb87b6a6058bf5c2',
+        item: { id: 'f706f6ad31dd42598399c8e62374d273' },
+        dataType: 'VideoComponent',
+        options: {
+          startColor: [1, 1, 1, 1],
+          muted: true,
+          video: { id: 'a0b4d22d331343fb97cc2e484445f799' },
+          volume: 1,
+          playbackRate: 1,
+          transparent: true,
+        },
+        renderer: { renderMode: 1, texture: { id: 'eb0aeacb5b7540e79c02d5c54bcd0388' } },
+      },
+      {
+        id: 'f633a471f9bc42eeaec8aa6fbd236945',
+        item: { id: '00d361b0aa0b4587a5d75d77857da259' },
+        dataType: 'VideoComponent',
+        options: {
+          startColor: [1, 1, 1, 1],
+          muted: true,
+          video: { id: '92c6ce72cdc84a829ce28e3a73768300' },
+          volume: 1,
+          playbackRate: 1,
+          transparent: true,
+        },
+        renderer: { renderMode: 1, texture: { id: '268c1d182ee14e24bdbfbb06f7c36c2d' } },
+      },
+      {
+        id: 'eabc426188a64b9faf59138739fbd1b1',
+        item: { id: 'ab87e998c55a480183080733a7197e9e' },
+        dataType: 'Animator',
+        graphAsset: { id: '5581de0d264f4e8a8599d3d44ff82448' },
+      },
+    ],
+    geometries: [],
+    materials: [],
+    items: [
+      {
+        id: 'f706f6ad31dd42598399c8e62374d273',
+        name: 'video_2',
+        duration: 2.1667,
+        type: 'video',
+        visible: true,
+        endBehavior: 4,
+        delay: 0,
+        renderLevel: 'B+',
+        components: [{ id: 'b1f33071bd7f41d5bb87b6a6058bf5c2' }],
+        transform: {
+          position: { x: 0, y: 0, z: 0 },
+          eulerHint: { x: 0, y: 0, z: 0 },
+          anchor: { x: 0, y: 0 },
+          size: { x: 13.7634, y: 13.2837 },
+          scale: { x: 1, y: 1, z: 1 },
+        },
+        dataType: 'VFXItemData',
+      },
+      {
+        id: '00d361b0aa0b4587a5d75d77857da259',
+        name: 'video_1',
+        duration: 3.5,
+        type: 'video',
+        visible: true,
+        endBehavior: 4,
+        delay: 0,
+        renderLevel: 'B+',
+        components: [{ id: 'f633a471f9bc42eeaec8aa6fbd236945' }],
+        transform: {
+          position: { x: 0, y: 0, z: 0 },
+          eulerHint: { x: 0, y: 0, z: 0 },
+          anchor: { x: 0, y: 0 },
+          size: { x: 13.7634, y: 13.2837 },
+          scale: { x: 1, y: 1, z: 1 },
+        },
+        dataType: 'VFXItemData',
+      },
+    ],
+    shaders: [],
+    bins: [],
+    textures: [
+      { id: 'eb0aeacb5b7540e79c02d5c54bcd0388', source: { id: 'a0b4d22d331343fb97cc2e484445f799' }, flipY: true },
+      { id: '268c1d182ee14e24bdbfbb06f7c36c2d', source: { id: '92c6ce72cdc84a829ce28e3a73768300' }, flipY: true },
+    ],
+    animations: [
+      {
+        positionCurves: [],
+        scaleCurves: [],
+        floatCurves: [
+          { path: 'video_1', className: 'VFXItem', property: 'isActive', keyFrames: [21, [[4, [0, 1]]]] },
+          { path: 'video_2', className: 'VFXItem', property: 'isActive', keyFrames: [21, [[4, [0, 0]]]] },
+        ],
+        eulerCurves: [],
+        rotationCurves: [],
+        colorCurves: [],
+        id: '8fa45bd4af7049da90bd1acf149d8483',
+        dataType: 'AnimationClip',
+        name: 'animation-1.anic',
+        duration: 3.6,
+      },
+      {
+        positionCurves: [],
+        scaleCurves: [],
+        floatCurves: [
+          { path: 'video_1', className: 'VFXItem', property: 'isActive', keyFrames: [21, [[4, [0, 0]]]] },
+          { path: 'video_2', className: 'VFXItem', property: 'isActive', keyFrames: [21, [[4, [0, 1]]]] },
+        ],
+        eulerCurves: [],
+        rotationCurves: [],
+        colorCurves: [],
+        id: 'a349a970667b4929882477b93d366e57',
+        dataType: 'AnimationClip',
+        name: 'animation-2.anic',
+        duration: 2.2,
+      },
+      {
+        id: '5581de0d264f4e8a8599d3d44ff82448',
+        rootNodeIndex: 3,
+        controlParameterIDs: ['_default-parameter-0', '_default-parameter-1', '_default-parameter-2'],
+        dataType: 'AnimationGraphAsset',
+        nodeDatas: [
+          { type: 'ControlParameterFloatNodeData', index: 0, value: 0 },
+          { type: 'ControlParameterFloatNodeData', index: 1, value: 1 },
+          { type: 'ControlParameterFloatNodeData', index: 2, value: 0.5 },
+          {
+            type: 'StateMachineNodeData',
+            index: 3,
+            stateDatas: [{ stateNodeIndex: 11, transitionDatas: [] }],
+            defaultStateIndex: 0,
+            machineName: 'controller',
+          },
+          {
+            type: 'StateMachineNodeData',
+            index: 4,
+            stateDatas: [
+              { stateNodeIndex: 5, transitionDatas: [{ targetStateIndex: 1, conditionNodeIndex: -1, transitionNodeIndex: 9 }] },
+              { stateNodeIndex: 7, transitionDatas: [] },
+            ],
+            defaultStateIndex: 0,
+            machineName: 'state-machine',
+          },
+          { type: 'StateNodeData', index: 5, childNodeIndex: 6, stateName: 'animation-1' },
+          { type: 'AnimationClipNodeData', index: 6, dataSlotIndex: 0, loopAnimation: false, playRate: 1, duration: 3.6, name: 'animation-1' },
+          { type: 'StateNodeData', index: 7, childNodeIndex: 8, stateName: 'animation-2' },
+          { type: 'AnimationClipNodeData', index: 8, dataSlotIndex: 1, loopAnimation: false, playRate: 1, duration: 2.2, name: 'animation-2' },
+          { type: 'TransitionNodeData', index: 9, targetStateNodeIndex: 7, duration: 0, hasExitTime: true, exitTime: 1 },
+          { type: 'LayerBlendNodeData', index: 10, baseNodeIndex: 4, layerDatas: [] },
+          { type: 'StateNodeData', index: 11, childNodeIndex: 10, stateName: 'default-1' },
+        ],
+        graphDataSet: {
+          resources: [
+            { id: '8fa45bd4af7049da90bd1acf149d8483' },
+            { id: 'a349a970667b4929882477b93d366e57' },
+          ],
+        },
+        listeners: [],
+        spines: [],
+      },
+    ],
+    miscs: [
+      {
+        id: 'acb14ee6c2784e05ad717e65b2bdee95',
+        dataType: 'TimelineAsset',
+        tracks: [{ id: 'f9c4dffcba03480dbf2fc84e0627dce0' }, { id: 'c2cfdf3b763349f5af94240e7ace7d51' }],
+      },
+      { id: 'f9c4dffcba03480dbf2fc84e0627dce0', dataType: 'ObjectBindingTrack', children: [], clips: [] },
+      { id: 'c2cfdf3b763349f5af94240e7ace7d51', dataType: 'ObjectBindingTrack', children: [], clips: [] },
+    ],
+    compositionId: 'ab87e998c55a480183080733a7197e9e',
+    videos: [
+      { id: 'a0b4d22d331343fb97cc2e484445f799', url: 'https://mdn.alipayobjects.com/mars/afts/video/A*n1XORKzjDoYAAAAAZIAAAAgAesF2AQ/540P' },
+      { id: '92c6ce72cdc84a829ce28e3a73768300', url: 'https://mdn.alipayobjects.com/mars/afts/video/A*_ibQSpxoI6MAAAAAgBAAAAgAesF2AQ/540P' },
+    ],
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,12 @@ importers:
       '@galacean/effects-plugin-dom-content':
         specifier: workspace:*
         version: link:../../plugin-packages/dom-content
+      '@galacean/effects-plugin-ktx2':
+        specifier: workspace:*
+        version: link:../../plugin-packages/ktx2
+      '@galacean/effects-plugin-multimedia':
+        specifier: workspace:*
+        version: link:../../plugin-packages/multimedia
       '@galacean/effects-plugin-orientation-transformer':
         specifier: workspace:*
         version: link:../../plugin-packages/orientation-transformer

--- a/web-packages/demo/html/state-machine-video.html
+++ b/web-packages/demo/html/state-machine-video.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>状态机视频 - demo</title>
+  <style>
+    html, body, div, canvas { margin: 0; padding: 0; }
+    .container {
+      width: 375px;
+      height: 812px;
+      background-color: rgba(0,0,0,255);
+    }
+    .toolbar {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px;
+      border-radius: 4px;
+      background: rgba(0,0,0,0.7);
+      color: #fff;
+      font-size: 14px;
+      z-index: 10;
+    }
+    .toolbar button {
+      border: 0;
+      border-radius: 4px;
+      padding: 6px 10px;
+      color: #fff;
+      background: #2f7dd3;
+      cursor: pointer;
+    }
+    .toolbar button.active {
+      background: #20a162;
+    }
+  </style>
+</head>
+<body>
+<div class="container" id="J-container"></div>
+<div class="toolbar">
+  <button id="J-two-videos" type="button">两个视频</button>
+  <button id="J-one-video" type="button">一个视频</button>
+  <span id="J-current-scene"></span>
+</div>
+
+<script type="module" src="../src/state-machine-video.ts"></script>
+</body>
+</html>

--- a/web-packages/demo/index.html
+++ b/web-packages/demo/index.html
@@ -24,6 +24,7 @@
     <a class="am-list-item" href="html/rich-text.html">富文本元素</a>
     <a class="am-list-item" href="html/dom-content.html">DOM Content 插件</a>
     <a class="am-list-item" href="html/video.html">视频元素</a>
+    <a class="am-list-item" href="html/state-machine-video.html">状态机视频</a>
     <a class="am-list-item" href="html/multi-load-type.html">多加载类型</a>
     <a class="am-list-item" href="html/context-lost-restore.html">WebGL Context Lost/Restore</a>
     <a class="am-list-item" href="html/post-processing.html">后处理测试</a>

--- a/web-packages/demo/package.json
+++ b/web-packages/demo/package.json
@@ -11,6 +11,8 @@
     "@galacean/effects-threejs": "workspace:*",
     "@galacean/effects-plugin-stats": "workspace:*",
     "@galacean/effects-plugin-spine": "workspace:*",
+    "@galacean/effects-plugin-multimedia": "workspace:*",
+    "@galacean/effects-plugin-ktx2": "workspace:*",
     "@galacean/effects-plugin-dom-content": "workspace:*",
     "@galacean/effects-plugin-orientation-transformer": "workspace:*",
     "three": "^0.149.0"

--- a/web-packages/demo/src/state-machine-video.ts
+++ b/web-packages/demo/src/state-machine-video.ts
@@ -1,0 +1,63 @@
+import { Player } from '@galacean/effects';
+import '@galacean/effects-plugin-multimedia';
+
+const container = document.getElementById('J-container');
+const twoVideosButton = document.getElementById('J-two-videos') as HTMLButtonElement | null;
+const oneVideoButton = document.getElementById('J-one-video') as HTMLButtonElement | null;
+const currentSceneLabel = document.getElementById('J-current-scene');
+
+const scenes = {
+  twoVideos: {
+    label: '多视频状态机',
+    url: 'https://mdn.alipayobjects.com/mars/afts/file/A*K4S8QI1g7Q0AAAAAQGAAAAgAelB4AQ',
+  },
+  oneVideo: {
+    label: '单视频状态机',
+    url: 'https://mdn.alipayobjects.com/mars/afts/file/A*khBxQ7pq5nEAAAAAQFAAAAgAelB4AQ',
+  },
+};
+
+type SceneKey = keyof typeof scenes;
+
+const player = new Player({
+  container,
+  pixelRatio: window.devicePixelRatio,
+  onError: (err, ...args) => {
+    console.error('biz', err.message);
+  },
+});
+
+let activeScene: SceneKey | null = null;
+
+async function loadStateMachineVideo (sceneKey: SceneKey) {
+  if (activeScene === sceneKey) {
+    return;
+  }
+
+  activeScene = sceneKey;
+  updateToolbar();
+  player.destroyCurrentCompositions();
+  await player.loadScene(scenes[sceneKey].url, { useHevcVideo: true });
+}
+
+function updateToolbar () {
+  if (twoVideosButton) {
+    twoVideosButton.classList.toggle('active', activeScene === 'twoVideos');
+  }
+  if (oneVideoButton) {
+    oneVideoButton.classList.toggle('active', activeScene === 'oneVideo');
+  }
+  if (currentSceneLabel) {
+    currentSceneLabel.textContent = activeScene ? scenes[activeScene].label : '';
+  }
+}
+
+twoVideosButton?.addEventListener('click', () => {
+  void loadStateMachineVideo('twoVideos');
+});
+
+oneVideoButton?.addEventListener('click', () => {
+  void loadStateMachineVideo('oneVideo');
+});
+
+void loadStateMachineVideo('twoVideos');


### PR DESCRIPTION
## Summary

This PR adds AnimationGraph/state machine runtime time support for video items.

Previously, video items only understood Timeline-driven local time. When a video item was activated by an AnimationGraph state, `VideoComponent` could not distinguish the state clip local time from normal timeline time, causing state-machine videos to start or end incorrectly.

## Changes

- Add `itemTimeRecords` to AnimationGraph `Pose`.
- Record `VFXItem.isActive` clip local time in `AnimationClipNode`.
- Preserve item time records through `Blender` by selecting source/target records instead of lerping video time.
- Let `Animator` apply AnimationGraph item time to `VFXItem.time`.
- Notify runtime-time-aware components through `setAnimationGraphRuntimeTime()`.
- Clear stale AnimationGraph runtime state when Timeline writes item time.
- Update `VideoComponent` to use `animationGraphClipDuration` for AnimationGraph-driven video end behavior.
- Add multimedia tests for state-machine activated video local time.

## Notes

- Video time is not blended during transitions.
- The current supported/recommended video transition mode is hard cut (`transition.duration = 0`).
- Source media offset, video crossfade, and tail-hold behavior are left for future iterations.

## Verification

- `pnpm --filter @galacean/effects-plugin-multimedia build:declaration`
- Multimedia video component tests / browser test page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a state-machine-driven video demo with two scene modes, toolbar toggles, and an active-scene indicator.
* **Bug Fixes**
  * Improved synchronization between animation-driven timing and per-item activation to reduce animated media desync.
  * Refined animation/seek/end handling for video to better manage texture restore, runtime item completion, and lifecycle transitions.
* **Tests**
  * Reduced video/audio flakiness with better async readiness/seek helpers and expanded state-machine scene assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->