### PR TITLE
feat: add engine create/destroy callbacks to plugin system

### DIFF
--- a/packages/effects-core/src/asset-manager.ts
+++ b/packages/effects-core/src/asset-manager.ts
@@ -383,7 +383,7 @@ export class AssetManager implements Disposable {
   }
 
   private async onPluginSceneLoadStart (scene: Scene) {
-    await PluginSystem.onAssetsLoadStart(scene, this.options);
+    await PluginSystem.notifyAssetsLoadStart(scene, this.options);
   }
 
   private async processTextures (

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -348,7 +348,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
 
     this.createRenderFrame();
 
-    PluginSystem.initializeComposition(this, scene);
+    PluginSystem.notifyCompositionCreated(this, scene);
   }
 
   /**
@@ -893,7 +893,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
     this.root.dispose();
     // FIXME: 注意这里增加了renderFrame销毁
     this.renderFrame.dispose();
-    PluginSystem.destroyComposition(this);
+    PluginSystem.notifyCompositionDestroy(this);
 
     this.update = () => {
       if (!__DEBUG__) {

--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -21,6 +21,7 @@ import { AssetService } from './asset-service';
 import { Ticker } from './ticker';
 import type { PointerEventData, Region } from './plugins';
 import { EventSystem } from './plugins';
+import { PluginSystem } from './plugin-system';
 import type { GLType } from './gl';
 import { HELP_LINK } from './constants';
 import { EventEmitter } from './events';
@@ -159,6 +160,8 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
       // @ts-expect-error
       currentFrame: {},
     };
+
+    PluginSystem.notifyEngineCreated(this);
   }
 
   /**
@@ -656,6 +659,8 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
       return;
     }
     this._disposed = true;
+
+    PluginSystem.notifyEngineDestroy(this);
 
     const info: string[] = [];
 

--- a/packages/effects-core/src/plugin-system.ts
+++ b/packages/effects-core/src/plugin-system.ts
@@ -47,22 +47,30 @@ export class PluginSystem {
     return plugins;
   }
 
-  static initializeComposition (composition: Composition, scene?: Scene) {
-    plugins.forEach(loader => loader.onCompositionCreated(composition, scene));
+  static notifyCompositionCreated (composition: Composition, scene?: Scene) {
+    plugins.forEach(plugin => plugin.onCompositionCreated(composition, scene));
   }
 
-  static destroyComposition (comp: Composition) {
-    plugins.forEach(loader => loader.onCompositionDestroy(comp));
+  static notifyCompositionDestroy (composition: Composition) {
+    plugins.forEach(plugin => plugin.onCompositionDestroy(composition));
   }
 
-  static async onAssetsLoadStart (scene: Scene, options?: SceneLoadOptions) {
+  static notifyEngineCreated (engine: Engine) {
+    plugins.forEach(plugin => plugin.onEngineCreated(engine));
+  }
+
+  static notifyEngineDestroy (engine: Engine) {
+    plugins.forEach(plugin => plugin.onEngineDestroy(engine));
+  }
+
+  static async notifyAssetsLoadStart (scene: Scene, options?: SceneLoadOptions) {
     return Promise.all(
       plugins.map(plugin => plugin.onAssetsLoadStart(scene, options)),
     );
   }
 
-  static onAssetsLoadFinish (scene: Scene, options: SceneLoadOptions, engine: Engine) {
-    plugins.forEach(loader => loader.onAssetsLoadFinish(scene, options, engine));
+  static notifyAssetsLoadFinish (scene: Scene, options: SceneLoadOptions, engine: Engine) {
+    plugins.forEach(plugin => plugin.onAssetsLoadFinish(scene, options, engine));
   }
 }
 

--- a/packages/effects-core/src/plugins/plugin.ts
+++ b/packages/effects-core/src/plugins/plugin.ts
@@ -45,4 +45,20 @@ export abstract class Plugin {
    * @param composition - 合成对象
    */
   onCompositionDestroy (composition: Composition): void { }
+
+  /**
+   * 引擎创建完成后触发。
+   * 适用于注册引擎级单例、建立以引擎为键的映射、绑定全局监听等场景。
+   * @param engine - 引擎实例
+   * @since 2.10.0
+   */
+  onEngineCreated (engine: Engine): void { }
+
+  /**
+   * 引擎销毁时触发。
+   * 适合解绑监听、释放引擎级资源或清理以引擎为键的映射。
+   * @param engine - 引擎实例
+   * @since 2.10.0
+   */
+  onEngineDestroy (engine: Engine): void { }
 }

