### PR TITLE
fix: preserve drag state until mouseup

### DIFF
--- a/packages/effects-core/src/plugins/interact/event-system.ts
+++ b/packages/effects-core/src/plugins/interact/event-system.ts
@@ -71,6 +71,14 @@ export class EventSystem implements Disposable {
   private nativeHandlers: NativeHandler[] = [];
   private target: HTMLCanvasElement | null = null;
   private mouseState: PointerState | null = null;
+  /**
+   * Logical mouse button state maintained from mousedown/mouseup transitions.
+   *
+   * On macOS, a trackpad may emit a release-edge pointermove with buttons=0
+   * before mouseup. Treating that motion as a release ends the drag early and
+   * may skip the final transform commit.
+   */
+  private mouseButtonMask = MouseButtonMask.None;
   private touchStates = new Map<number, PointerState>();
   private mouseFromTouchIndex: number | null = null;
   private touchFromMousePressed = false;
@@ -93,6 +101,7 @@ export class EventSystem implements Disposable {
     this._enabled = value;
     if (!value) {
       this.mouseState = null;
+      this.mouseButtonMask = MouseButtonMask.None;
       this.touchStates.clear();
       this.mouseFromTouchIndex = null;
       this.touchFromMousePressed = false;
@@ -170,6 +179,7 @@ export class EventSystem implements Disposable {
   dispose (): void {
     this.engine.windowRoot.cancelPointerInput();
     this.mouseState = null;
+    this.mouseButtonMask = MouseButtonMask.None;
     this.touchStates.clear();
     this.mouseFromTouchIndex = null;
     this.touchFromMousePressed = false;
@@ -238,6 +248,10 @@ export class EventSystem implements Disposable {
     if (!this.enabled || !this.target) {
       return;
     }
+    // Keep the canonical mask in sync even when mouseState already ended on a
+    // previous button release. The target and Window listeners may see the
+    // same mouseup, but clearing a bit twice is intentionally idempotent.
+    this.setMouseButtonPressed(event.button, false);
     const position = this.getCanvasPosition(event.clientX, event.clientY);
     const existingState = this.mouseState;
 
@@ -318,6 +332,7 @@ export class EventSystem implements Disposable {
   private onWindowBlur = (): void => {
     if (this.enabled) {
       this.mouseState = null;
+      this.mouseButtonMask = MouseButtonMask.None;
       this.touchStates.clear();
       this.mouseFromTouchIndex = null;
       this.touchFromMousePressed = false;
@@ -329,6 +344,7 @@ export class EventSystem implements Disposable {
     if (!this.enabled || !this.target) {
       return;
     }
+    this.setMouseButtonPressed(event.button, true);
     const position = this.getCanvasPosition(event.clientX, event.clientY);
 
     this.focusTarget();
@@ -427,7 +443,7 @@ export class EventSystem implements Disposable {
   ): boolean {
     let handled = false;
 
-    if (this.touchFromMousePressed && (event.buttons & 1) !== 0) {
+    if (this.touchFromMousePressed && (this.mouseButtonMask & MouseButtonMask.Left) !== 0) {
       handled = this.pushScreenDrag(
         0,
         position,
@@ -531,17 +547,22 @@ export class EventSystem implements Disposable {
     this.copyMouseFields(input, event, position);
     input.device = InputEvent.deviceIdMouse;
     input.buttonIndex = getMouseButton(event.button);
-    input.buttonMask = getMouseButtonMask(event.buttons);
-    if (pressed) {
-      input.buttonMask |= getMouseButtonBit(input.buttonIndex);
-    } else {
-      input.buttonMask &= ~getMouseButtonBit(input.buttonIndex);
-    }
+    input.buttonMask = this.mouseButtonMask;
     input.pressed = pressed;
     input.doubleClick = event.detail > 1;
     this.engine.windowRoot.pushInput(input);
 
     return this.engine.windowRoot.isInputHandled();
+  }
+
+  private setMouseButtonPressed (button: number, pressed: boolean): void {
+    const buttonBit = getMouseButtonBit(getMouseButton(button));
+
+    if (pressed) {
+      this.mouseButtonMask |= buttonBit;
+    } else {
+      this.mouseButtonMask &= ~buttonBit;
+    }
   }
 
   private pushWheelButton (
@@ -555,7 +576,7 @@ export class EventSystem implements Disposable {
     this.copyMouseFields(input, event, position);
     input.device = InputEvent.deviceIdMouse;
     input.buttonIndex = button;
-    input.buttonMask = getMouseButtonMask(event.buttons);
+    input.buttonMask = this.mouseButtonMask;
     input.factor = factor;
     input.pressed = true;
     this.engine.windowRoot.pushInput(input);
@@ -573,8 +594,8 @@ export class EventSystem implements Disposable {
 
     this.copyMouseFields(input, event, position);
     input.device = InputEvent.deviceIdMouse;
-    input.buttonMask = getMouseButtonMask(event.buttons);
-    input.pressed = event.buttons !== 0;
+    input.buttonMask = this.mouseButtonMask;
+    input.pressed = this.mouseButtonMask !== MouseButtonMask.None;
     input.relative.copyFrom(relative);
     input.screenRelative.copyFrom(relative);
     input.velocity.copyFrom(velocity);
@@ -868,28 +889,6 @@ function getMouseButton (button: number): MouseButton {
     default:
       return MouseButton.None;
   }
-}
-
-function getMouseButtonMask (buttons: number): MouseButtonMask {
-  let mask = MouseButtonMask.None;
-
-  if ((buttons & 1) !== 0) {
-    mask |= MouseButtonMask.Left;
-  }
-  if ((buttons & 2) !== 0) {
-    mask |= MouseButtonMask.Right;
-  }
-  if ((buttons & 4) !== 0) {
-    mask |= MouseButtonMask.Middle;
-  }
-  if ((buttons & 8) !== 0) {
-    mask |= MouseButtonMask.Xbutton1;
-  }
-  if ((buttons & 16) !== 0) {
-    mask |= MouseButtonMask.Xbutton2;
-  }
-
-  return mask;
 }
 
 function getMouseButtonBit (button: MouseButton): MouseButtonMask {

--- a/web-packages/test/unit/src/effects-core/components/control-input.spec.ts
+++ b/web-packages/test/unit/src/effects-core/components/control-input.spec.ts
@@ -11,6 +11,7 @@ import {
   InputEventScreenDrag,
   InputEventScreenTouch,
   MouseButton,
+  MouseButtonMask,
   MouseFilter,
   Player,
   UIControl,
@@ -71,6 +72,37 @@ class AcceptingControl extends RecordingControl {
   override onMouseDown (event: InputEventMouseButton): void {
     super.onMouseDown(event);
     event.accept();
+  }
+}
+
+class MouseStateRecordingControl extends ContainerControl {
+  readonly states: Array<{
+    phase: 'down' | 'move' | 'up',
+    buttonMask: MouseButtonMask,
+    pressed: boolean,
+  }> = [];
+
+  override onMouseDown (event: InputEventMouseButton): void {
+    this.record('down', event);
+  }
+
+  override onMouseMove (event: InputEventMouseMotion): void {
+    this.record('move', event);
+  }
+
+  override onMouseUp (event: InputEventMouseButton): void {
+    this.record('up', event);
+  }
+
+  private record (
+    phase: 'down' | 'move' | 'up',
+    event: InputEventMouseButton | InputEventMouseMotion,
+  ): void {
+    this.states.push({
+      phase,
+      buttonMask: event.buttonMask,
+      pressed: event.pressed,
+    });
   }
 }
 
@@ -155,7 +187,94 @@ describe('core/gui input', () => {
     expect(order).deep.equals(['rect', 'focus']);
   });
 
-  it('matches Godot by focusing before mapping native touch coordinates', () => {
+  it('keeps the admitted button session through a release-edge motion with buttons=0', () => {
+    player.canvas.getBoundingClientRect = canvasRect;
+    const control = addControl(
+      composition.sceneRoot,
+      new MouseStateRecordingControl(player.engine),
+      0, 0, 100, 100,
+    );
+
+    player.canvas.dispatchEvent(new MouseEvent('mousedown', {
+      clientX: 20,
+      clientY: 30,
+      button: 0,
+      buttons: 1,
+    }));
+    window.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 21,
+      clientY: 30,
+      button: 0,
+      buttons: 0,
+    }));
+    window.dispatchEvent(new MouseEvent('mouseup', {
+      clientX: 21,
+      clientY: 30,
+      button: 0,
+      buttons: 0,
+    }));
+    window.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 22,
+      clientY: 30,
+      button: 0,
+      buttons: 0,
+    }));
+
+    expect(control.states).deep.equals([
+      { phase: 'down', buttonMask: MouseButtonMask.Left, pressed: true },
+      { phase: 'move', buttonMask: MouseButtonMask.Left, pressed: true },
+      { phase: 'up', buttonMask: MouseButtonMask.None, pressed: false },
+      { phase: 'move', buttonMask: MouseButtonMask.None, pressed: false },
+    ]);
+  });
+
+  it('clears the canonical button mask after overlapping button releases', () => {
+    player.canvas.getBoundingClientRect = canvasRect;
+    const control = addControl(
+      composition.sceneRoot,
+      new MouseStateRecordingControl(player.engine),
+      0, 0, 100, 100,
+    );
+
+    player.canvas.dispatchEvent(new MouseEvent('mousedown', {
+      clientX: 20,
+      clientY: 30,
+      button: 0,
+      buttons: 1,
+    }));
+    player.canvas.dispatchEvent(new MouseEvent('mousedown', {
+      clientX: 20,
+      clientY: 30,
+      button: 2,
+      buttons: 3,
+    }));
+    window.dispatchEvent(new MouseEvent('mouseup', {
+      clientX: 20,
+      clientY: 30,
+      button: 2,
+      buttons: 1,
+    }));
+    window.dispatchEvent(new MouseEvent('mouseup', {
+      clientX: 20,
+      clientY: 30,
+      button: 0,
+      buttons: 0,
+    }));
+    window.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 21,
+      clientY: 30,
+      button: 0,
+      buttons: 0,
+    }));
+
+    expect(control.states[control.states.length - 1]).deep.equals({
+      phase: 'move',
+      buttonMask: MouseButtonMask.None,
+      pressed: false,
+    });
+  });
+
+  it('focusing before mapping native touch coordinates', () => {
     const order: string[] = [];
 
     player.canvas.focus = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse and trackpad drag handling, preventing interactions from ending prematurely during button release.
  * Preserved accurate mouse-button state across movement, scrolling, touch emulation, window focus changes, and overlapping button releases.

* **Tests**
  * Added coverage for release-edge motion and simultaneous mouse-button interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->