### PR TITLE
refactor: move geometry draw logic to renderer

### DIFF
--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -1,5 +1,4 @@
 import * as spec from '@galacean/effects-specification';
-import type { Matrix4 } from '@galacean/effects-math/es/core/matrix4';
 import type { Database, SceneData } from './asset-loader';
 import { AssetLoader } from './asset-loader';
 import type { EffectsObject } from './effects-object';
@@ -470,10 +469,44 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
   /** @hide */
   bindBuffers (
     vertexBuffers: Record<string, VertexBuffer>,
-    indexBuffer: DataBuffer | undefined,
+    indexBuffer: DataBuffer | null,
     effect: ShaderVariant,
   ): void {
     throw new Error('The active rendering backend cannot bind geometry buffers.');
+  }
+
+  /**
+   * 使用当前绑定的顶点和索引缓冲区绘制图元。
+   * @param mode - 图元类型
+   * @param indexOffset - 索引缓冲区中的字节偏移
+   * @param indexCount - 索引数量
+   * @param instanceCount - 实例数量
+   * @hide
+   */
+  drawElementsType (
+    mode: number,
+    indexOffset: number,
+    indexCount: number,
+    instanceCount?: number,
+  ): void {
+    throw new Error('The active rendering backend cannot draw indexed primitives.');
+  }
+
+  /**
+   * 使用当前绑定的顶点缓冲区绘制图元。
+   * @param mode - 图元类型
+   * @param vertexStart - 起始顶点
+   * @param vertexCount - 顶点数量
+   * @param instanceCount - 实例数量
+   * @hide
+   */
+  drawArraysType (
+    mode: number,
+    vertexStart: number,
+    vertexCount: number,
+    instanceCount?: number,
+  ): void {
+    throw new Error('The active rendering backend cannot draw primitives.');
   }
 
   addTexture (tex: Texture) {
@@ -638,10 +671,6 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
   }
 
   clear (action: RenderPassClearAction) {
-    // OVERRIDE
-  }
-
-  drawGeometry (geometry: Geometry, matrix: Matrix4, material: Material, subMeshIndex = 0) {
     // OVERRIDE
   }
 

--- a/packages/effects-core/src/render/geometry.ts
+++ b/packages/effects-core/src/render/geometry.ts
@@ -49,12 +49,12 @@ type VertexArrayObject = object;
 interface VertexArrayObjectEngine {
   recordVertexArrayObject: (
     vertexBuffers: Record<string, VertexBuffer>,
-    indexBuffer: DataBuffer | undefined,
+    indexBuffer: DataBuffer | null,
     shader: ShaderVariant,
   ) => VertexArrayObject | undefined,
   bindVertexArrayObject: (
     vertexArrayObject: VertexArrayObject,
-    indexBuffer: DataBuffer | undefined,
+    indexBuffer: DataBuffer | null,
   ) => void,
   releaseVertexArrayObject: (vertexArrayObject: VertexArrayObject) => void,
 }
