### PR TITLE
chore: bump @galacean/effects-math to 1.2.1

### DIFF
--- a/packages/effects-core/package.json
+++ b/packages/effects-core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@galacean/effects-specification": "^2.9.0",
-    "@galacean/effects-math": "1.2.0",
+    "@galacean/effects-math": "1.2.1",
     "flatbuffers": "24.3.25",
     "uuid": "9.0.1",
     "libtess": "1.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
   packages/effects-core:
     dependencies:
       '@galacean/effects-math':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.2.1
+        version: 1.2.1
       '@galacean/effects-specification':
         specifier: ^2.9.0
         version: 2.9.0
@@ -333,12 +333,12 @@ importers:
       '@galacean/effects':
         specifier: workspace:*
         version: link:../../packages/effects
-      '@galacean/effects-plugin-gui':
-        specifier: workspace:*
-        version: link:../../plugin-packages/gui
       '@galacean/effects-plugin-ffd':
         specifier: workspace:*
         version: link:../../plugin-packages/ffd
+      '@galacean/effects-plugin-gui':
+        specifier: workspace:*
+        version: link:../../plugin-packages/gui
       '@galacean/effects-plugin-model':
         specifier: workspace:*
         version: link:../../plugin-packages/model
@@ -2258,8 +2258,8 @@ packages:
     resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
     dev: true
 
-  /@galacean/effects-math@1.2.0:
-    resolution: {integrity: sha512-kJzh2TuaXnRZo6R7xxcx64GkQuPtA6DmXxa+EXadkZNMNCSzJdCS53ZmEd2VbR1n/HSnbDRt4y6g5SElTfUv3Q==}
+  /@galacean/effects-math@1.2.1:
+    resolution: {integrity: sha512-vO5VEk8qg4+yF7TuttDrPr5fLK2HxFf1wqdoCzaO2umBO6NNIxl+SzzLqleMwo2kuZHIYoH2OtekHLPnw9MvIQ==}
     engines: {node: '>=10.0.0'}
 
   /@galacean/effects-specification@2.8.1:
@@ -3070,7 +3070,7 @@ packages:
     resolution: {integrity: sha512-gzBDmLIM6FQOyU3D8smJent+SGfoGlenka1gbwXy+/hrIN+2ZRsvdL9blYXKLwH0gx+FxSTDjELJiM0JRl2oFg==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      '@galacean/effects-math': 1.2.0
+      '@galacean/effects-math': 1.2.1
       '@galacean/effects-specification': 2.8.1
       '@types/draco3dgltf': 1.4.3
       '@types/ndarray': 1.0.11


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the math package to version 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->