### PR TITLE
refactor: drive particle emitter transform via TransformTrack

### DIFF
--- a/packages/effects-core/src/fallback/index.ts
+++ b/packages/effects-core/src/fallback/index.ts
@@ -9,7 +9,7 @@ import { getStandardInteractContent } from './interact';
 import {
   version21Migration, version22Migration, version24Migration, version30Migration,
   version31Migration, version32Migration, version33Migration, version34Migration,
-  version35Migration, version36Migration, version37Migration,
+  version35Migration, version36Migration, version37Migration, version38Migration,
 } from './migration';
 import { getStandardParticleContent } from './particle';
 import { getStandardNullContent, getStandardSpriteContent } from './sprite';
@@ -38,16 +38,17 @@ export function getStandardJSON (json: any): JSONScene {
   if (v0.test(json.version)) {
     reverseParticle = (/^(\d+)/).exec(json.version)?.[0] === '0';
 
-    return version37Migration(
-      version36Migration(
-        version35Migration(
-          version34Migration(
-            version33Migration(
-              version32Migration(
-                version31Migration(
-                  version30Migration(
-                    version21Migration(
-                      getStandardJSONFromV0(json))))))))));
+    return version38Migration(
+      version37Migration(
+        version36Migration(
+          version35Migration(
+            version34Migration(
+              version33Migration(
+                version32Migration(
+                  version31Migration(
+                    version30Migration(
+                      version21Migration(
+                        getStandardJSONFromV0(json)))))))))));
   }
 
   reverseParticle = false;
@@ -89,6 +90,9 @@ export function getStandardJSON (json: any): JSONScene {
       }
       if (minorVersion < 8) {
         json = version37Migration(json);
+      }
+      if (minorVersion < 9) {
+        json = version38Migration(json);
       }
     }
 

