### PR TITLE
fix: keep composition order stable without mutating array

### DIFF
--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -94,7 +94,6 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
    * 渲染过程中错误队列
    */
   renderErrors: Set<Error> = new Set();
-  compositions: Composition[] = [];
   assetManagers: AssetManager[] = [];
   assetService: AssetService;
   eventSystem: EventSystem;
@@ -137,6 +136,7 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
   protected renderbuffers: Renderbuffer[] = [];
   protected particleSystems: ParticleSystem[] = [];
 
+  private _compositions: Composition[] = [];
   private _graphics: Graphics;
   private assetLoader: AssetLoader;
   private clearAction: RenderPassClearAction = {
@@ -182,6 +182,10 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
     };
 
     PluginSystem.notifyEngineCreated(this);
+  }
+
+  get compositions (): Composition[] {
+    return this._compositions.sort((a, b) => a.getIndex() - b.getIndex());
   }
 
   get graphics (): Graphics {
@@ -322,8 +326,6 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
     //-------------------------------------------------------------------------
 
     const compositions = this.compositions;
-
-    compositions.sort((a, b) => a.getIndex() - b.getIndex());
 
     let skipRender = false;
 
@@ -771,8 +773,8 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
     this.geometries = [];
     this.meshes = [];
     this.renderPasses = [];
-    this.compositions = [];
     this.particleSystems = [];
+    this._compositions = [];
   }
 
   private getTargetSize (parentEle: HTMLElement) {

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -292,7 +292,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
    * 获取当前播放的所有合成（请不要修改返回的数组内容）
    */
   getCompositions () {
-    return this.compositions.sort((a, b) => a.getIndex() - b.getIndex());
+    return this.compositions;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Composition lists now consistently appear in index order.
  * Prevented internal sorting from unexpectedly changing composition collection order.
  * Disposed engines now properly clear their compositions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->