@@ -259,7 +259,7 @@ export class Geometry extends EffectsObject {
     const engine = this.engine;
 
     if (!vertexArrayObjects || !supportsVertexArrayObjects(engine)) {
-      engine.bindBuffers(this.vertexBuffers, this.indexBuffer, shader);
+      engine.bindBuffers(this.vertexBuffers, this.indexBuffer ?? null, shader);
 
       return;
     }
@@ -268,7 +268,7 @@ export class Geometry extends EffectsObject {
     if (!vertexArrayObject) {
       vertexArrayObject = engine.recordVertexArrayObject(
         this.vertexBuffers,
-        this.indexBuffer,
+        this.indexBuffer ?? null,
         shader,
       );
       if (vertexArrayObject) {
@@ -276,9 +276,9 @@ export class Geometry extends EffectsObject {
       }
     }
     if (vertexArrayObject) {
-      engine.bindVertexArrayObject(vertexArrayObject, this.indexBuffer);
+      engine.bindVertexArrayObject(vertexArrayObject, this.indexBuffer ?? null);
     } else {
-      engine.bindBuffers(this.vertexBuffers, this.indexBuffer, shader);
+      engine.bindBuffers(this.vertexBuffers, this.indexBuffer ?? null, shader);
     }
   }
 

--- a/packages/effects-core/src/render/renderer.ts
+++ b/packages/effects-core/src/render/renderer.ts
@@ -172,7 +172,47 @@ export class Renderer {
   }
 
   drawGeometry (geometry: Geometry, matrix: Matrix4, material: Material, subMeshIndex = 0) {
-    this.engine.drawGeometry(geometry, matrix, material, subMeshIndex);
+    if (!geometry || !material) {
+      return;
+    }
+
+    material.initialize();
+    geometry.initialize();
+    geometry.flush();
+    material.setMatrix('effects_ObjectToWorld', matrix);
+
+    try {
+      material.use(this, this.renderingData.currentFrame.globalUniforms);
+    } catch (e) {
+      console.error(e);
+      this.engine.renderErrors.add(e as Error);
+
+      return;
+    }
+
+    const indexBuffer = geometry.getIndexBuffer();
+    let offset = geometry.getDrawStart();
+    let count = geometry.getDrawCount();
+    const subMeshes = geometry.subMeshes;
+
+    if (subMeshes.length > 0) {
+      const subMesh = subMeshes[subMeshIndex];
+
+      offset = subMesh.offset;
+      count = indexBuffer ? subMesh.indexCount ?? 0 : subMesh.vertexCount;
+    }
+    if (count <= 0) {
+      return;
+    }
+
+    geometry.bind(material.shaderVariant);
+    const instanceCount = geometry.instanceCount || undefined;
+
+    if (indexBuffer) {
+      this.engine.drawElementsType(geometry.mode, offset, count, instanceCount);
+    } else {
+      this.engine.drawArraysType(geometry.mode, offset, count, instanceCount);
+    }
   }
 
   getTemporaryRT (

--- a/packages/effects-threejs/src/three-renderer.ts
+++ b/packages/effects-threejs/src/three-renderer.ts
@@ -1,4 +1,4 @@
-import type { Engine } from '@galacean/effects-core';
+import type { Engine, Geometry, Material, math } from '@galacean/effects-core';
 import { Renderer } from '@galacean/effects-core';
 
 export class ThreeRenderer extends Renderer {
@@ -12,5 +12,13 @@ export class ThreeRenderer extends Renderer {
 
   override getHeight (): number {
     return this.engine.canvas.height;
+  }
+
+  override drawGeometry (
+    geometry: Geometry,
+    matrix: math.Matrix4,
+    material: Material,
+    subMeshIndex = 0,
+  ): void {
   }
 }

--- a/packages/effects-webgl/src/gl-engine.ts
+++ b/packages/effects-webgl/src/gl-engine.ts
@@ -1,9 +1,9 @@
 import type {
-  DataBuffer, DataBufferOptions, EngineOptions, Geometry, IndicesArray, Material, Nullable,
+  DataBuffer, DataBufferOptions, EngineOptions, IndicesArray, Nullable,
   RenderPassClearAction, ShaderLibrary, ShaderVariant, Texture, VertexBuffer, math,
 } from '@galacean/effects-core';
 import {
-  BufferDataType, Engine, GPUCapability, Renderer, TextureLoadAction, assertExist,
+  Engine, GPUCapability, Renderer, TextureLoadAction, assertExist,
   glContext, isIOS, logger, toBufferView,
 } from '@galacean/effects-core';
 import { GLShaderLibrary } from './gl-shader-library';
@@ -37,6 +37,9 @@ export class GLEngine extends Engine {
   private currentFramebuffer: Record<number, WebGLFramebuffer | null>;
   private currentTextureBinding: Record<number, Record<number, WebGLTexture | null>>;
   private currentRenderbuffer: Record<number, WebGLRenderbuffer | null>;
+  private currentIndexBuffer: DataBuffer | null = null;
+  private currentVertexArrayObject: WebGLVertexArrayObject | null = null;
+  private vaoRecordInProgress = false;
   private activeTextureIndex: number;
   private pixelStorei: Record<string, GLenum>;
 
@@ -189,14 +192,33 @@ export class GLEngine extends Engine {
     data: BufferData | number,
     options: DataBufferOptions,
   ): GLDataBuffer {
-    return this.createDataBuffer(this.gl.ARRAY_BUFFER, data, options);
+    const resource = this.gl.createBuffer();
+
+    if (!resource) {
+      throw new Error(`Failed to create buffer. gl isContextLost=${this.gl.isContextLost()}`);
+    }
+    const buffer = new GLDataBuffer(resource);
+    const view = typeof data === 'number' ? undefined : toBufferView(data);
+    const byteLength = typeof data === 'number' ? data : view!.byteLength;
+
+    assignInspectorName(resource, options.label);
+    this.bindArrayBuffer(buffer);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, Math.max(byteLength, 1), options.usage);
+    if (view && byteLength > 0) {
+      this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, view);
+    }
+    this.bindArrayBuffer(null);
+    buffer.capacity = byteLength;
+    buffer.references = 1;
+
+    return buffer;
   }
 
   override createDynamicVertexBuffer (
     data: BufferData | number,
     options: DataBufferOptions,
   ): GLDataBuffer {
-    return this.createDataBuffer(this.gl.ARRAY_BUFFER, data, options);
+    return this.createVertexBuffer(data, options);
   }
 
   override createIndexBuffer (
@@ -204,11 +226,22 @@ export class GLEngine extends Engine {
     options: DataBufferOptions,
   ): GLDataBuffer {
     const data = this.normalizeIndexData(indices);
-    const buffer = this.createDataBuffer(this.gl.ELEMENT_ARRAY_BUFFER, data, {
-      ...options,
-      type: data instanceof Uint32Array ? BufferDataType.UnsignedInt : BufferDataType.UnsignedShort,
-    });
+    const resource = this.gl.createBuffer();
 
+    if (!resource) {
+      throw new Error(`Failed to create buffer. gl isContextLost=${this.gl.isContextLost()}`);
+    }
+    const buffer = new GLDataBuffer(resource);
+
+    assignInspectorName(resource, options.label);
+    this.bindIndexBuffer(buffer);
+    this.gl.bufferData(this.gl.ELEMENT_ARRAY_BUFFER, Math.max(data.byteLength, 1), options.usage);
+    if (data.byteLength > 0) {
+      this.gl.bufferSubData(this.gl.ELEMENT_ARRAY_BUFFER, 0, data);
+    }
+    this.bindIndexBuffer(null);
+    buffer.capacity = data.byteLength;
+    buffer.references = 1;
     buffer.is32Bits = data instanceof Uint32Array;
 
     return buffer;
@@ -250,6 +283,7 @@ export class GLEngine extends Engine {
     if (data.byteLength > 0) {
       this.gl.bufferSubData(this.gl.ELEMENT_ARRAY_BUFFER, byteOffset, data);
     }
+    this.bindIndexBuffer(null);
   }
 
   /** @hide */
@@ -274,7 +308,7 @@ export class GLEngine extends Engine {
   /** @hide */
   recordVertexArrayObject (
     vertexBuffers: Record<string, VertexBuffer>,
-    indexBuffer: DataBuffer | undefined,
+    indexBuffer: DataBuffer | null,
     effect: ShaderVariant,
   ): WebGLVertexArrayObject | undefined {
     const vertexArrayObject = this.gl.createVertexArray() ?? undefined;
@@ -282,10 +316,12 @@ export class GLEngine extends Engine {
     if (!vertexArrayObject) {
       return undefined;
     }
-    this.bindVertexArrayObject(vertexArrayObject);
+    this.vaoRecordInProgress = true;
+    this.bindVertexArrayObject(vertexArrayObject, null);
     this.bindVertexBuffersAttributes(vertexBuffers, effect);
     this.bindIndexBuffer(indexBuffer);
-    this.bindVertexArrayObject(null);
+    this.vaoRecordInProgress = false;
+    this.bindVertexArrayObject(null, null);
 
     return vertexArrayObject;
   }
@@ -293,10 +329,10 @@ export class GLEngine extends Engine {
   /** @hide */
   override bindBuffers (
     vertexBuffers: Record<string, VertexBuffer>,
-    indexBuffer: DataBuffer | undefined,
+    indexBuffer: DataBuffer | null,
     effect: ShaderVariant,
   ): void {
-    this.bindVertexArrayObject(null);
+    this.bindVertexArrayObject(null, null);
     this.bindVertexBuffersAttributes(vertexBuffers, effect);
     this.bindIndexBuffer(indexBuffer);
   }
@@ -342,44 +378,25 @@ export class GLEngine extends Engine {
     }
   }
 
-  bindArrayBuffer (buffer?: DataBuffer): void {
+  bindArrayBuffer (buffer: DataBuffer | null): void {
+    if (!this.vaoRecordInProgress) {
+      this.unbindVertexArrayObject();
+    }
     this.gl.bindBuffer(
       this.gl.ARRAY_BUFFER,
       buffer?.underlyingResource as WebGLBuffer | undefined ?? null,
     );
   }
 
-  protected bindIndexBuffer (buffer?: DataBuffer): void {
+  protected bindIndexBuffer (buffer: DataBuffer | null): void {
+    if (!this.vaoRecordInProgress) {
+      this.unbindVertexArrayObject();
+    }
+    this.currentIndexBuffer = buffer;
     this.gl.bindBuffer(
       this.gl.ELEMENT_ARRAY_BUFFER,
       buffer?.underlyingResource as WebGLBuffer | undefined ?? null,
     );
-  }
-
-  private createDataBuffer (
-    target: number,
-    data: BufferData | number,
-    options: DataBufferOptions,
-  ): GLDataBuffer {
-    const resource = this.gl.createBuffer();
-
-    if (!resource) {
-      throw new Error(`Failed to create buffer. gl isContextLost=${this.gl.isContextLost()}`);
-    }
-    const buffer = new GLDataBuffer(resource);
-    const view = typeof data === 'number' ? undefined : toBufferView(data);
-    const byteLength = typeof data === 'number' ? data : view!.byteLength;
-
-    assignInspectorName(resource, options.label);
-    this.gl.bindBuffer(target, resource);
-    this.gl.bufferData(target, Math.max(byteLength, 1), options.usage);
-    if (view && byteLength > 0) {
-      this.gl.bufferSubData(target, 0, view);
-    }
-    buffer.capacity = byteLength;
-    buffer.references = 1;
-
-    return buffer;
   }
 
   private normalizeIndexData (indices: IndicesArray): Uint16Array | Uint32Array {
@@ -416,8 +433,25 @@ export class GLEngine extends Engine {
   }
 
   /** @hide */
-  bindVertexArrayObject (vertexArrayObject: WebGLVertexArrayObject | null): void {
+  bindVertexArrayObject (
+    vertexArrayObject: WebGLVertexArrayObject | null,
+    indexBuffer: DataBuffer | null,
+  ): void {
+    this.currentIndexBuffer = indexBuffer;
+    if (this.currentVertexArrayObject === vertexArrayObject) {
+      return;
+    }
+    this.currentVertexArrayObject = vertexArrayObject;
     this.gl.bindVertexArray(vertexArrayObject);
+  }
+
+  private unbindVertexArrayObject (): void {
+    if (!this.currentVertexArrayObject) {
+      return;
+    }
+    this.currentVertexArrayObject = null;
+    this.currentIndexBuffer = null;
+    this.gl.bindVertexArray(null);
   }
 
   deleteGLTexture (texture: GLTexture) {
@@ -441,77 +475,40 @@ export class GLEngine extends Engine {
     }
   }
 
-  override drawGeometry (geometry: Geometry, matrix: Matrix4, material: Material, subMeshIndex = 0): void {
-    if (!geometry || !material) {
-      return;
-    }
-
-    material.initialize();
-    geometry.initialize();
-    geometry.flush();
-    const renderingData = this.renderingData;
-
-    material.setMatrix('effects_ObjectToWorld', matrix);
-
-    try {
-      material.use(this.renderer, renderingData.currentFrame.globalUniforms);
-    } catch (e) {
-      console.error(e);
-
-      this.renderErrors.add(e as Error);
-
-      return;
-    }
-
-    const gl = this.gl;
-
-    if (!gl) {
-      console.warn('GLGPURenderer has not bound a gl object, unable to render geometry.');
-
-      return;
-    }
-
-    geometry.bind(material.shaderVariant);
-    const indexDataBuffer = geometry.getIndexBuffer();
-    const indexType = geometry.getIndexType();
-    let offset = geometry.getDrawStart();
-    let count = geometry.getDrawCount();
-    const mode = geometry.mode;
-    const subMeshes = geometry.subMeshes;
-
-    if (subMeshes && subMeshes.length) {
-      const subMesh = subMeshes[subMeshIndex];
-
-      offset = subMesh.offset;
-      if (indexDataBuffer) {
-        count = subMesh.indexCount ?? 0;
-      } else {
-        count = subMesh.vertexCount;
-      }
-    }
-    if (count <= 0) {
-      this.bindVertexArrayObject(null);
-
-      return;
-    }
-    const instanceCount = geometry.instanceCount;
-
-    if (instanceCount > 0 && !this.gpuCapability.detail.instanceDraw) {
-      this.bindVertexArrayObject(null);
+  override drawElementsType (
+    mode: number,
+    indexOffset: number,
+    indexCount: number,
+    instanceCount?: number,
+  ): void {
+    if (instanceCount && !this.gpuCapability.detail.instanceDraw) {
       throw new Error(INSTANCE_DRAW_ERROR);
     }
-    if (indexDataBuffer) {
-      if (instanceCount > 0) {
-        gl.drawElementsInstanced(mode, count, indexType, offset ?? 0, instanceCount);
-      } else {
-        gl.drawElements(mode, count, indexType, offset ?? 0);
-      }
-    } else if (instanceCount > 0) {
-      gl.drawArraysInstanced(mode, offset, count, instanceCount);
+    const indexType = this.currentIndexBuffer?.is32Bits
+      ? this.gl.UNSIGNED_INT
+      : this.gl.UNSIGNED_SHORT;
+
+    if (instanceCount) {
+      this.gl.drawElementsInstanced(mode, indexCount, indexType, indexOffset, instanceCount);
     } else {
-      gl.drawArrays(mode, offset, count);
+      this.gl.drawElements(mode, indexCount, indexType, indexOffset);
     }
-    this.bindVertexArrayObject(null);
+  }
+
+  override drawArraysType (
+    mode: number,
+    vertexStart: number,
+    vertexCount: number,
+    instanceCount?: number,
+  ): void {
+    if (instanceCount && !this.gpuCapability.detail.instanceDraw) {
+      throw new Error(INSTANCE_DRAW_ERROR);
+    }
+    if (instanceCount) {
+      this.gl.drawArraysInstanced(mode, vertexStart, vertexCount, instanceCount);
+    } else {
+      this.gl.drawArrays(mode, vertexStart, vertexCount);
+    }
   }
 
   override clear (action: RenderPassClearAction): void {
@@ -564,6 +561,9 @@ export class GLEngine extends Engine {
     this.currentTextureBinding = {};
     this.pixelStorei = {};
     this.currentRenderbuffer = {};
+    this.currentIndexBuffer = null;
+    this.currentVertexArrayObject = null;
+    this.vaoRecordInProgress = false;
   }
 
   override setSampleAlphaToCoverage (enable: boolean) {

--- a/web-packages/test/unit/src/effects-webgl/geometry.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/geometry.spec.ts
@@ -348,6 +348,7 @@ describe('webgl/geometry', () => {
     const gl = engine.gl;
     const originalDrawElements = gl.drawElements;
     const offsets: number[] = [];
+    const types: number[] = [];
     const material = {
       initialize () {},
       setMatrix () {},
@@ -362,6 +363,7 @@ describe('webgl/geometry', () => {
     } as unknown as Material;
 
     gl.drawElements = ((...args) => {
+      types.push(args[2]);
       offsets.push(args[3]);
     }) as typeof gl.drawElements;
     try {
@@ -381,7 +383,8 @@ describe('webgl/geometry', () => {
           drawCount: indices.length - 1,
         });
 
-        engine.drawGeometry(geometry, math.Matrix4.IDENTITY, material);
+        engine.renderer.drawGeometry(geometry, math.Matrix4.IDENTITY, material);
+        expect(gl.getParameter(gl.VERTEX_ARRAY_BINDING)).not.to.equal(null);
         geometry.dispose();
       });
     } finally {
@@ -391,6 +394,59 @@ describe('webgl/geometry', () => {
       Uint16Array.BYTES_PER_ELEMENT,
       Uint32Array.BYTES_PER_ELEMENT,
     ]);
+    expect(types).to.deep.equal([gl.UNSIGNED_SHORT, gl.UNSIGNED_INT]);
+  });
+
+  it('draws unindexed sub-mesh ranges through the renderer', () => {
+    const gl = engine.gl;
+    const originalDrawArrays = gl.drawArrays;
+    const calls: number[][] = [];
+    const geometry = new Geometry(engine, {
+      attributes: {
+        aPosition: {
+          data: new Float32Array([0, 0, 1, 0, 0, 1]),
+          size: 2,
+        },
+      },
+      drawCount: 3,
+      mode: glContext.TRIANGLES,
+    });
+
+    geometry.subMeshes = [{ offset: 1, indexCount: 0, vertexCount: 2 }];
+    gl.drawArrays = ((...args) => {
+      calls.push(args);
+    }) as typeof gl.drawArrays;
+    try {
+      engine.renderer.drawGeometry(
+        geometry,
+        math.Matrix4.IDENTITY,
+        createMaterialStub(),
+      );
+      expect(gl.getParameter(gl.VERTEX_ARRAY_BINDING)).not.to.equal(null);
+    } finally {
+      gl.drawArrays = originalDrawArrays;
+      geometry.dispose();
+    }
+    expect(calls).to.deep.equal([[gl.TRIANGLES, 1, 2]]);
+  });
+
+  it('protects a cached vertex array while creating another geometry', () => {
+    const gl = engine.gl;
+    const material = createMaterialStub();
+    const firstGeometry = createGeometry(engine);
+    const secondGeometry = createGeometry(engine);
+
+    engine.renderer.drawGeometry(firstGeometry, math.Matrix4.IDENTITY, material);
+    const vertexArrayObject = gl.getParameter(gl.VERTEX_ARRAY_BINDING) as WebGLVertexArrayObject;
+    const indexResource = firstGeometry.getIndexBuffer()!.underlyingResource;
+
+    secondGeometry.initialize();
+    expect(gl.getParameter(gl.VERTEX_ARRAY_BINDING)).to.equal(null);
+    gl.bindVertexArray(vertexArrayObject);
+    expect(gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)).to.equal(indexResource);
+    gl.bindVertexArray(null);
+    firstGeometry.dispose();
+    secondGeometry.dispose();
   });
 
   it('rejects instanced drawing when it is unsupported', () => {
@@ -398,7 +454,7 @@ describe('webgl/geometry', () => {
 
     geometry.instanceCount = 2;
     Object.defineProperty(engine.gpuCapability.detail, 'instanceDraw', { value: false });
-    expect(() => engine.drawGeometry(
+    expect(() => engine.renderer.drawGeometry(
       geometry,
       math.Matrix4.IDENTITY,
       createMaterialStub(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved rendering for indexed and non-indexed geometry, including instanced drawing support where available.
  * Added more reliable handling of vertex and index buffers during rendering.
  * Improved WebGL rendering behavior for indexed geometry types and vertex array objects.

* **Bug Fixes**
  * Prevented invalid draw calls when geometry or materials are unavailable.
  * Added clearer error handling when material setup fails.
  * Improved validation for empty or invalid sub-mesh ranges.

* **Tests**
  * Expanded coverage for indexed draw types, non-indexed ranges, vertex array binding, and unsupported instancing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->