### PR TITLE
fix: restore mask material state

### DIFF
--- a/packages/effects-core/src/material/mask-ref-manager.ts
+++ b/packages/effects-core/src/material/mask-ref-manager.ts
@@ -47,6 +47,13 @@ export class MaskProcessor {
 
   private stencilClearAction: RenderPassClearAction;
 
+  private prevStencilFunc: [number, number] = [0, 0];
+  private prevStencilOpFail: [number, number] = [0, 0];
+  private prevStencilOpZFail: [number, number] = [0, 0];
+  private prevStencilOpZPass: [number, number] = [0, 0];
+  private prevStencilRef: [number, number] = [0, 0];
+  private prevStencilMask: [number, number] = [0, 0];
+
   /**
    * @deprecated 使用 maskReferences 替代
    */
@@ -244,24 +251,25 @@ export class MaskProcessor {
   drawGeometryMask (renderer: Renderer, geometry: Geometry, worldMatrix: Matrix4, material: Material, maskRef: number, subMeshIndex = 0): void {
     const prevColorMask = material.colorMask;
     const prevStencilTest = material.stencilTest;
-    const prevStencilFunc = material.stencilFunc;
-    const prevStencilOpFail = material.stencilOpFail;
-    const prevStencilOpZFail = material.stencilOpZFail;
-    const prevStencilOpZPass = material.stencilOpZPass;
-    const prevStencilRef = material.stencilRef;
-    const prevStencilMask = material.stencilMask;
+
+    this.copyStencilArrayValue(this.prevStencilFunc, material.stencilFunc);
+    this.copyStencilArrayValue(this.prevStencilOpFail, material.stencilOpFail);
+    this.copyStencilArrayValue(this.prevStencilOpZFail, material.stencilOpZFail);
+    this.copyStencilArrayValue(this.prevStencilOpZPass, material.stencilOpZPass);
+    this.copyStencilArrayValue(this.prevStencilRef, material.stencilRef);
+    this.copyStencilArrayValue(this.prevStencilMask, material.stencilMask);
 
     this.setupMaskMaterial(material, maskRef);
     renderer.drawGeometry(geometry, worldMatrix, material, subMeshIndex);
 
     material.colorMask = prevColorMask;
     material.stencilTest = prevStencilTest;
-    material.stencilFunc = prevStencilFunc;
-    material.stencilOpFail = prevStencilOpFail;
-    material.stencilOpZFail = prevStencilOpZFail;
-    material.stencilOpZPass = prevStencilOpZPass;
-    material.stencilRef = prevStencilRef;
-    material.stencilMask = prevStencilMask;
+    material.stencilFunc = this.prevStencilFunc;
+    material.stencilOpFail = this.prevStencilOpFail;
+    material.stencilOpZFail = this.prevStencilOpZFail;
+    material.stencilOpZPass = this.prevStencilOpZPass;
+    material.stencilRef = this.prevStencilRef;
+    material.stencilMask = this.prevStencilMask;
   }
 
   /**
@@ -310,6 +318,15 @@ export class MaskProcessor {
       // 无蒙版：关闭 stencil 测试
       material.stencilTest = false;
     }
+  }
+
+  private copyStencilArrayValue (target: [number, number], source: [number, number] | undefined): void {
+    if (!source) {
+      return;
+    }
+
+    target[0] = source[0];
+    target[1] = source[1];
   }
 
 }


### PR DESCRIPTION
## Summary

Restore stencil state correctly after drawing geometry masks.

Reuse preallocated stencil state arrays to avoid additional allocations in the rendering path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved masking reliability by safely preserving and restoring stencil settings during mask rendering.
  * Prevented unintended changes to existing stencil configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->