### PR TITLE
fix: preserve context for externally owned canvas

### DIFF
--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -39,6 +39,10 @@ export interface EngineOptions extends WebGLContextAttributes {
   notifyTouch?: boolean,
   interactive?: boolean,
   /**
+   * Engine 是否拥有 canvas 的生命周期，默认 true。
+   */
+  ownsCanvas?: boolean,
+  /**
    * 是否不处理 WebGL 上下文丢失恢复。
    * - `true`（默认）：上传 GPU 后释放 CPU 端源数据以节省内存；上下文丢失后不自动恢复，
    *   渲染暂停，等待宿主重建资源后手动恢复播放。
@@ -129,6 +133,10 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
    */
   doNotHandleContextLost = true;
   /**
+   * Engine 是否拥有 canvas 的生命周期
+   */
+  readonly ownsCanvas: boolean;
+  /**
    * WebGL 上下文是否处于丢失状态
    */
   protected contextWasLost = false;
@@ -161,6 +169,7 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
     super();
     this.canvas = canvas;
     this.env = options?.env ?? '';
+    this.ownsCanvas = options?.ownsCanvas ?? true;
     this.doNotHandleContextLost = options?.doNotHandleContextLost ?? true;
     this.name = options?.name ?? this.name;
     this.pixelRatio = options?.pixelRatio ?? getPixelRatio();

--- a/packages/effects-webgl/src/gl-context-manager.ts
+++ b/packages/effects-webgl/src/gl-context-manager.ts
@@ -32,13 +32,13 @@ export class GLContextManager {
     canvas.addEventListener('webglcontextrestored', this.contextRestoredListener);
   }
 
-  dispose () {
+  dispose (releaseContext = true) {
     if (this.canvas) {
       this.canvas.removeEventListener('webglcontextlost', this.contextLostListener);
       this.canvas.removeEventListener('webglcontextrestored', this.contextRestoredListener);
     }
 
-    if (this.gl) {
+    if (this.gl && releaseContext) {
       this.gl.getExtension('WEBGL_lose_context')?.loseContext();
     }
 

--- a/packages/effects-webgl/src/gl-engine.ts
+++ b/packages/effects-webgl/src/gl-engine.ts
@@ -549,7 +549,7 @@ export class GLEngine extends Engine {
     this.renderer.dispose();
     this.renderTargetPool.dispose();
     this.shaderLibrary?.dispose();
-    this.context.dispose();
+    this.context.dispose(this.ownsCanvas);
     this.reset();
   }
 

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -138,6 +138,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       doNotHandleContextLost,
     } = config;
     const { willCaptureImage: preserveDrawingBuffer, premultipliedAlpha } = renderOptions;
+    const ownsCanvas = !canvas;
 
     this.onError = onError;
 
@@ -156,7 +157,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
 
     this.env = env;
     this.name = name || `${seed++}`;
-    let useExternalCanvas = false;
 
     try {
       if (initErrors.length) {
@@ -168,7 +168,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
 
       if (canvas) {
         this.canvas = canvas;
-        useExternalCanvas = true;
       } else {
         assertContainer(container);
         this.canvas = document.createElement('canvas');
@@ -188,6 +187,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
         interactive,
         pixelRatio: Number.isFinite(pixelRatio) ? pixelRatio as number : getPixelRatio(),
         doNotHandleContextLost,
+        ownsCanvas,
       });
       this.engine.offscreenMode = true;
 
@@ -250,7 +250,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
 
       assertNoConcurrentPlayers();
     } catch (e: any) {
-      if (this.canvas && !useExternalCanvas) {
+      if (this.canvas && ownsCanvas) {
         this.canvas.remove();
       }
       this.engine?.dispose();
@@ -656,11 +656,13 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
     if (this.canvas instanceof HTMLCanvasElement) {
       // TODO: 数据模版下掉可以由文本模块单独管理
       canvasPool.dispose();
-      // canvas will become a cry emoji in Android if still in dom
-      if (this.canvas.parentNode) {
-        this.canvas.parentNode.removeChild(this.canvas);
+      if (this.engine.ownsCanvas) {
+        // canvas will become a cry emoji in Android if still in dom
+        if (this.canvas.parentNode) {
+          this.canvas.parentNode.removeChild(this.canvas);
+        }
+        this.canvas.remove();
       }
-      this.canvas.remove();
     }
 
     // 在报错函数中传入 player.name

--- a/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
@@ -43,13 +43,13 @@ describe('webgl/gl-context-lost', () => {
   let engine: GLEngine;
   let gl: WebGLRenderingContext;
 
-  function createEngine (doNotHandleContextLost: boolean): GLEngine {
+  function createEngine (doNotHandleContextLost: boolean, ownsCanvas = true): GLEngine {
     const c = document.createElement('canvas');
 
     c.width = 64;
     c.height = 64;
 
-    return new GLEngine(c, { glType: 'webgl2', doNotHandleContextLost });
+    return new GLEngine(c, { glType: 'webgl2', doNotHandleContextLost, ownsCanvas });
   }
 
   afterEach(() => {
@@ -262,6 +262,19 @@ describe('webgl/gl-context-lost', () => {
       engine.removeTexture(tex);
       tex.dispose();
     });
+  });
+
+  it('销毁 Engine 时可保留外部 canvas 的 WebGL context', function () {
+    engine = createEngine(true, false);
+    gl = engine.gl as WebGLRenderingContext;
+    if (!canEmulateContextLoss(engine)) {
+      this.skip();
+
+      return;
+    }
+    engine.dispose();
+
+    expect(gl.isContextLost()).to.equal(false);
   });
 
   describe('opt-in 模式 CPU 数据保留', () => {

--- a/web-packages/test/unit/src/effects/player-event.spec.ts
+++ b/web-packages/test/unit/src/effects/player-event.spec.ts
@@ -35,6 +35,40 @@ describe('player/event', () => {
     player.dispose();
   });
 
+  it('dispose preserves a caller-owned canvas for reuse', () => {
+    const container = document.createElement('div');
+    const canvas = document.createElement('canvas');
+
+    container.style.width = '64px';
+    container.style.height = '64px';
+    container.appendChild(canvas);
+    document.body.appendChild(container);
+    player = new Player({ canvas, manualRender: true });
+
+    expect(player.engine.ownsCanvas).to.equal(false);
+
+    player.dispose();
+
+    expect(canvas.parentNode).to.equal(container);
+    container.remove();
+  });
+
+  it('dispose releases a Player-owned canvas', () => {
+    const container = document.createElement('div');
+
+    container.style.width = '64px';
+    container.style.height = '64px';
+    document.body.appendChild(container);
+    player = new Player({ container, manualRender: true });
+    const canvas = player.canvas;
+
+    expect(player.engine.ownsCanvas).to.equal(true);
+    player.dispose();
+
+    expect(canvas.parentNode).to.equal(null);
+    container.remove();
+  });
+
   it('player lost/restored', async () => {
     player = new Player({
       canvas: document.createElement('canvas'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for externally provided canvases, allowing their WebGL context and DOM placement to remain available after disposal.
  - Engines now track whether they own their canvas.
  - Automatically created canvases continue to be removed when the player is disposed.

- **Bug Fixes**
  - Improved cleanup behavior to avoid releasing WebGL contexts belonging to external canvases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->