### PR TITLE
Merge origin/main into origin/feat/2.11

### DIFF
--- a/CHANGELOG-zh_CN.md
+++ b/CHANGELOG-zh_CN.md
@@ -8,6 +8,12 @@
 
 ---
 
+## 2.10.1
+
+`2026-09-03`
+
+- Fix: preserve context for externally owned canvas. [#1535](https://github.com/galacean/effects-runtime/pull/1535) @wumaolinmaoan
+
 ## 2.10.0
 
 `2026-08-31`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2.10.1
+
+`2026-09-03`
+
+- Fix: preserve context for externally owned canvas. [#1535](https://github.com/galacean/effects-runtime/pull/1535) @wumaolinmaoan
+
 ## 2.10.0
 
 `2026-08-31`

--- a/packages/effects-core/package.json
+++ b/packages/effects-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-core",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects runtime core for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -39,6 +39,10 @@ export interface EngineOptions extends WebGLContextAttributes {
   notifyTouch?: boolean,
   interactive?: boolean,
   /**
+   * Engine 是否拥有 canvas 的生命周期，默认 true。
+   */
+  ownsCanvas?: boolean,
+  /**
    * 是否不处理 WebGL 上下文丢失恢复。
    * - `true`（默认）：上传 GPU 后释放 CPU 端源数据以节省内存；上下文丢失后不自动恢复，
    *   渲染暂停，等待宿主重建资源后手动恢复播放。
@@ -129,6 +133,10 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
    */
   doNotHandleContextLost = true;
   /**
+   * Engine 是否拥有 canvas 的生命周期
+   */
+  readonly ownsCanvas: boolean;
+  /**
    * WebGL 上下文是否处于丢失状态
    */
   protected contextWasLost = false;
@@ -161,6 +169,7 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
     super();
     this.canvas = canvas;
     this.env = options?.env ?? '';
+    this.ownsCanvas = options?.ownsCanvas ?? true;
     this.doNotHandleContextLost = options?.doNotHandleContextLost ?? true;
     this.name = options?.name ?? this.name;
     this.pixelRatio = options?.pixelRatio ?? getPixelRatio();

--- a/packages/effects-helper/package.json
+++ b/packages/effects-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-helper",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects runtime helper for the web",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/effects-threejs/package.json
+++ b/packages/effects-threejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-threejs",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects runtime threejs plugin for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/packages/effects-webgl/package.json
+++ b/packages/effects-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-webgl",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects runtime webgl for the web",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/effects-webgl/src/gl-context-manager.ts
+++ b/packages/effects-webgl/src/gl-context-manager.ts
@@ -32,13 +32,13 @@ export class GLContextManager {
     canvas.addEventListener('webglcontextrestored', this.contextRestoredListener);
   }
 
-  dispose () {
+  dispose (releaseContext = true) {
     if (this.canvas) {
       this.canvas.removeEventListener('webglcontextlost', this.contextLostListener);
       this.canvas.removeEventListener('webglcontextrestored', this.contextRestoredListener);
     }
 
-    if (this.gl) {
+    if (this.gl && releaseContext) {
       this.gl.getExtension('WEBGL_lose_context')?.loseContext();
     }
 

--- a/packages/effects-webgl/src/gl-engine.ts
+++ b/packages/effects-webgl/src/gl-engine.ts
@@ -549,7 +549,7 @@ export class GLEngine extends Engine {
     this.renderer.dispose();
     this.renderTargetPool.dispose();
     this.shaderLibrary?.dispose();
-    this.context.dispose();
+    this.context.dispose(this.ownsCanvas);
     this.reset();
   }
 

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects runtime player for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/packages/effects/src/player.ts
+++ b/packages/effects/src/player.ts
@@ -138,6 +138,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
       doNotHandleContextLost,
     } = config;
     const { willCaptureImage: preserveDrawingBuffer, premultipliedAlpha } = renderOptions;
+    const ownsCanvas = !canvas;
 
     this.onError = onError;
 
@@ -156,7 +157,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
 
     this.env = env;
     this.name = name || `${seed++}`;
-    let useExternalCanvas = false;
 
     try {
       if (initErrors.length) {
@@ -168,7 +168,6 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
 
       if (canvas) {
         this.canvas = canvas;
-        useExternalCanvas = true;
       } else {
         assertContainer(container);
         this.canvas = document.createElement('canvas');
@@ -188,6 +187,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
         interactive,
         pixelRatio: Number.isFinite(pixelRatio) ? pixelRatio as number : getPixelRatio(),
         doNotHandleContextLost,
+        ownsCanvas,
       });
       this.engine.offscreenMode = true;
 
@@ -250,7 +250,7 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
 
       assertNoConcurrentPlayers();
     } catch (e: any) {
-      if (this.canvas && !useExternalCanvas) {
+      if (this.canvas && ownsCanvas) {
         this.canvas.remove();
       }
       this.engine?.dispose();
@@ -656,11 +656,13 @@ export class Player extends EventEmitter<PlayerEvent<Player>> implements Disposa
     if (this.canvas instanceof HTMLCanvasElement) {
       // TODO: 数据模版下掉可以由文本模块单独管理
       canvasPool.dispose();
-      // canvas will become a cry emoji in Android if still in dom
-      if (this.canvas.parentNode) {
-        this.canvas.parentNode.removeChild(this.canvas);
+      if (this.engine.ownsCanvas) {
+        // canvas will become a cry emoji in Android if still in dom
+        if (this.canvas.parentNode) {
+          this.canvas.parentNode.removeChild(this.canvas);
+        }
+        this.canvas.remove();
       }
-      this.canvas.remove();
     }
 
     // 在报错函数中传入 player.name

--- a/plugin-packages/alipay-downgrade/package.json
+++ b/plugin-packages/alipay-downgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-alipay-downgrade",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player downgrade plugin for Alipay",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/dom-content/package.json
+++ b/plugin-packages/dom-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-dom-content",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects plugin for rendering HTML/CSS DOM content as texture",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/downgrade/package.json
+++ b/plugin-packages/downgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-downgrade",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player downgrade plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/editor-gizmo/package.json
+++ b/plugin-packages/editor-gizmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-editor-gizmo",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player editor gizmo plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/ffd/package.json
+++ b/plugin-packages/ffd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-ffd",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player Free-form deformation plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/gui/package.json
+++ b/plugin-packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-gui",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "GUI controls and layout containers for Galacean Effects",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/ktx2/package.json
+++ b/plugin-packages/ktx2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-ktx2",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player Khronos Texture 2.0 plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/model/package.json
+++ b/plugin-packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-model",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player model plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/multimedia/package.json
+++ b/plugin-packages/multimedia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-multimedia",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player multimedia plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/orientation-transformer/package.json
+++ b/plugin-packages/orientation-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-orientation-transformer",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player orientation transformer plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/rich-text/package.json
+++ b/plugin-packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-rich-text",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player rich text plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/spine/package.json
+++ b/plugin-packages/spine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-spine",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects player spine plugin",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/plugin-packages/stats/package.json
+++ b/plugin-packages/stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-plugin-stats",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Galacean Effects runtime stats for the web",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",

--- a/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
+++ b/web-packages/test/unit/src/effects-webgl/gl-context-lost.spec.ts
@@ -43,13 +43,13 @@ describe('webgl/gl-context-lost', () => {
   let engine: GLEngine;
   let gl: WebGLRenderingContext;
 
-  function createEngine (doNotHandleContextLost: boolean): GLEngine {
+  function createEngine (doNotHandleContextLost: boolean, ownsCanvas = true): GLEngine {
     const c = document.createElement('canvas');
 
     c.width = 64;
     c.height = 64;
 
-    return new GLEngine(c, { glType: 'webgl2', doNotHandleContextLost });
+    return new GLEngine(c, { glType: 'webgl2', doNotHandleContextLost, ownsCanvas });
   }
 
   afterEach(() => {
@@ -262,6 +262,19 @@ describe('webgl/gl-context-lost', () => {
       engine.removeTexture(tex);
       tex.dispose();
     });
+  });
+
+  it('销毁 Engine 时可保留外部 canvas 的 WebGL context', function () {
+    engine = createEngine(true, false);
+    gl = engine.gl as WebGLRenderingContext;
+    if (!canEmulateContextLoss(engine)) {
+      this.skip();
+
+      return;
+    }
+    engine.dispose();
+
+    expect(gl.isContextLost()).to.equal(false);
   });
 
   describe('opt-in 模式 CPU 数据保留', () => {

--- a/web-packages/test/unit/src/effects/player-event.spec.ts
+++ b/web-packages/test/unit/src/effects/player-event.spec.ts
@@ -35,6 +35,40 @@ describe('player/event', () => {
     player.dispose();
   });
 
+  it('dispose preserves a caller-owned canvas for reuse', () => {
+    const container = document.createElement('div');
+    const canvas = document.createElement('canvas');
+
+    container.style.width = '64px';
+    container.style.height = '64px';
+    container.appendChild(canvas);
+    document.body.appendChild(container);
+    player = new Player({ canvas, manualRender: true });
+
+    expect(player.engine.ownsCanvas).to.equal(false);
+
+    player.dispose();
+
+    expect(canvas.parentNode).to.equal(container);
+    container.remove();
+  });
+
+  it('dispose releases a Player-owned canvas', () => {
+    const container = document.createElement('div');
+
+    container.style.width = '64px';
+    container.style.height = '64px';
+    document.body.appendChild(container);
+    player = new Player({ container, manualRender: true });
+    const canvas = player.canvas;
+
+    expect(player.engine.ownsCanvas).to.equal(true);
+    player.dispose();
+
+    expect(canvas.parentNode).to.equal(null);
+    container.remove();
+  });
+
   it('player lost/restored', async () => {
     player = new Player({
       canvas: document.createElement('canvas'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed cleanup for externally provided canvases so disposing an effect no longer destroys their WebGL context or removes them from the page.
  - Improved canvas lifecycle handling during initialization failures and disposal.

- **New Features**
  - Added support for explicitly tracking whether the effect engine owns its canvas, while preserving existing behavior for internally created canvases.

- **Release**
  - Updated packages to version **2.10.1**.
  - Added changelog entries dated **September 3, 2026**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->