--- a/packages/effects-core/src/fallback/migration.ts
+++ b/packages/effects-core/src/fallback/migration.ts
@@ -840,6 +840,91 @@ export function version37Migration (json: spec.JSONScene): spec.JSONScene {
 }
 
 /**
+ * 3.9 数据适配：将粒子发射器路径迁移到元素的 TransformTrack。
+ * 粒子自身的生命周期曲线仍由 ParticleSystem 消费。
+ */
+export function version38Migration (json: JSONScene): JSONScene {
+  json.miscs ??= [];
+  const assets = new Map(json.miscs.map(asset => [asset.id, asset]));
+  const items = new Map(json.items.map(item => [item.id, item]));
+  const bindings: spec.SceneBindingData[] = [];
+
+  for (const component of json.components) {
+    if (component.dataType !== DataType.CompositionComponent) {
+      continue;
+    }
+    const composition = component as spec.CompositionComponentData;
+
+    if (composition.sceneBindings) {
+      for (const binding of composition.sceneBindings) {
+        bindings.push(binding);
+      }
+    }
+  }
+
+  for (const component of json.components) {
+    if (component.dataType !== DataType.ParticleSystem) {
+      continue;
+    }
+    const particle = component as spec.ParticleSystemData;
+    const path = particle.emitterTransform?.path;
+
+    if (!path) {
+      continue;
+    }
+    const item = items.get(particle.item.id);
+    const itemBindings = bindings.filter(binding => binding.value.id === particle.item.id);
+
+    if (!item) {
+      continue;
+    }
+    for (const binding of itemBindings) {
+      const parent = assets.get(binding.key.id) as spec.TrackAssetData | undefined;
+
+      if (!parent || parent.dataType !== DataType.ObjectBindingTrack) {
+        continue;
+      }
+      const playable = {
+        id: generateGUID(),
+        dataType: DataType.TransformPlayableAsset,
+        positionOverLifetime: { path },
+      };
+      const track: spec.TrackAssetData = {
+        id: generateGUID(),
+        dataType: DataType.TransformTrack,
+        children: [],
+        clips: [{
+          start: item.delay,
+          duration: item.duration,
+          endBehavior: item.endBehavior,
+          asset: { id: playable.id },
+        }],
+      };
+
+      const existingTrack = parent.children
+        .map(child => assets.get(child.id) as spec.TrackAssetData | undefined)
+        .find(child => child?.dataType === DataType.TransformTrack);
+
+      if (existingTrack) {
+        // 使用同一个 mixer 合成已有动画与发射器路径，避免多条轨道相互覆盖。
+        existingTrack.clips.push(...track.clips);
+      } else {
+        // 放在其他行为轨道前，确保发射粒子时能读取到本帧的 transform。
+        parent.children.unshift({ id: track.id });
+        json.miscs.push(track);
+        assets.set(track.id, track);
+      }
+      json.miscs.push(playable);
+    }
+    delete particle.emitterTransform;
+  }
+
+  json.version = '3.9' as unknown as JSONSceneVersion;
+
+  return json;
+}
+
+/**
  * 确保文本组件有版本标识字段
  */
 function ensureTextVerticalAlign (options: any) {

--- a/packages/effects-core/src/plugins/particle/particle-system.ts
+++ b/packages/effects-core/src/plugins/particle/particle-system.ts
@@ -73,12 +73,6 @@ type ParticleEmissionOptions = {
   burstOffsets: Record<string, vec3[] | null>,
 };
 
-interface ParticleTransform {
-  position: Vector3,
-  rotation?: Euler,
-  path?: ValueGetter<vec3>,
-}
-
 type TrailOptions = {
   lifetime: ValueGetter<number>,
   minimumVertexDistance: number,
@@ -148,7 +142,6 @@ export class ParticleSystem extends Component implements Maskable {
   private frozen: boolean;
   private upDirectionWorld: Vector3 | null;
   private uvs: number[][];
-  private basicTransform: ParticleTransform;
   private clickedPoint: LinkNode<ParticleContent>;
 
   private particleMeshProps: ParticleMeshProps | null = null;
@@ -208,48 +201,7 @@ export class ParticleSystem extends Component implements Maskable {
     return this.ended;
   }
 
-  initEmitterTransform () {
-    const position = this.item.transform.position.clone();
-    const rotation = this.item.transform.rotation.clone();
-    const transformPath = this.props.emitterTransform && this.props.emitterTransform.path;
-    let path;
-
-    if (transformPath) {
-      if (transformPath[0] === spec.ValueType.CONSTANT_VEC3) {
-        position.add(transformPath[1]);
-      } else {
-        path = createValueGetter(transformPath);
-      }
-    }
-    this.basicTransform = {
-      position, rotation, path,
-    };
-
-    const selfPos = position.clone();
-
-    if (path) {
-      selfPos.add(path.getValue(0));
-    }
-    this.transform.setPosition(selfPos.x, selfPos.y, selfPos.z);
-
-    if (this.options.particleFollowParent) {
-      const worldMatrix = this.transform.getWorldMatrix();
-
-      this.renderer.updateWorldMatrix(worldMatrix);
-    }
-  }
-
-  private updateEmitterTransform (time: number) {
-    const { path, position } = this.basicTransform;
-    const selfPos = position.clone();
-
-    if (path) {
-      const duration = this.item.duration;
-
-      selfPos.add(path.getValue(time / duration));
-    }
-    this.transform.setPosition(selfPos.x, selfPos.y, selfPos.z);
-
+  private updateEmitterWorldMatrix () {
     if (this.options.particleFollowParent) {
       const worldMatrix = this.transform.getWorldMatrix();
 
@@ -323,7 +275,7 @@ export class ParticleSystem extends Component implements Maskable {
     this.meshes = this.renderer.meshes;
 
     this.startEmit();
-    this.initEmitterTransform();
+    this.updateEmitterWorldMatrix();
 
     this.item.on('click', ()=>{
       if (this.interaction?.behavior === spec.ParticleInteractionBehavior.removeParticle) {
@@ -387,7 +339,7 @@ export class ParticleSystem extends Component implements Maskable {
           const meshTime = now;
           const maxCount = options.maxCount;
 
-          this.updateEmitterTransform(timePassed);
+          this.updateEmitterWorldMatrix();
           const shouldSkipGenerate = () => {
             const first = link.first;
 

--- a/web-packages/test/case/copy-frame-baseline.cjs
+++ b/web-packages/test/case/copy-frame-baseline.cjs
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.resolve(__dirname, '../../..');
+const destination = path.join(root, 'web-packages/test/dist/baseline');
+const artifacts = [
+  ['packages/effects/dist/index.min.js', 'effects.js'],
+  ...['model', 'rich-text', 'spine', 'orientation-transformer'].map(name => [
+    `plugin-packages/${name}/dist/index.min.js`, `${name}.js`,
+  ]),
+];
+
+console.log('正在构建帧对比产物（pnpm build）...');
+const build = spawnSync('pnpm', ['build'], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+if (build.error || build.status !== 0) {
+  console.error('构建失败，未更新帧对比基准。', build.error?.message || build.signal || '');
+  process.exit(build.status || 1);
+}
+
+// 先检查所有产物，避免缺失文件时只更新一部分基准。
+const missing = artifacts.filter(([source]) => !fs.existsSync(path.join(root, source)));
+
+if (missing.length > 0) {
+  console.error('构建后仍缺少以下产物，未更新帧对比基准：');
+  for (const [source] of missing) {
+    console.error(`  ${source}`);
+  }
+  process.exitCode = 1;
+} else {
+  fs.mkdirSync(destination, { recursive: true });
+  for (const [source, filename] of artifacts) {
+    fs.copyFileSync(path.join(root, source), path.join(destination, filename));
+    console.log(`${source} -> web-packages/test/dist/baseline/${filename}`);
+  }
+  console.log('帧对比基准已更新，URL 加 local=true 即可使用。');
+}

--- a/web-packages/test/case/src/common/player/test-controller.ts
+++ b/web-packages/test/case/src/common/player/test-controller.ts
@@ -5,6 +5,8 @@ import { loadScript } from '../utilities';
 
 const params = new URLSearchParams(location.search);
 const oldVersion = params.get('version') || '2.9.0';  // 旧版 Player 版本
+// URL 加 local=true 时，读取 web-packages/test/dist/baseline 下的 UMD 产物。
+const useLocalBaseline = params.get('local') === 'true';
 
 const playerOptions: PlayerConfig = {
   env: 'editor',
@@ -52,13 +54,17 @@ export class TestController {
   }
 
   async loadOldPlayer (version: string) {
-    const url = `https://unpkg.com/@galacean/effects@${version}/dist/index.min.js`;
+    const url = useLocalBaseline
+      ? '/dist/baseline/effects.js'
+      : `https://unpkg.com/@galacean/effects@${version}/dist/index.min.js`;
 
     return loadScript(url);
   }
 
   async loadOldPlugin (name: string, version: string) {
-    const url = `https://unpkg.com/@galacean/effects-plugin-${name}@${version}/dist/index.min.js`;
+    const url = useLocalBaseline
+      ? `/dist/baseline/${name}.js`
+      : `https://unpkg.com/@galacean/effects-plugin-${name}@${version}/dist/index.min.js`;
 
     return loadScript(url);
   }

--- a/web-packages/test/unit/src/effects-core/plugins/particle/transform.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/particle/transform.spec.ts
@@ -203,7 +203,6 @@ describe('core/plugins/particle/transform', () => {
     // @ts-expect-error
     const { position, rotation, path } = itemContent.basicTransform;
 
-    // @ts-expect-error
     expect(sanitizeNumbers(rotation)).to.eql([0, 0, -180]);
     expect(position.toArray()).to.eql([0, 0, 0]);
     expect(path).to.be.an.instanceof(BezierCurvePath);

--- a/web-packages/test/unit/src/effects-core/plugins/particle/transform.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/particle/transform.spec.ts
@@ -1,4 +1,5 @@
-import { Player, ParticleSystem, VFXItem, BezierCurvePath, ParticleSystemRenderer } from '@galacean/effects';
+import { Player, ParticleSystem, VFXItem, createValueGetter, ParticleSystemRenderer } from '@galacean/effects';
+import { ensureFixedVec3 } from '../../../../../../../packages/effects-core/src/fallback/utils';
 import { sanitizeNumbers } from '../../../utils';
 
 const { expect } = chai;
@@ -181,13 +182,15 @@ describe('core/plugins/particle/transform', () => {
   });
 
   it('transform path with asMovement', async () => {
+    const pathData = [7, [[[0, 0, 1, 1], [1, 1, 1, 1]], [[0, -1.5, -1], [0.2, 1.2, 0]], [[1, 1, 0], [2, 1, 0]]]];
+
     const comp = await generateComposition(player, [{
       name: 'item',
       type: '2',
       transform: {
         position: [0, 0, 0],
         rotation: [0, 0, -180],
-        path: [7, [[[0, 0, 1, 1], [1, 1, 1, 1]], [[0, -1.5, -1], [0.2, 1.2, 0]], [[1, 1, 0], [2, 1, 0]]]],
+        path: pathData,
       },
       velocityOverLifetime: {
         asMovement: true,
@@ -200,12 +203,26 @@ describe('core/plugins/particle/transform', () => {
     expect(item).to.be.instanceof(VFXItem);
     expect(itemContent).to.be.an.instanceof(ParticleSystem);
 
-    // @ts-expect-error
-    const { position, rotation, path } = itemContent.basicTransform;
+    const path = createValueGetter(ensureFixedVec3(pathData)!);
+    const createPoint = itemContent.createPoint.bind(itemContent);
+    const emissionPositions: number[][] = [];
 
-    expect(sanitizeNumbers(rotation)).to.eql([0, 0, -180]);
-    expect(position.toArray()).to.eql([0, 0, 0]);
-    expect(path).to.be.an.instanceof(BezierCurvePath);
+    itemContent.createPoint = lifetime => {
+      emissionPositions.push(item.transform.position.toArray());
+
+      return createPoint(lifetime);
+    };
+    // 直接 seek：轨道求值目标帧，补算粒子时使用该帧的发射器位置。
+    player.gotoAndStop(2.5);
+    const expectedPosition = path.getValue(2.5 / item.duration).toArray();
+
+    expect(emissionPositions.length).to.be.greaterThan(1);
+    for (const position of [...emissionPositions, item.transform.position.toArray()]) {
+      position.forEach((value, index) => {
+        expect(value).to.be.closeTo(expectedPosition[index], 1e-6);
+      });
+    }
+    expect(sanitizeNumbers(item.transform.rotation.toArray())).to.eql([0, 0, -180]);
     expect(item.getComponent(ParticleSystemRenderer).particleMesh.linearVelOverLifetime?.asMovement).to.be.true;
     expect(item.getComponent(ParticleSystemRenderer).particleMesh.speedOverLifetime).to.not.exist;
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when loading legacy and older scene files by updating particle emitter transform data automatically.
  - Particle emitters now follow parent transformations more reliably during playback.
  - Updated particle path behavior to preserve expected emission positions and item transforms.

- **Tests**
  - Added coverage for legacy scene conversion and particle transform behavior.
  - Added a local baseline workflow for validating player and plugin builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->