### PR TITLE
feat: implement context lost and restore handling in gl engine

### DIFF
--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -853,16 +853,14 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   }
 
   lost (e: Event): void {
-    this.videoState = this.textures.map(tex => {
-      if ('video' in tex.source) {
-        tex.source.video.pause();
+    // GPU 资源由引擎统一 rebuild，合成仅保留纯 JS 运行时状态，此处无需处理。
+  }
 
-        return tex.source.video.currentTime;
-      }
-    });
-
-    this.textures.map(tex => tex.dispose());
-    this.dispose();
+  /**
+   * 上下文恢复后的空操作。
+   * GPU 资源已由引擎统一重建，视频纹理会在下次渲染时自然更新，不自动重新播放。
+   */
+  restore (): void {
   }
 
   /**

--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -7,6 +7,7 @@ import type { Material } from './material';
 import type {
   GPUCapability, Geometry, Mesh, RenderPass, RenderPassClearAction, Renderer, RenderingData, ShaderLibrary,
 } from './render';
+import type { Framebuffer, Renderbuffer } from './render';
 import { Graphics, RenderTargetPool } from './render';
 import type { Scene, SceneRenderLevel } from './scene';
 import type { Texture } from './texture';
@@ -34,6 +35,14 @@ export interface EngineOptions extends WebGLContextAttributes {
   pixelRatio?: number,
   notifyTouch?: boolean,
   interactive?: boolean,
+  /**
+   * 是否不处理 WebGL 上下文丢失恢复。
+   * - `true`（默认）：上传 GPU 后释放 CPU 端源数据以节省内存；上下文丢失后不自动恢复，
+   *   渲染暂停，等待宿主重建资源后手动恢复播放。
+   * - `false`：保留 CPU 端源数据，上下文丢失后引擎自动按资源类型就地重建 GPU 资源并恢复渲染。
+   *   该配置为构造期选项，运行时从 `true` 改为 `false` 无法找回已经丢弃的源数据。
+   */
+  doNotHandleContextLost?: boolean,
 }
 
 type EngineEvent = {
@@ -92,7 +101,6 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
    * 引擎的像素比
    */
   pixelRatio: number;
-
   /**
    * @hidden
    * Internal utility.
@@ -105,13 +113,22 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
   renderingData: RenderingData;
 
   graphics: Graphics;
-
+  /**
+   * 是否不处理上下文丢失恢复（构造期配置，默认 true）
+   */
+  doNotHandleContextLost = true;
+  /**
+   * WebGL 上下文是否处于丢失状态
+   */
+  protected contextWasLost = false;
   protected _disposed = false;
   protected textures: Texture[] = [];
   protected materials: Material[] = [];
   protected geometries: Geometry[] = [];
   protected meshes: Mesh[] = [];
   protected renderPasses: RenderPass[] = [];
+  protected framebuffers: Framebuffer[] = [];
+  protected renderbuffers: Renderbuffer[] = [];
 
   private assetLoader: AssetLoader;
   private clearAction: RenderPassClearAction = {
@@ -134,6 +151,7 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
     super();
     this.canvas = canvas;
     this.env = options?.env ?? '';
+    this.doNotHandleContextLost = options?.doNotHandleContextLost ?? true;
     this.name = options?.name ?? this.name;
     this.pixelRatio = options?.pixelRatio ?? getPixelRatio();
     this.jsonSceneData = {};
@@ -269,6 +287,11 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
   }
 
   mainLoop (dt: number): void {
+    // 上下文丢失/恢复期间跳过渲染，避免打到失效的 GL 上下文。
+    if (this.contextWasLost) {
+      return;
+    }
+
     const { renderErrors } = this;
 
     if (renderErrors.size > 0) {
@@ -513,6 +536,34 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
       return;
     }
     removeItem(this.renderPasses, pass);
+  }
+
+  addFramebuffer (framebuffer: Framebuffer) {
+    if (this.disposed) {
+      return;
+    }
+    addItem(this.framebuffers, framebuffer);
+  }
+
+  removeFramebuffer (framebuffer: Framebuffer) {
+    if (this.disposed) {
+      return;
+    }
+    removeItem(this.framebuffers, framebuffer);
+  }
+
+  addRenderbuffer (renderbuffer: Renderbuffer) {
+    if (this.disposed) {
+      return;
+    }
+    addItem(this.renderbuffers, renderbuffer);
+  }
+
+  removeRenderbuffer (renderbuffer: Renderbuffer) {
+    if (this.disposed) {
+      return;
+    }
+    removeItem(this.renderbuffers, renderbuffer);
   }
 
   addComposition (composition: Composition) {

--- a/packages/effects-core/src/utils/index.ts
+++ b/packages/effects-core/src/utils/index.ts
@@ -38,7 +38,7 @@ export interface Disposable {
 }
 
 export interface RestoreHandler {
-  restore (): void,
+  restore (): void | Promise<void>,
 }
 
 export interface LostHandler {

--- a/packages/effects-webgl/src/gl-context-manager.ts
+++ b/packages/effects-webgl/src/gl-context-manager.ts
@@ -17,16 +17,16 @@ export class GLContextManager {
     assertExist(canvas);
     this.gl = createGLContext(canvas, glType, options);
     this.contextLostListener = (e: Event) => {
+      // 必须在 lost 同步阶段最前调用 preventDefault，浏览器才会触发 restored 事件。
+      e.preventDefault();
       for (const lostHandler of this.lostHandlers) {
         lostHandler.lost(e);
       }
-      this.canvas?.removeEventListener('webglcontextlost', this.contextLostListener);
     };
-    this.contextRestoredListener = (e: Event) => {
-      for (const restorable of this.restoreHandlers) {
-        restorable.restore();
+    this.contextRestoredListener = () => {
+      for (const restoreHandler of this.restoreHandlers) {
+        restoreHandler.restore();
       }
-      this.canvas?.addEventListener('webglcontextlost', this.contextLostListener);
     };
     canvas.addEventListener('webglcontextlost', this.contextLostListener);
     canvas.addEventListener('webglcontextrestored', this.contextRestoredListener);

--- a/packages/effects-webgl/src/gl-engine.ts
+++ b/packages/effects-webgl/src/gl-engine.ts
@@ -60,24 +60,19 @@ export class GLEngine extends Engine {
     });
 
     this.context.addRestoreHandler({
-      restore: () => {
-        // preventDefault 已在 GLContextManager 内同步调用。此处按模式分发并就地重建资源。
+      restore: async () => {
         if (this.doNotHandleContextLost) {
           this.emit('contextrestored', this);
 
           return;
         }
 
-        void (async () => {
-          const { gl } = this.context;
+        try {
+          const gl = this.context.gl;
 
           if (!gl) {
-            this.contextWasLost = false;
-            this.emit('contextrestored', this);
-
             return;
           }
-
           // 1. 清空与旧上下文绑定的状态缓存。
           this.reset();
           // 2. 重新探测 GPU 能力。
@@ -93,17 +88,19 @@ export class GLEngine extends Engine {
           // 7. 重建 framebuffer（最后：附件纹理已就绪，仅重挂 fbo）。
           this.framebuffers.forEach(fb => (fb as GLFramebuffer).restore());
 
-          this.contextWasLost = false;
-
           if (isIOS() && this.canvas) {
             this.canvas.style.display = 'none';
             window.setTimeout(() => {
               this.canvas.style.display = '';
             }, 0);
           }
-
+        } catch (e) {
+          this.renderErrors.add(e as Error);
+        } finally {
+          // 无论重建成功、部分失败还是 gl 不可用，都复位标志并通知宿主，避免 mainLoop 永久短路。
+          this.contextWasLost = false;
           this.emit('contextrestored', this);
-        })();
+        }
       },
     });
 

--- a/packages/effects-webgl/src/gl-engine.ts
+++ b/packages/effects-webgl/src/gl-engine.ts
@@ -1,5 +1,5 @@
-import type { Composition, EngineOptions, Geometry, Material, Nullable, RenderPassClearAction, ShaderLibrary, Texture, Texture2DSourceOptionsVideo, math } from '@galacean/effects-core';
-import { Engine, GPUCapability, Renderer, SceneLoader, TextureLoadAction, assertExist, glContext, isIOS, logger } from '@galacean/effects-core';
+import type { EngineOptions, Geometry, Material, Nullable, RenderPassClearAction, ShaderLibrary, Texture, math } from '@galacean/effects-core';
+import { Engine, GPUCapability, Renderer, TextureLoadAction, assertExist, glContext, isIOS, logger } from '@galacean/effects-core';
 import { GLShaderLibrary } from './gl-shader-library';
 import type { GLTexture } from './gl-texture';
 import { GLContextManager } from './gl-context-manager';
@@ -32,7 +32,6 @@ export class GLEngine extends Engine {
   private currentRenderbuffer: Record<number, WebGLRenderbuffer | null>;
   private activeTextureIndex: number;
   private pixelStorei: Record<string, GLenum>;
-  private restoreCompositionsCache: Composition[] = [];
 
   constructor (canvas: HTMLCanvasElement, options?: EngineOptions) {
     super(canvas, options);
@@ -50,65 +49,61 @@ export class GLEngine extends Engine {
     this.context = new GLContextManager(canvas, options.glType, options);
     this.context.addLostHandler({
       lost: e => {
-        this.ticker?.pause();
-        this.restoreCompositionsCache = this.compositions.slice();
+        // 仅恢复模式启用帧短路标志。
+        if (!this.doNotHandleContextLost) {
+          this.contextWasLost = true;
+        }
         this.compositions.forEach(comp => comp.lost(e));
-        e.preventDefault();
         logger.error(`WebGL context lost. Event target: ${e.target}.`);
         this.emit('contextlost', { engine: this, e });
       },
     });
 
     this.context.addRestoreHandler({
-      restore: async () => {
-        // FIXME: 需要测试下lost和restore流程
-        const { gl } = this.context;
+      restore: () => {
+        // preventDefault 已在 GLContextManager 内同步调用。此处按模式分发并就地重建资源。
+        if (this.doNotHandleContextLost) {
+          this.emit('contextrestored', this);
 
-        if (!gl) {
-          throw new Error('Can not restore automatically because losing gl context.');
+          return;
         }
 
-        this.reset();
-        this.shaderLibrary = new GLShaderLibrary(this);
-        this.gpuCapability = new GPUCapability(gl);
+        void (async () => {
+          const { gl } = this.context;
 
-        await Promise.all(this.restoreCompositionsCache.map(async composition => {
-          const { time: currentTime, url, speed, reusable, renderOrder, transform, videoState } = composition;
-          const newComposition = await SceneLoader.load(url, this);
+          if (!gl) {
+            this.contextWasLost = false;
+            this.emit('contextrestored', this);
 
-          newComposition.speed = speed;
-          newComposition.reusable = reusable;
-          newComposition.renderOrder = renderOrder;
-          newComposition.transform.setPosition(transform.position.x, transform.position.y, transform.position.z);
-          newComposition.transform.setRotation(transform.rotation.x, transform.rotation.y, transform.rotation.z);
-          newComposition.transform.setScale(transform.scale.x, transform.scale.y, transform.scale.z);
-          newComposition.onItemMessage = composition.onItemMessage;
-
-          for (let i = 0; i < videoState.length; i++) {
-            if (videoState[i]) {
-              const video = (newComposition.textures[i].source as Texture2DSourceOptionsVideo).video;
-
-              video.currentTime = videoState[i] ?? 0;
-              await video.play();
-            }
+            return;
           }
-          newComposition.isEnded = false;
-          newComposition.gotoAndPlay(currentTime);
 
-          return newComposition;
-        }));
+          // 1. 清空与旧上下文绑定的状态缓存。
+          this.reset();
+          // 2. 重新探测 GPU 能力。
+          this.gpuCapability = new GPUCapability(gl);
+          // 3. 重建 shader（先于其它资源：纹理/几何上传可能依赖 shader）。
+          await this.shaderLibrary.restore();
+          // 4. 重建几何顶点缓冲
+          this.geometries.forEach(geo => (geo as GLGeometry).restore());
+          // 5. 重建 renderbuffer
+          this.renderbuffers.forEach(rb => (rb as GLRenderbuffer).restore());
+          // 6. 重建纹理
+          this.textures.forEach(tex => (tex as GLTexture).restore());
+          // 7. 重建 framebuffer（最后：附件纹理已就绪，仅重挂 fbo）。
+          this.framebuffers.forEach(fb => (fb as GLFramebuffer).restore());
 
-        this.restoreCompositionsCache = [];
-        this.ticker?.resume();
+          this.contextWasLost = false;
 
-        if (isIOS() && this.canvas) {
-          this.canvas.style.display = 'none';
-          window.setTimeout(() => {
-            this.canvas.style.display = '';
-          }, 0);
-        }
+          if (isIOS() && this.canvas) {
+            this.canvas.style.display = 'none';
+            window.setTimeout(() => {
+              this.canvas.style.display = '';
+            }, 0);
+          }
 
-        this.emit('contextrestored', this);
+          this.emit('contextrestored', this);
+        })();
       },
     });
 

--- a/packages/effects-webgl/src/gl-framebuffer.ts
+++ b/packages/effects-webgl/src/gl-framebuffer.ts
@@ -1,5 +1,5 @@
 import type {
-  Disposable, FramebufferProps, Renderbuffer, Renderer, RenderPassStoreAction, Texture,
+  Disposable, FramebufferProps, Renderbuffer, Renderer, RenderPassStoreAction, RestoreHandler, Texture,
   Texture2DSourceOptionsFramebuffer,
 } from '@galacean/effects-core';
 import {
@@ -12,7 +12,7 @@ import type { GLEngine } from './gl-engine';
 
 let seed = 1;
 
-export class GLFramebuffer extends Framebuffer implements Disposable {
+export class GLFramebuffer extends Framebuffer implements Disposable, RestoreHandler {
   storeInvalidAttachments?: GLenum[]; // Pass渲染结束是否保留attachment的渲染内容，不保留可以提升部分性能。
   depthStencilRenderbuffer?: GLRenderbuffer;
   depthTexture?: GLTexture;
@@ -117,6 +117,7 @@ export class GLFramebuffer extends Framebuffer implements Disposable {
     }
     if (willUseFbo) {
       this.fbo = this.engine.createGLFramebuffer(this.name) as WebGLFramebuffer;
+      this.engine.addFramebuffer(this);
     }
 
     switch (storageType) {
@@ -348,8 +349,25 @@ export class GLFramebuffer extends Framebuffer implements Disposable {
     }
   }
 
+  /**
+   * 上下文恢复后重建 framebuffer 句柄。
+   * 内部 renderbuffer 由中央 renderbuffers 列表统一恢复，此处不重复处理。
+   * 附件纹理由各自 GLTexture.restore 恢复，此处仅重置 ready 并清空附件缓存，
+   * 让下次 bind 用各纹理的最新句柄重新挂载。
+   */
+  restore (): void {
+    if (!this.fbo) {
+      return;
+    }
+    // 旧 fbo 已随上下文丢失失效，直接重建。
+    this.fbo = this.engine.createGLFramebuffer(this.name) as WebGLFramebuffer;
+    this.ready = false;
+    this.attachmentTextures.length = 0;
+  }
+
   override dispose (options?: { depthStencilAttachment?: RenderPassDestroyAttachmentType }) {
     if (this.renderer) {
+      this.engine.removeFramebuffer(this);
       this.engine.deleteGLFramebuffer(this);
       delete this.fbo;
       const clearAttachment = options?.depthStencilAttachment ? options.depthStencilAttachment : RenderPassDestroyAttachmentType.force;

--- a/packages/effects-webgl/src/gl-geometry.ts
+++ b/packages/effects-webgl/src/gl-geometry.ts
@@ -309,12 +309,14 @@ export class GLGeometry extends Geometry {
       }
     });
 
-    // 需要释放的 attributes 数据
+    // 需要释放的 attributes 数据。
+    // 仅在不处理上下文恢复（默认 doNotHandleContextLost=true）时释放以节省内存；
+    // 启用恢复时永久保留 CPU 数据，供 restore 重新上传。
     Object.keys(this.attributesReleasable).forEach(name => {
       const releasable = this.attributesReleasable[name];
       const bufferName = attributes[name].dataSource;
 
-      if (bufferProps[bufferName] && releasable) {
+      if (bufferProps[bufferName] && releasable && this.engine && this.engine.doNotHandleContextLost) {
         bufferProps[bufferName].data = undefined;
       }
     });
@@ -509,6 +511,41 @@ export class GLGeometry extends Geometry {
       rootBoneName: data.rootBoneName,
       inverseBindMatrices: data.inverseBindMatrices,
     };
+  }
+
+  /**
+   * 上下文恢复后原地重建顶点缓冲区。
+   * 不新建 GLGPUBuffer 实例（避免与 CPU 副本机制产生两份数据），而是复用每个 buffer.restore()。
+   * VAO 旧句柄已失效，清空后由下次 setupAttributes 惰性重建。
+   */
+  restore (): void {
+    if (!this.initialized) {
+      return;
+    }
+    // 清空 VAO 缓存，下个 GLProgram.setupAttributes 会重建。
+    Object.keys(this.vaos).forEach(key => {
+      this.vaos[key] = undefined;
+    });
+    // 原地重建 attribute 缓冲区。
+    Object.keys(this.buffers).forEach(name => {
+      const buffer = this.buffers[name];
+
+      if (buffer) {
+        buffer.restore();
+      }
+    });
+    // 原地重建索引缓冲区。
+    this.indicesBuffer?.restore();
+    // 标记全部脏数据，强制全量重新上传。
+    Object.keys(this.dirtyFlags).forEach(name => {
+      this.dirtyFlags[name] = {
+        dirty: true,
+        discard: true,
+        start: Number.POSITIVE_INFINITY,
+        end: 0,
+      };
+    });
+    this.flush();
   }
 
   override dispose (): void {

--- a/packages/effects-webgl/src/gl-gpu-buffer.ts
+++ b/packages/effects-webgl/src/gl-gpu-buffer.ts
@@ -37,14 +37,20 @@ export interface GLGPUBufferProps {
 }
 
 export class GLGPUBuffer implements Disposable {
+  glBuffer: WebGLBuffer | null;
+
   readonly bytesPerElement: number;
   readonly target: GPUBufferTarget;
   readonly type: GPUBufferType;
   readonly usage: WebGLRenderingContext['STATIC_DRAW'] | WebGLRenderingContext['DYNAMIC_DRAW'] | WebGLRenderingContext['STREAM_DRAW'];
-  readonly glBuffer: WebGLBuffer | null;
+  readonly name?: string;
 
   private byteLength = 0;
   private destroyed = false;
+  /**
+   * CPU 端数据副本，仅在上下文可恢复（doNotHandleContextLost=false）时保留，供上下文恢复时重新上传。
+   */
+  private cpuData?: spec.TypedArray;
 
   constructor (
     public readonly engine: GLEngine,
@@ -63,6 +69,7 @@ export class GLGPUBuffer implements Disposable {
     this.usage = usage;
     this.glBuffer = this.createGLBuffer(name) as WebGLBuffer;
     this.bytesPerElement = bytesPerElement;
+    this.name = name;
 
     if (data) {
       this.bufferData(data);
@@ -109,6 +116,10 @@ export class GLGPUBuffer implements Disposable {
           gl.bufferSubData(target, 0, data);
         }
       }
+      // 上下文可恢复时保留 CPU 副本，供 restore 重新上传。
+      if (!this.engine.doNotHandleContextLost && typeof data !== 'number') {
+        this.cpuData = data.slice();
+      }
     } else {
       this.byteLength = 0;
     }
@@ -127,15 +138,38 @@ export class GLGPUBuffer implements Disposable {
         gl.bufferData(target, byteLength, this.usage);
       }
       gl.bufferSubData(target, byteOffset, data);
+
+      // 维护 CPU 副本，使 restore 能还原最新内容。
+      // subData 来自原始 data 的子 view，elementOffset + data.length 必然 ≤ cpuData.length，无需扩容。
+      if (this.cpuData) {
+        this.cpuData.set(data, elementOffset);
+      }
     } else {
       this.byteLength = 0;
     }
   }
 
+  /**
+   * 上下文恢复后原地重建 GL 缓冲区。
+   * 有 CPU 副本时完整重新上传；否则按原容量建空缓冲区（软降级，等内容另行更新）。
+   */
+  restore (): void {
+    if (this.engine.disposed) {
+      return;
+    }
+    // 旧句柄已随上下文丢失失效，无需 delete。
+    this.glBuffer = this.createGLBuffer(this.name);
+    if (this.cpuData) {
+      this.bufferData(this.cpuData);
+    } else if (this.byteLength > 0) {
+      this.bufferData(this.byteLength);
+    }
+  }
+
   dispose (): void {
     this.engine.gl.deleteBuffer(this.glBuffer);
-    // @ts-expect-error safe to assign
     this.glBuffer = null;
+    this.cpuData = undefined;
     this.destroyed = true;
   }
 

--- a/packages/effects-webgl/src/gl-renderbuffer.ts
+++ b/packages/effects-webgl/src/gl-renderbuffer.ts
@@ -1,8 +1,8 @@
 import type { RenderbufferProps, Renderer } from '@galacean/effects-core';
-import { throwDestroyedError, Renderbuffer, logger } from '@galacean/effects-core';
+import { throwDestroyedError, Renderbuffer, logger, type RestoreHandler } from '@galacean/effects-core';
 import type { GLEngine } from './gl-engine';
 
-export class GLRenderbuffer extends Renderbuffer {
+export class GLRenderbuffer extends Renderbuffer implements RestoreHandler {
   buffer: WebGLRenderbuffer | null;
 
   private initialized = false;
@@ -27,6 +27,27 @@ export class GLRenderbuffer extends Renderbuffer {
     this.initialized = true;
     this.renderer = renderer;
     this.buffer = (renderer.engine as GLEngine).gl.createRenderbuffer() as WebGLRenderbuffer;
+    renderer.engine.addRenderbuffer(this);
+  }
+
+  /**
+   * 上下文恢复后重建 renderbuffer 句柄并重新分配存储。
+   */
+  restore (): void {
+    if (!this.renderer) {
+      return;
+    }
+    const gl = (this.renderer.engine as GLEngine).gl;
+
+    // 旧句柄已失效，直接重建。
+    this.buffer = gl.createRenderbuffer() as WebGLRenderbuffer;
+    // 强制 setSize 重新执行 renderbufferStorage（setSize 在尺寸相同时会跳过）。
+    const targetWidth = this.size[0];
+    const targetHeight = this.size[1];
+
+    this.size[0] = -1;
+    this.size[1] = -1;
+    this.setSize(targetWidth, targetHeight);
   }
 
   setSize (width: number, height: number) {
@@ -55,7 +76,10 @@ export class GLRenderbuffer extends Renderbuffer {
 
   dispose () {
     if (this.renderer) {
-      (this.renderer.engine as GLEngine).deleteGLRenderbuffer(this);
+      const engine = this.renderer.engine as GLEngine;
+
+      engine.deleteGLRenderbuffer(this);
+      engine.removeRenderbuffer(this);
       this.renderer = null;
       this.buffer = null;
     }

--- a/packages/effects-webgl/src/gl-shader-library.ts
+++ b/packages/effects-webgl/src/gl-shader-library.ts
@@ -17,7 +17,7 @@ let shaderSeed = 0;
 export class GLShaderLibrary implements ShaderLibrary, Disposable, RestoreHandler {
   readonly shaderResults: Record<string, ShaderCompileResult> = {};
 
-  private readonly glAsyncCompileExt: KHR_parallel_shader_compile | null;
+  private glAsyncCompileExt: KHR_parallel_shader_compile | null;
   private programMap: Record<string, GLProgram> = {};
   private glVertShaderMap = new Map<number, WebGLShader>();
   private glFragShaderMap = new Map<number, WebGLShader>();
@@ -296,8 +296,36 @@ export class GLShaderLibrary implements ShaderLibrary, Disposable, RestoreHandle
     }
   }
 
-  restore (): void {
-    // TODO
+  async restore (): Promise<void> {
+    const gl = this.engine.gl;
+
+    // 上下文重建后扩展对象引用已失效，需要重新获取。
+    this.glAsyncCompileExt = gl.getExtension('KHR_parallel_shader_compile');
+    // 清空与旧上下文绑定的 GPU 句柄缓存。
+    this.programMap = {};
+    this.glVertShaderMap = new Map<number, WebGLShader>();
+    this.glFragShaderMap = new Map<number, WebGLShader>();
+    this.shaderAllDone = false;
+
+    // 逐个 shader 复用首次编译路径重编译。KHR_parallel_shader_compile 存在时，
+    // compileShader 会通过 requestAnimationFrame 轮询完成状态，因此必须等待回调后
+    // 才能允许 engine 恢复渲染，避免材质绑定 context lost 前的失效 program。
+    await Promise.all(Object.keys(this.cachedShaders).map(key => {
+      const shader = this.cachedShaders[key];
+
+      shader.resetForContextRestore();
+
+      return new Promise<void>(resolve => {
+        this.compileShader(shader, result => {
+          // 重编译完成后用缓存的 uniform/sampler 名称重新查询 location，
+          // 对齐目标实现"重编译后内部刷新 location、不依赖外部 markDirty"。
+          if (result.status === ShaderCompileResultStatus.success) {
+            shader.refillUniforms();
+          }
+          resolve();
+        });
+      });
+    }));
   }
 
   dispose (): void {

--- a/packages/effects-webgl/src/gl-shader.ts
+++ b/packages/effects-webgl/src/gl-shader.ts
@@ -19,6 +19,8 @@ export class GLShaderVariant extends ShaderVariant {
   uniformLocations: Record<string, WebGLUniformLocation | null> = {};
 
   private samplerChannels: Record<string, number> = {};
+  private uniformsNames: string[] = [];
+  private samplerList: string[] = [];
 
   constructor (engine: Engine, source: ShaderWithSource) {
     super(engine, source);
@@ -78,6 +80,10 @@ export class GLShaderVariant extends ShaderVariant {
     // 避免修改原数组。
     const samplerList = samplers.slice();
 
+    // 缓存名称，便于上下文恢复后重新绑定 uniform location。
+    this.uniformsNames = uniformNames.slice();
+    this.samplerList = samplerList.slice();
+
     uniformNames = uniformNames.concat(samplerList);
     const avaliableUniforms = (this.engine as GLEngine).getUniforms(this.program.program, uniformNames);
 
@@ -100,6 +106,27 @@ export class GLShaderVariant extends ShaderVariant {
       const samplerName = samplerList[index];
 
       this.samplerChannels[samplerName] = index;
+    }
+  }
+
+  /**
+   * 上下文丢失后重置 GPU 侧状态，使其在下次 compileShader 时重新编译并重新绑定 uniform/sampler。
+   */
+  resetForContextRestore () {
+    this.initialized = false;
+    this.uniformLocations = {};
+    this.samplerChannels = {};
+  }
+
+  /**
+   * 上下文恢复重编译完成后，用缓存的 uniform/sampler 名称重新查询并填充 location
+   */
+  refillUniforms () {
+    if (!this.initialized || !this.program) {
+      return;
+    }
+    if (this.uniformsNames.length > 0 || this.samplerList.length > 0) {
+      this.fillShaderInformation(this.uniformsNames, this.samplerList);
     }
   }
 

--- a/packages/effects-webgl/src/gl-texture.ts
+++ b/packages/effects-webgl/src/gl-texture.ts
@@ -82,6 +82,12 @@ export class GLTexture extends Texture implements Disposable, RestoreHandler {
   }
 
   release () {
+    // 仅在不处理上下文恢复（默认 doNotHandleContextLost=true）时释放 CPU 端像素源以节省内存。
+    // 启用恢复时保留源数据，供 GLTexture.restore 重新上传，实现离线可用的就地重建。
+    if (!this.engine.doNotHandleContextLost) {
+      return;
+    }
+
     const { sourceType } = this.source;
 
     switch (sourceType) {
@@ -468,8 +474,25 @@ export class GLTexture extends Texture implements Disposable, RestoreHandler {
     this.update(this.source);
   }
 
-  restore () {
-    // TODO
+  restore (): void {
+    const glEngine = this.engine as GLEngine;
+    const gl = glEngine.gl;
+
+    // target 仅在 initialize() 时从 source 取值赋给实例字段；若纹理在丢失前尚未 initialize
+    // （如内置纹理未被使用过），this.target 可能为空，需在此从 source 补全，避免 bind/update 时 INVALID target。
+    if (this.target === undefined) {
+      const { target = gl.TEXTURE_2D } = this.source;
+
+      this.target = target;
+    }
+
+    // 旧句柄已随上下文丢失失效，无需 delete，直接重建。
+    this.textureBuffer = gl.createTexture();
+    assignInspectorName(this.textureBuffer, this.source.name);
+    this.initialized = false;
+    // opt-in 模式下 release 不释放 CPU 源数据，image/cube/data/compressed/mipmaps 源恒在，直接重新上传即可。
+    this.update(this.source);
+    this.initialized = true;
   }
 
   override dispose (): void {

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -135,6 +135,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       interactive = false,
       renderOptions = {},
       env = '',
+      doNotHandleContextLost,
     } = config;
     const { willCaptureImage: preserveDrawingBuffer, premultipliedAlpha } = renderOptions;
 
@@ -186,6 +187,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
         notifyTouch: notifyTouch,
         interactive,
         pixelRatio: Number.isFinite(pixelRatio) ? pixelRatio as number : getPixelRatio(),
+        doNotHandleContextLost,
       });
       this.engine.offscreenMode = true;
 

--- a/packages/effects/src/types.ts
+++ b/packages/effects/src/types.ts
@@ -67,11 +67,10 @@ export interface PlayerConfig {
    */
   notifyTouch?: boolean,
   /**
+   * @since 2.10.0
    * 是否不处理 WebGL 上下文丢失恢复。
-   * - `true`（默认）：上传 GPU 后释放 CPU 端源数据以节省内存；上下文丢失后不自动恢复，
-   *   渲染暂停，等待宿主重建资源后手动恢复播放。
-   * - `false`：保留 CPU 端源数据，上下文丢失后引擎自动就地重建 GPU 资源并恢复渲染。
-   *   该配置为构造期选项，运行时从 `true` 改为 `false` 无法找回已丢弃的源数据。
+   * - `true`（默认）：上传 GPU 后释放 CPU 端源数据以节省内存；上下文 lost 后无法 restore 恢复渲染
+   * - `false`：保留 CPU 端源数据，上下文 lost 后引擎会自动监听 restore 事件就地重建 GPU 资源并恢复渲染
    */
   doNotHandleContextLost?: boolean,
   /**

--- a/packages/effects/src/types.ts
+++ b/packages/effects/src/types.ts
@@ -67,6 +67,14 @@ export interface PlayerConfig {
    */
   notifyTouch?: boolean,
   /**
+   * 是否不处理 WebGL 上下文丢失恢复。
+   * - `true`（默认）：上传 GPU 后释放 CPU 端源数据以节省内存；上下文丢失后不自动恢复，
+   *   渲染暂停，等待宿主重建资源后手动恢复播放。
+   * - `false`：保留 CPU 端源数据，上下文丢失后引擎自动就地重建 GPU 资源并恢复渲染。
+   *   该配置为构造期选项，运行时从 `true` 改为 `false` 无法找回已丢弃的源数据。
+   */
+  doNotHandleContextLost?: boolean,
+  /**
    * 每帧渲染调用后的回调，WebGL2 上下文生效
    * @param time - GPU 渲染使用的时间，秒
    * @deprecated 2.8.0

--- a/web-packages/demo/src/context-lost-restore.ts
+++ b/web-packages/demo/src/context-lost-restore.ts
@@ -22,6 +22,7 @@ let allocateTimeout: any;
       gpuFrame++;
       max = Math.max(time, max);
     },
+    doNotHandleContextLost: false,
     onError: e => {
       switch (e.cause) {
         case 'webglcontextlost':

--- a/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
@@ -72,7 +72,7 @@ describe('webgl/gl-context-lost', () => {
       (engine.transparentTexture as GLTexture).initialize();
     });
 
-    it('纹理 GPU 句柄在 restore 后被重建', async () => {
+    it('纹理 GPU 句柄在 restore 后被重建', async function () {
       if (!canEmulateContextLoss(engine)) {
         this.skip();
 
@@ -100,7 +100,7 @@ describe('webgl/gl-context-lost', () => {
       tex.dispose();
     }).timeout(8000);
 
-    it('shader program 在 restore 后被重建', async () => {
+    it('shader program 在 restore 后被重建', async function () {
       if (!canEmulateContextLoss(engine)) {
         this.skip();
 
@@ -130,7 +130,7 @@ describe('webgl/gl-context-lost', () => {
       expect(variant.initialized).to.equal(true);
     }).timeout(8000);
 
-    it('连续两次 context lost 均可恢复', async () => {
+    it('连续两次 context lost 均可恢复', async function () {
       if (!canEmulateContextLoss(engine)) {
         this.skip();
 

--- a/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
@@ -1,0 +1,211 @@
+//@ts-nocheck
+import { glContext, TextureSourceType } from '@galacean/effects-core';
+import type { GLShaderVariant } from '@galacean/effects-webgl';
+import { GLTexture, GLEngine } from '@galacean/effects-webgl';
+
+const { assert, expect } = chai;
+
+/**
+ * 等待 engine 触发 contextrestored 事件。
+ */
+function onceContextRestored (engine: GLEngine): Promise<void> {
+  return new Promise(resolve => {
+    engine.once('contextrestored', () => resolve());
+  });
+}
+
+/**
+ * 触发一次真实的 context lost/restore 周期。
+ * WEBGL_lose_context 不会在 loseContext 后自动恢复，必须等 lost 事件到达后显式 restoreContext。
+ */
+function emulateContextLoss (engine: GLEngine): Promise<void> {
+  const restored = onceContextRestored(engine);
+  const ext = (engine.gl as WebGLRenderingContext).getExtension('WEBGL_lose_context');
+
+  engine.canvas.addEventListener('webglcontextlost', () => {
+    window.setTimeout(() => ext?.restoreContext(), 0);
+  }, { once: true });
+  ext?.loseContext();
+
+  return restored;
+}
+
+/**
+ * 是否具备真实上下文丢失/恢复的测试条件（需要 WEBGL_lose_context 扩展）。
+ */
+function canEmulateContextLoss (engine: GLEngine): boolean {
+  return !!(engine.gl as WebGLRenderingContext).getExtension('WEBGL_lose_context');
+}
+
+describe('webgl/gl-context-lost', () => {
+  let canvas: HTMLCanvasElement;
+  let engine: GLEngine;
+  let gl: WebGLRenderingContext;
+
+  function createEngine (doNotHandleContextLost: boolean): GLEngine {
+    const c = document.createElement('canvas');
+
+    c.width = 64;
+    c.height = 64;
+
+    return new GLEngine(c, { glType: 'webgl2', doNotHandleContextLost });
+  }
+
+  afterEach(() => {
+    if (engine) {
+      engine.dispose();
+      engine = null as any;
+    }
+    if (canvas) {
+      canvas.remove();
+      canvas = null as any;
+    }
+  });
+
+  // 需要真实浏览器 + WEBGL_lose_context 扩展的用例，用 canEmulateContextLoss 守卫。
+  describe('opt-in 自动恢复（doNotHandleContextLost=false）', () => {
+    beforeEach(() => {
+      engine = createEngine(false);
+      gl = engine.gl as WebGLRenderingContext;
+      // GLEngine 构造已创建内置纹理，但需 initialize 才有 GL 句柄。
+      (engine.whiteTexture as GLTexture).initialize();
+      (engine.transparentTexture as GLTexture).initialize();
+    });
+
+    it('纹理 GPU 句柄在 restore 后被重建', async () => {
+      if (!canEmulateContextLoss(engine)) {
+        this.skip();
+
+        return;
+      }
+
+      const tex = new GLTexture(engine, {
+        sourceType: TextureSourceType.data,
+        data: { width: 2, height: 2, data: new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]) },
+        format: glContext.RGBA,
+        internalFormat: glContext.RGBA,
+        type: glContext.UNSIGNED_BYTE,
+      });
+
+      tex.initialize();
+      const before = tex.textureBuffer;
+
+      await emulateContextLoss(engine);
+
+      const after = tex.textureBuffer;
+
+      expect(after).to.not.equal(before);
+      expect(after).to.be.instanceOf(WebGLTexture);
+      engine.removeTexture(tex);
+      tex.dispose();
+    }).timeout(8000);
+
+    it('shader program 在 restore 后被重建', async () => {
+      if (!canEmulateContextLoss(engine)) {
+        this.skip();
+
+        return;
+      }
+
+      const vs = `#version 300 es
+      layout(location=0) in vec2 aPosition;
+      void main(){ gl_Position = vec4(aPosition,0.0,1.0); }`;
+      const fs = `#version 300 es
+      precision highp float;
+      out vec4 outColor;
+      void main(){ outColor = vec4(1.0,0.0,0.0,1.0); }`;
+      const library = engine.shaderLibrary;
+      const id = library.addShader({ vertex: vs, fragment: fs, name: 'restore-test' });
+      const variant = (library as any).cachedShaders[id] as GLShaderVariant;
+
+      variant.initialize();
+      const beforeProgram = variant.program?.program;
+
+      await emulateContextLoss(engine);
+
+      const afterProgram = variant.program?.program;
+
+      expect(afterProgram).to.not.equal(beforeProgram);
+      expect(afterProgram).to.be.instanceOf(WebGLProgram);
+      expect(variant.initialized).to.equal(true);
+    }).timeout(8000);
+
+    it('连续两次 context lost 均可恢复', async () => {
+      if (!canEmulateContextLoss(engine)) {
+        this.skip();
+
+        return;
+      }
+
+      const tex = new GLTexture(engine, {
+        sourceType: TextureSourceType.data,
+        data: { width: 1, height: 1, data: new Uint8Array([255, 255, 255, 255]) },
+        format: glContext.RGBA,
+        internalFormat: glContext.RGBA,
+        type: glContext.UNSIGNED_BYTE,
+      });
+
+      tex.initialize();
+
+      // 第一次丢失恢复
+      await emulateContextLoss(engine);
+      expect(tex.textureBuffer).to.be.instanceOf(WebGLTexture);
+
+      // 第二次丢失恢复（验证永久保留 CPU 数据策略）
+      await emulateContextLoss(engine);
+      expect(tex.textureBuffer).to.be.instanceOf(WebGLTexture);
+
+      engine.removeTexture(tex);
+      tex.dispose();
+    }).timeout(15000);
+  });
+
+  describe('默认模式（doNotHandleContextLost=true）', () => {
+    beforeEach(() => {
+      engine = createEngine(true);
+      gl = engine.gl as WebGLRenderingContext;
+    });
+
+    it('release 释放 CPU 源数据（默认内存优先）', () => {
+      const tex = new GLTexture(engine, {
+        sourceType: TextureSourceType.data,
+        data: { width: 2, height: 2, data: new Uint8Array(16) },
+        format: glContext.RGBA,
+        internalFormat: glContext.RGBA,
+        type: glContext.UNSIGNED_BYTE,
+      });
+
+      tex.initialize();
+
+      // 默认模式 release 后 source.data 被释放。
+      expect((tex.source as any).data).to.be.undefined;
+      engine.removeTexture(tex);
+      tex.dispose();
+    });
+  });
+
+  describe('opt-in 模式 CPU 数据保留', () => {
+    beforeEach(() => {
+      engine = createEngine(false);
+      gl = engine.gl as WebGLRenderingContext;
+    });
+
+    it('release 保留 CPU 源数据（opt-in 可恢复）', () => {
+      const data = new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255]);
+      const tex = new GLTexture(engine, {
+        sourceType: TextureSourceType.data,
+        data: { width: 2, height: 2, data },
+        format: glContext.RGBA,
+        internalFormat: glContext.RGBA,
+        type: glContext.UNSIGNED_BYTE,
+      });
+
+      tex.initialize();
+
+      // opt-in 模式 release 不释放源数据。
+      expect((tex.source as any).data).to.not.be.undefined;
+      engine.removeTexture(tex);
+      tex.dispose();
+    });
+  });
+});

--- a/web-packages/test/unit/src/effects-webgl/index.ts
+++ b/web-packages/test/unit/src/effects-webgl/index.ts
@@ -1,5 +1,6 @@
 import './gl-dispose.spec';
 import './gl-frame-buffer.spec';
+import './gl-context-lost.spec';
 import './gl-geometry.spec';
 import './gl-gpu-buffer.spec';
 import './gl-material.spec';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable WebGL context-loss recovery via `doNotHandleContextLost` option (defaults to `true`).
  * When set to `false`, CPU-side texture source data is retained and GPU resources are rebuilt on context restoration.
* **Bug Fixes**
  * Prevented rendering/GL calls while the WebGL context is lost.
  * Improved in-place restoration for shaders, textures, geometry, framebuffers, and renderbuffers; added proper restore handling across key WebGL objects.
* **Tests**
  * Added unit coverage for context-loss/restore cycles, including repeated recovery and CPU-data retention/release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->