### PR TITLE
fix: ensure minimum canvas size for text rendering

### DIFF
--- a/packages/effects-core/src/plugins/text/text-component-base.ts
+++ b/packages/effects-core/src/plugins/text/text-component-base.ts
@@ -269,25 +269,27 @@ export class TextComponentBase {
     }
 
     const context = this.context;
+    const textureWidth = Math.max(1, width);
+    const textureHeight = Math.max(1, height);
 
     // 先保存状态
     context.save();
 
     // 设置canvas尺寸
-    this.canvas.width = width;
-    this.canvas.height = height;
+    this.canvas.width = textureWidth;
+    this.canvas.height = textureHeight;
 
     //重置变换
     context.setTransform(1, 0, 0, 1, 0, 0);
 
     // 处理翻转
     if (!flipY) {
-      context.translate(0, height);
+      context.translate(0, textureHeight);
       context.scale(1, -1);
     }
 
     // 在翻转后清空画布
-    context.clearRect(0, 0, width, height);
+    context.clearRect(0, 0, textureWidth, textureHeight);
 
     // 设置 alpha 修复用填充色（不实际输出像素）
     context.fillStyle = `rgba(255, 255, 255, ${this.ALPHA_FIX_VALUE})`;
@@ -299,7 +301,7 @@ export class TextComponentBase {
     context.restore();
 
     // 创建新纹理
-    const imageData = context.getImageData(0, 0, width, height);
+    const imageData = context.getImageData(0, 0, textureWidth, textureHeight);
     const texture = Texture.createWithData(
       this.engine,
       {

--- a/web-packages/test/unit/src/effects-core/plugins/text/text-item.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/text/text-item.spec.ts
@@ -49,6 +49,15 @@ describe('core/plugins/text/text-item', () => {
     expect(textComponent.textStyle.fontFamily).to.equal(options.fontFamily);
   });
 
+  it('文本宽度为 0 时使用最小纹理', () => {
+    textComponent.setFontStyle(spec.FontStyle.normal);
+    textComponent.setTextWidth(0);
+
+    expect(() => textComponent.renderText({} as spec.TextContentOptions)).not.to.throw();
+    expect(textComponent.textLayout.width).to.equal(0);
+    expect(textComponent.canvas.width).to.equal(1);
+  });
+
   // 换行集成测试：打桩 measureText 返回固定宽度（CJK=10 / 西文与标点=5 / 空格=3），
   // letterSpace 默认 0、keepWordIntact 默认 true。通过调整 textLayout.width 吸收 fontOffset，
   // 使 getLineCount 内部 width = textLayout.width + fontOffset 等于目标值，得到确定性行数。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text rendering when content has zero width.
  * Preserved the intended layout width while ensuring rendering completes successfully.

* **Tests**
  * Added regression coverage for zero-width text rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->