--- a/packages/effects-core/src/precompositions/precomposition-manager.ts
+++ b/packages/effects-core/src/precompositions/precomposition-manager.ts
@@ -20,8 +20,8 @@ export class PrecompositionManager {
 
     engine.clearResources();
 
-    // 触发插件系统 pluginSystem 的回调 onAssetsLoadFinish
-    PluginSystem.onAssetsLoadFinish(scene, options, engine);
+    // 通过 PluginSystem.notifyAssetsLoadFinish 通知所有插件的 onAssetsLoadFinish 回调
+    PluginSystem.notifyAssetsLoadFinish(scene, options, engine);
 
     engine.assetService.prepareAssets(scene, scene.assets);
     engine.assetService.updateTextVariables(scene, options.variables);

--- a/packages/effects-core/src/scene-loader.ts
+++ b/packages/effects-core/src/scene-loader.ts
@@ -26,8 +26,8 @@ export class SceneLoader {
 
     engine.clearResources();
 
-    // 触发插件系统 pluginSystem 的回调 onAssetsLoadFinish
-    PluginSystem.onAssetsLoadFinish(loadedScene, assetManager.options, engine);
+    // 通过 PluginSystem.notifyAssetsLoadFinish 通知所有插件的 onAssetsLoadFinish 回调
+    PluginSystem.notifyAssetsLoadFinish(loadedScene, assetManager.options, engine);
 
     engine.assetService.prepareAssets(loadedScene, loadedScene.assets);
     engine.assetService.updateTextVariables(loadedScene, options.variables);

--- a/packages/effects-threejs/src/three-display-object.ts
+++ b/packages/effects-threejs/src/three-display-object.ts
@@ -104,8 +104,8 @@ export class ThreeDisplayObject extends THREE.Group {
 
         engine.clearResources();
 
-        // 触发插件系统 pluginSystem 的回调 onAssetsLoadFinish
-        PluginSystem.onAssetsLoadFinish(scene, assetManager.options, engine);
+        // 通过 PluginSystem.notifyAssetsLoadFinish 通知所有插件的 onAssetsLoadFinish 回调
+        PluginSystem.notifyAssetsLoadFinish(scene, assetManager.options, engine);
         this.assetService.prepareAssets(scene, assetManager.getAssets());
         this.assetService.updateTextVariables(scene, assetManager.options.variables);
 

--- a/web-packages/test/unit/src/effects-core/engine-plugin.spec.ts
+++ b/web-packages/test/unit/src/effects-core/engine-plugin.spec.ts
@@ -1,0 +1,54 @@
+import type { Engine } from '@galacean/effects';
+import { Player, Plugin, registerPlugin, unregisterPlugin } from '@galacean/effects';
+
+const { expect } = chai;
+
+describe('core/engine/plugin-engine-lifetime', () => {
+  it('triggers onEngineCreated on construction and onEngineDestroy on dispose', () => {
+    let createdEngine: Engine | undefined;
+    let destroyedEngine: Engine | undefined;
+
+    // 传入带类型函数，保留 spy 的调用签名（可带参调用）。
+    const createdSpy = chai.spy((engine: Engine) => {
+      // 引擎基类构造结束时触发，此时子类 renderer 等可能尚未初始化，
+      // 仅校验拿到的是有效的引擎实例（canvas 已就绪）。
+      expect(engine.canvas).to.be.an.instanceOf(HTMLCanvasElement);
+      createdEngine = engine;
+    });
+    const destroySpy = chai.spy((engine: Engine) => {
+      // 在引擎释放资源前触发，此时 disposed 已置位（避免重入），
+      // 但引擎及子类资源（renderer/gl 等）仍可访问。
+      expect(engine.disposed).to.eql(true);
+      destroyedEngine = engine;
+    });
+
+    class TestEnginePlugin extends Plugin {
+      override onEngineCreated (engine: Engine) {
+        createdSpy(engine);
+      }
+
+      override onEngineDestroy (engine: Engine) {
+        destroySpy(engine);
+      }
+    }
+
+    registerPlugin('test-engine-plugin', TestEnginePlugin);
+
+    const player = new Player({ canvas: document.createElement('canvas') });
+    const engine = player.engine;
+
+    expect(createdSpy).to.have.been.called.once;
+    expect(createdEngine).to.eql(engine);
+
+    player.dispose();
+
+    expect(destroySpy).to.have.been.called.once;
+    expect(destroyedEngine).to.eql(engine);
+
+    unregisterPlugin('test-engine-plugin');
+  });
+
+  afterEach(() => {
+    unregisterPlugin('test-engine-plugin');
+  });
+});

--- a/web-packages/test/unit/src/effects-core/index.ts
+++ b/web-packages/test/unit/src/effects-core/index.ts
@@ -15,6 +15,7 @@ import './plugins/sprite';
 // plugin text
 import './plugins/text';
 import './asset-manager.spec';
+import './engine-plugin.spec';
 import './texture.spec';
 import './transform.spec';
 import './utils.spec';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin lifecycle notifications for engine creation and destruction.
  * Plugin integrations now receive consistent notifications when compositions are created or destroyed and when scene assets begin or finish loading.
  * Added plugin callbacks for responding to engine lifecycle events.

* **Tests**
  * Added coverage verifying engine lifecycle callbacks and their associated engine instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->