### PR TITLE
fix: guard optional canvas DOM APIs

### DIFF
--- a/packages/effects-core/src/plugins/interact/event-system.ts
+++ b/packages/effects-core/src/plugins/interact/event-system.ts
@@ -126,11 +126,17 @@ export class EventSystem extends EventEmitter<EventSystemEvent> implements Dispo
     if (!target || typeof window === 'undefined') {
       return;
     }
-    if (!target.hasAttribute('tabindex')) {
+    // Mini-program canvas adapters support input events but may not implement
+    // the full HTMLElement attribute and CSSStyleDeclaration APIs.
+    if (
+      typeof target.hasAttribute === 'function' &&
+      typeof target.removeAttribute === 'function' &&
+      !target.hasAttribute('tabindex')
+    ) {
       target.tabIndex = 0;
       this.addedTabIndex = true;
     }
-    if (!target.style.outline) {
+    if (typeof target.style?.removeProperty === 'function' && !target.style.outline) {
       target.style.outline = 'none';
       this.addedOutlineStyle = true;
     }
@@ -827,7 +833,9 @@ export class EventSystem extends EventEmitter<EventSystemEvent> implements Dispo
   }
 
   private focusTarget (): void {
-    this.target?.focus();
+    if (typeof this.target?.focus === 'function') {
+      this.target.focus();
+    }
   }
 
   private resetInputState (): void {

--- a/web-packages/test/unit/src/effects-core/index.ts
+++ b/web-packages/test/unit/src/effects-core/index.ts
@@ -3,6 +3,7 @@ import './composition';
 import './fallback';
 import './image-template/image-template.spec';
 import './interact/interact.spec';
+import './interact/event-system.spec';
 import './math';
 import './plugins/cal/transform.spec';
 import './plugins/cal/transform-clip-mix.spec';

--- a/web-packages/test/unit/src/effects-core/interact/event-system.spec.ts
+++ b/web-packages/test/unit/src/effects-core/interact/event-system.spec.ts
@@ -1,0 +1,51 @@
+import type { Engine } from '@galacean/effects';
+import { EventSystem } from '@galacean/effects';
+
+const { expect } = chai;
+
+describe('core/interact/event-system', () => {
+  it('supports a mini-program canvas without DOM attribute and style methods', () => {
+    const listeners = new Map<string, EventListener[]>();
+    const canvas = {
+      width: 100,
+      height: 100,
+      style: {},
+      addEventListener (name: string, listener: EventListener) {
+        const handlers = listeners.get(name) ?? [];
+
+        handlers.push(listener);
+        listeners.set(name, handlers);
+      },
+      removeEventListener (name: string, listener: EventListener) {
+        const handlers = listeners.get(name);
+
+        if (handlers) {
+          const index = handlers.indexOf(listener);
+
+          if (index >= 0) {
+            handlers.splice(index, 1);
+          }
+        }
+      },
+      getBoundingClientRect () {
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          width: 100,
+          height: 100,
+          right: 100,
+          bottom: 100,
+          toJSON: () => ({}),
+        };
+      },
+    } as unknown as HTMLCanvasElement;
+    const eventSystem = new EventSystem({ compositions: [] } as unknown as Engine);
+
+    expect(() => eventSystem.bindListeners(canvas)).not.to.throw();
+    expect(listeners.get('touchstart')).to.have.length(1);
+    expect(() => eventSystem.dispose()).not.to.throw();
+    expect(listeners.get('touchstart')).to.have.length(0);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas event handling for mini-program environments that do not support standard DOM attributes, styles, or focus methods.
  * Preserved accessibility-related focus setup when supported.

* **Tests**
  * Added coverage verifying event listeners can be registered and removed safely on mini-program-style canvases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->