### PR TITLE
docs: fix ts build

### DIFF
--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -488,7 +488,9 @@ export class ParticleSystem extends Component implements Maskable {
   }
 
   /**
-   * @internal
+   * @hidden
+   * Internal utility.
+   * Not part of the public API — do not rely on this in your code.
    */
   rebuild (): void {
     this.renderer?.rebuild();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the particle system rebuild method is an internal utility and not part of the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->