### PR TITLE
refactor: move timeline playback control into CompositionComponent

### DIFF
--- a/packages/effects-core/README-zh_CN.md
+++ b/packages/effects-core/README-zh_CN.md
@@ -82,15 +82,15 @@ const assetManager = new AssetManager(options);
 管理动画播放的数据处理与渲染：
 
 ```typescript
-const composition = new Composition(props, scene);
+const composition = new Composition(engine, props, scene);
 
 // 播放控制
 composition.play();
 composition.pause();
 composition.resume();
 
-// 更新
-composition.update(deltaTime);
+// 更新并渲染全部合成，deltaTime 单位为毫秒
+engine.mainLoop(deltaTime);
 
 // 销毁
 composition.dispose();
@@ -100,7 +100,12 @@ composition.dispose();
 - `renderFrame`：当前帧的渲染数据对象
 - `rootItem`：合成根元素
 - `camera`：合成相机
-- `speed`：播放速度
+- `speed`：时间轴播放速度
+
+播放接口转发到根 `CompositionComponent`。暂停、倍速、跳帧和重播仅影响时间轴；
+处于启用状态的 Animator 和脚本使用 Engine 的帧时间，时间轴暂停时仍会更新。
+跳帧立即求值时间轴，普通组件在下一次 Engine 帧更新时执行。
+组件注册和生命周期仍由合成所属场景管理。
 
 ### 4. VFX 元素 [VFXItem](./src/vfx-item.ts)
 

--- a/packages/effects-core/README.md
+++ b/packages/effects-core/README.md
@@ -82,15 +82,15 @@ Supported features:
 Manages data processing and rendering for animation playback:
 
 ```typescript
-const composition = new Composition(props, scene);
+const composition = new Composition(engine, props, scene);
 
 // Playback control
 composition.play();
 composition.pause();
 composition.resume();
 
-// Update
-composition.update(deltaTime);
+// Advance and render all compositions (deltaTime is in milliseconds).
+engine.mainLoop(deltaTime);
 
 // Dispose
 composition.dispose();
@@ -100,7 +100,13 @@ Main properties:
 - `renderFrame`: The rendering data object for the current frame
 - `rootItem`: The root element of the composition
 - `camera`: The composition camera
-- `speed`: Playback speed
+- `speed`: Timeline playback speed
+
+Playback controls delegate to the root `CompositionComponent`. Pause, speed, seek,
+and restart affect only the timeline. Enabled Animator and script components use
+the engine's frame delta, even when the timeline is paused. Seeking evaluates the
+timeline immediately; ordinary component updates run on the next engine frame.
+Component registration and lifecycle remain owned by the composition's scene.
 
 ### 4. VFX Element [VFXItem](./src/vfx-item.ts)
 

--- a/packages/effects-core/src/components/composition-component.ts
+++ b/packages/effects-core/src/components/composition-component.ts
@@ -3,8 +3,9 @@ import type { TrackAsset, TimelineAsset } from '../plugins';
 import { TimelineInstance, PlayState } from '../plugins';
 import { VFXItem } from '../vfx-item';
 import { effectsClass } from '../decorators';
+import { EventEmitter } from '../events';
+import type { EventEmitterListener, EventEmitterOptions } from '../events';
 import { Component } from './component';
-import { decimalEqual } from '../math';
 
 export interface SceneBinding {
   key: TrackAsset,
@@ -20,6 +21,10 @@ export enum UpdateModes {
   EveryUpdate,
   Manual,
 }
+
+export type CompositionComponentEvent = {
+  end: [CompositionComponent],
+};
 
 /**
  * @since 2.0.0
@@ -40,16 +45,53 @@ export class CompositionComponent extends Component {
 
   playOnStart = false;
 
-  endBehavior = spec.EndBehavior.forward;
+  speed = 1;
+  /** Absolute start of the timeline, in seconds. */
+  startTime = 0;
+  isEnded = false;
+  private isEndCalled = false;
+  private readonly eventEmitter = new EventEmitter<CompositionComponentEvent>();
 
   private time = 0;
-  private lastTime = 0;
   private sceneBindings: SceneBinding[] = [];
   private timelineAsset: TimelineAsset | null = null;
   private _timelineInstance: TimelineInstance | null = null;
   private nestedCompositions: CompositionComponent[] = [];
 
+  get endBehavior () {
+    return this.item.endBehavior;
+  }
+
+  set endBehavior (value: spec.EndBehavior) {
+    this.item.endBehavior = value;
+  }
+
   private get timelineInstance (): TimelineInstance | null {
+    this.initializeTimeline();
+
+    return this._timelineInstance;
+  }
+
+  on<E extends keyof CompositionComponentEvent> (
+    eventName: E,
+    listener: EventEmitterListener<CompositionComponentEvent[E]>,
+    options?: EventEmitterOptions,
+  ) {
+    this.eventEmitter.on(eventName, listener, options);
+  }
+
+  off<E extends keyof CompositionComponentEvent> (
+    eventName: E,
+    listener: EventEmitterListener<CompositionComponentEvent[E]>,
+  ) {
+    this.eventEmitter.off(eventName, listener);
+  }
+
+  override onAwake () {
+    this.initializeTimeline();
+  }
+
+  private initializeTimeline () {
     if (!this._timelineInstance && this.timelineAsset) {
       this._timelineInstance = new TimelineInstance(this.timelineAsset, this.sceneBindings);
 
@@ -62,13 +104,10 @@ export class CompositionComponent extends Component {
         if (boundObject instanceof VFXItem && VFXItem.isComposition(boundObject)) {
           const nestedComposition = boundObject.getComponent(CompositionComponent);
 
-          nestedComposition.updateMode = UpdateModes.Manual;  // 嵌套预合成由父级预合成驱动更新
           this.nestedCompositions.push(nestedComposition);
         }
       }
     }
-
-    return this._timelineInstance;
   }
 
   override onEnable () {
@@ -111,8 +150,8 @@ export class CompositionComponent extends Component {
 
   stop () {
     this.state = PlayState.Stopped;
-    this.time = 0;
-    this.lastTime = 0;
+    this.time = this.startTime;
+    this.resetEndState();
 
     for (const subComposition of this.nestedCompositions) {
       subComposition.stop();
@@ -124,7 +163,7 @@ export class CompositionComponent extends Component {
   }
 
   setTime (time: number) {
-    this.time = time;
+    this.evaluateAt(time);
   }
 
   override onUpdate (dt: number): void {
@@ -133,44 +172,91 @@ export class CompositionComponent extends Component {
     }
 
     if (this.updateMode === UpdateModes.EveryUpdate) {
-      this.tick(dt / 1000);
+      this.tick(dt / 1000 * this.speed);
     }
   }
 
   tick (deltaTime: number) {
-    if (!this.timelineInstance) {
+    this.evaluateAt(this.time + deltaTime);
+  }
+
+  /** Apply playback end behavior and sample the timeline without advancing other components. */
+  evaluateAt (time: number) {
+    if (!this.item) {
       return;
     }
+    const previousTime = this.time;
+    let localTime = time - this.startTime;
 
-    let time = this.time;
-
-    if (decimalEqual(this.lastTime, this.time)) {
-      time += deltaTime;
+    if (time < previousTime && localTime < 0) {
+      localTime = 0;
     }
+    const duration = this.item.duration;
+    const isEnded = localTime >= duration;
 
-    if (time > this.item.duration) {
+    if (this.isEnded !== isEnded) {
+      this.isEndCalled = false;
+    }
+    this.isEnded = isEnded;
+
+    if (isEnded) {
       switch (this.endBehavior) {
         case spec.EndBehavior.forward:
 
           break;
         case spec.EndBehavior.freeze:
-          time = this.item.duration;
+          localTime = duration;
 
           break;
         case spec.EndBehavior.restart:
-          time = time % this.item.duration;
+          localTime = duration > 0 ? localTime % duration : 0;
+          if (duration > 0) {
+            this.isEndCalled = false;
+          }
 
           break;
         case spec.EndBehavior.destroy:
-          this.item.dispose();
-
-          return;
+          break;
       }
     }
 
-    this.timelineInstance.evaluate(time, deltaTime);
+    this.sampleTime(localTime + this.startTime);
+    if (this.isEnded) {
+      this.emitEnd();
+      if (this.item && this.endBehavior === spec.EndBehavior.destroy
+        && this.item !== this.item.composition?.sceneRoot) {
+        this.item.dispose();
+      }
+    }
+  }
 
-    this.lastTime = this.time = time;
+  private emitEnd () {
+    if (!this.isEndCalled) {
+      this.isEndCalled = true;
+      this.eventEmitter.emit('end', this);
+    }
+  }
+
+  /**
+   * Sample an absolute timeline time in seconds, already mapped by the caller.
+   * Parent clips own the playback range of nested compositions; do not apply
+   * this component's standalone end behavior or update its end state here.
+   * @internal
+   */
+  sampleTime (time: number) {
+    const previousTime = this.time;
+
+    this.timelineInstance?.evaluate(time, time - previousTime);
+    this.time = time;
+    if (this.updateMode === UpdateModes.EveryUpdate || this.item === this.item.composition?.sceneRoot) {
+      this.setChildrenRenderOrder(0);
+    }
+  }
+
+  /** @internal */
+  resetEndState () {
+    this.isEnded = false;
+    this.isEndCalled = false;
   }
 
   /**

--- a/packages/effects-core/src/composition.ts
+++ b/packages/effects-core/src/composition.ts
@@ -12,7 +12,7 @@ import { RenderFrame } from './render';
 import type { Scene } from './scene';
 import { TextureLoadAction, type Texture } from './texture';
 import type { Constructor, Disposable, LostHandler } from './utils';
-import { assertExist, generateGUID, logger, noop } from './utils';
+import { assertExist, generateGUID, noop } from './utils';
 import { VFXItem } from './vfx-item';
 import type { CompositionEvent } from './events';
 import { EventEmitter } from './events';
@@ -124,7 +124,13 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   /**
    * 动画播放速度
    */
-  speed = 1;
+  get speed () {
+    return this.rootComposition.speed;
+  }
+
+  set speed (value: number) {
+    this.rootComposition.speed = value;
+  }
   /**
    * 是否卸载纹理贴图，就是将纹理贴图大小设置为1x1
    */
@@ -162,7 +168,9 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   /**
    * 合成是否结束
    */
-  isEnded = false;
+  get isEnded () {
+    return this.rootComposition.isEnded;
+  }
   /**
    * 合成id
    */
@@ -198,7 +206,9 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   /**
    * 合成开始渲染的时间
    */
-  readonly startTime: number = 0;
+  get startTime () {
+    return this.rootComposition.startTime;
+  }
   /**
    * 插件元素根元素
    */
@@ -224,11 +234,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
    */
   protected destroyed = false;
   protected rootComposition: CompositionComponent;
-  /**
-   * 合成暂停/播放 标识
-   */
-  private paused = true;
-  private isEndCalled = false;
   private _renderOrder = 0;
   private _interactive = true;
   private _textures: Texture[] = [];
@@ -318,8 +323,14 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
     this.sceneRoot.name = 'sceneRoot';
 
     this.rootComposition = this.sceneRoot.getComponent(CompositionComponent) ?? this.sceneRoot.addComponent(CompositionComponent);
-    this.rootComposition.updateMode = UpdateModes.Manual;
-    this.rootComposition.play();
+    this.rootComposition.updateMode = UpdateModes.EveryUpdate;
+    this.rootComposition.pause();
+    this.rootComposition.on('end', () => {
+      this.emit('end', { composition: this });
+      if (this.shouldDispose()) {
+        this.dispose();
+      }
+    });
 
     // Bind animation event
     this.sceneRoot.on('animationevent', eventData => {
@@ -330,7 +341,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
 
     this.renderOrder = baseRenderOrder;
     this.id = sourceContent?.id ?? generateGUID();
-    this.startTime = sourceContent?.startTime ?? 0;
+    this.rootComposition.startTime = sourceContent?.startTime ?? 0;
     this.event = engine.eventSystem;
     this.statistic = {
       loadStart: scene?.startTime ?? 0,
@@ -499,7 +510,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
    * 暂停合成的播放
    */
   pause () {
-    this.paused = true;
+    this.rootComposition.pause();
     this.emit('pause');
   }
 
@@ -508,14 +519,14 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
    * @returns
    */
   getPaused () {
-    return this.paused;
+    return this.rootComposition.state !== PlayState.Playing;
   }
 
   /**
    * 恢复合成的播放
    */
   resume () {
-    this.paused = false;
+    this.rootComposition.play();
     if (this.isEnded && this.reusable) {
       this.restart();
     }
@@ -561,18 +572,7 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
    * @param time - 相对 startTime 的时间
    */
   setTime (time: number) {
-    const speed = this.speed;
-    const pause = this.getPaused();
-
-    if (pause) {
-      this.resume();
-    }
-    this.setSpeed(1);
-    this.forwardTime(time + this.startTime);
-    this.setSpeed(speed);
-    if (pause) {
-      this.paused = true;
-    }
+    this.rootComposition.setTime(time + this.startTime);
   }
 
   addItem (item: VFXItem) {
@@ -590,21 +590,10 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
   }
 
   /**
-   * 前进合成到指定时间
-   * @param time - 相对0时刻的时间
-   */
-  private forwardTime (time: number) {
-    const deltaTime = time * 1000 - this.time * 1000;
-
-    this.update(deltaTime);
-  }
-
-  /**
    * 重置状态函数
    */
   protected reset () {
-    this.isEnded = false;
-    this.isEndCalled = false;
+    this.rootComposition.resetEndState();
   }
 
   /** Renders this Composition content. Screen-space UI is rendered by Engine. */
@@ -619,106 +608,8 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
     this.renderer.renderRenderFrame(this.renderFrame);
   }
 
-  /**
-   * 合成更新，针对所有 item 的更新
-   * @param deltaTime - 更新的时间步长
-   */
-  update (deltaTime: number) {
-    if (this.getPaused()) {
-      return;
-    }
-
-    const previousCompositionTime = this.time;
-
-    this.updateCompositionTime(deltaTime * this.speed / 1000);
-    const deltaTimeInMs = (this.time - previousCompositionTime) * 1000;
-
-    this.rootComposition.setChildrenRenderOrder(0);
-
-    this.sceneTicking.update.tick(deltaTimeInMs);
-    this.sceneTicking.lateUpdate.tick(deltaTimeInMs);
-
-    this.updateCamera();
-
-    if (this.isEnded && !this.isEndCalled) {
-      this.isEndCalled = true;
-      this.emit('end', { composition: this });
-    }
-    if (this.shouldDispose()) {
-      this.dispose();
-    }
-  }
-
   private shouldDispose () {
     return this.isEnded && this.sceneRoot.endBehavior === spec.EndBehavior.destroy && !this.reusable;
-  }
-
-  /**
-   * 更新相机
-   * @override
-   */
-  private updateCamera () {
-    this.camera.updateMatrix();
-  }
-
-  /**
-   * 更新主合成组件
-   */
-  private updateCompositionTime (deltaTime: number) {
-    if (this.rootComposition.state !== PlayState.Playing || !this.rootComposition.isActiveAndEnabled) {
-      return;
-    }
-
-    // 相对于合成开始时间的时间
-    let localTime = this.time + deltaTime - this.startTime;
-
-    if (deltaTime < 0 && localTime < 0) {
-      localTime = 0;
-    }
-
-    const duration = this.sceneRoot.duration;
-    const endBehavior = this.sceneRoot.endBehavior;
-
-    let isEnded = false;
-
-    if (localTime >= duration) {
-
-      isEnded = true;
-
-      switch (endBehavior) {
-        case spec.EndBehavior.restart: {
-          localTime = localTime % duration;
-          this.restart();
-
-          break;
-        }
-        case spec.EndBehavior.freeze: {
-          localTime = Math.min(duration, localTime);
-
-          break;
-        }
-        case spec.EndBehavior.forward: {
-
-          break;
-        }
-        case spec.EndBehavior.destroy: {
-
-          break;
-        }
-      }
-    }
-
-    this.rootComposition.tick(localTime + this.startTime - this.rootComposition.getTime());
-
-    // end state changed, handle onEnd flags
-    if (this.isEnded !== isEnded) {
-      if (isEnded) {
-        this.isEnded = true;
-      } else {
-        this.isEnded = false;
-        this.isEndCalled = false;
-      }
-    }
   }
 
   /**
@@ -885,12 +776,6 @@ export class Composition extends EventEmitter<CompositionEvent<Composition>> imp
     // FIXME: 注意这里增加了renderFrame销毁
     this.renderFrame.dispose();
     PluginSystem.notifyCompositionDestroy(this);
-
-    this.update = () => {
-      if (!__DEBUG__) {
-        logger.error(`Update disposed composition: ${this.name}.`);
-      }
-    };
 
     this.dispose = noop;
     this.renderer.engine.removeComposition(this);

--- a/packages/effects-core/src/engine.ts
+++ b/packages/effects-core/src/engine.ts
@@ -340,41 +340,54 @@ export class Engine extends EventEmitter<EngineEvent> implements Disposable {
       return;
     }
 
-    dt = Math.min(dt, 33) * this.speed;
+    dt *= this.speed;
 
     // Sort compositions by index
     //-------------------------------------------------------------------------
 
     const compositions = this.compositions;
 
-    let skipRender = false;
+    for (const composition of compositions) {
+      if (composition.textureOffloaded) {
+        const error = new Error(`Composition ${composition.name} cannot update while its textures are offloaded.`);
+
+        logger.error(error.message);
+        this.ticker?.pause();
+        this.emit('rendererror', error);
+
+        return;
+      }
+    }
 
     // Update Compositions
     //-------------------------------------------------------------------------
 
     for (const composition of compositions) {
-      if (composition.textureOffloaded) {
-        skipRender = true;
-        logger.error(`Composition ${composition.name} texture offloaded, skip render.`);
-        continue;
-      }
-
-      composition.update(dt);
+      composition.sceneTicking.update.tick(dt);
     }
 
-    if (skipRender) {
-      this.emit('rendererror', new Error('Play when texture offloaded.'));
-      this.ticker?.pause();
-
-      return;
+    for (const composition of compositions) {
+      composition.sceneTicking.lateUpdate.tick(dt);
     }
 
     this.emit('update', dt);
+
+    this.renderFrame();
+  }
+
+  /** Render current scene state without advancing timelines, Animator or scripts. */
+  renderFrame (): void {
+    if (this.contextWasLost || this.renderErrors.size > 0) {
+      return;
+    }
+
+    const compositions = this.compositions;
 
     // Tick compositions onPreRender
     //-------------------------------------------------------------------------
 
     for (const composition of compositions) {
+      composition.camera.updateMatrix();
       composition.sceneTicking.preRender.tick(0);
     }
 

--- a/packages/effects-core/src/plugins/timeline/playables/sub-composition-clip-playable.ts
+++ b/packages/effects-core/src/plugins/timeline/playables/sub-composition-clip-playable.ts
@@ -7,7 +7,9 @@ export class SubCompositionClipPlayable extends Playable {
     const boundObject = context.output.getUserData();
 
     if (boundObject instanceof CompositionComponent) {
-      boundObject.tick(this.getTime() - boundObject.getTime());
+      // RuntimeClip has already mapped parent time through the clip's range
+      // and end behavior, so sample that time directly.
+      boundObject.sampleTime(this.getTime());
     }
   }
 }

--- a/packages/effects-core/src/plugins/timeline/tracks/sub-composition-track.ts
+++ b/packages/effects-core/src/plugins/timeline/tracks/sub-composition-track.ts
@@ -1,5 +1,5 @@
 import * as spec from '@galacean/effects-specification';
-import { CompositionComponent } from '../../../components';
+import { CompositionComponent, UpdateModes } from '../../../components';
 import { effectsClass } from '../../../decorators';
 import { VFXItem } from '../../../vfx-item';
 import type { TrackMixerPlayable } from '../playables';
@@ -14,7 +14,12 @@ export class SubCompositionTrack extends TrackAsset {
       throw new Error('SubCompositionTrack needs to be set under the VFXItem track.');
     }
 
-    return boundObject.getComponent(CompositionComponent);
+    const composition = boundObject.getComponent(CompositionComponent);
+
+    // The parent clip owns this component's time as soon as it is bound.
+    composition.updateMode = UpdateModes.Manual;
+
+    return composition;
   }
 
   override createTrackMixer (): TrackMixerPlayable {

--- a/packages/effects-threejs/src/three-display-object.ts
+++ b/packages/effects-threejs/src/three-display-object.ts
@@ -180,10 +180,18 @@ export class ThreeDisplayObject extends THREE.Group {
    * @param delta
    */
   update (delta: number) {
-    this.compositions.forEach(composition => {
-      composition.update(delta);
+    const compositions = this.compositions;
 
+    for (const composition of compositions) {
+      composition.sceneTicking.update.tick(delta);
+    }
+    for (const composition of compositions) {
+      composition.sceneTicking.lateUpdate.tick(delta);
+    }
+    for (const composition of compositions) {
+      composition.camera.updateMatrix();
+      composition.sceneTicking.preRender.tick(0);
       composition.render();
-    });
+    }
   }
 }

--- a/plugin-packages/model/test/src/model-plugin.spec.ts
+++ b/plugin-packages/model/test/src/model-plugin.spec.ts
@@ -21,7 +21,7 @@ describe('mode plugin test', () => {
 
     expect(() => {
       comp.play();
-      comp.update(0);
+      player.engine.mainLoop(0);
     }).not.to.throw();
 
     comp.dispose();

--- a/web-packages/demo/src/three-large-scene.ts
+++ b/web-packages/demo/src/three-large-scene.ts
@@ -86,14 +86,25 @@ const jsons: [url: string, pos: number[], scale?: number][] = [
   let lastTime = performance.now();
 
   function render () {
+    const now = performance.now();
+    const delta = now - lastTime;
+
     for (const group of groups) {
       const { currentComposition } = group;
 
       if (!currentComposition.isDestroyed) {
-        currentComposition.update(performance.now() - lastTime);
+        currentComposition.sceneTicking.update.tick(delta);
       }
     }
-    lastTime = performance.now();
+    for (const group of groups) {
+      if (!group.currentComposition.isDestroyed) {
+        group.currentComposition.sceneTicking.lateUpdate.tick(delta);
+      }
+    }
+    for (const group of groups) {
+      group.currentComposition.camera.updateMatrix();
+    }
+    lastTime = now;
     // 标志板设置
     groups[2].lookAt(camera.position.x, camera.position.y, camera.position.z);
     renderThree();

--- a/web-packages/test/case/src/common/player/test-player.ts
+++ b/web-packages/test/case/src/common/player/test-player.ts
@@ -54,6 +54,7 @@ export class TestPlayer {
     // @ts-expect-error
     Math.seedrandom('runtime');
     this.clearResource();
+    this.lastTime = 0;
 
     const assetManager = new this.assetManager({ ...loadOptions, timeout: 100 });
     let json: spec.JSONScene | string = url;
@@ -78,11 +79,14 @@ export class TestPlayer {
 
   gotoTime (newtime: number) {
     const time = newtime;
+    const deltaTime = (time - this.lastTime) * 1000;
 
-    this.lastTime = newtime;
+    this.lastTime = time;
     // @ts-expect-error
     Math.seedrandom(`runtime${time}`);
-    this.player.gotoAndStop(time);
+    // Seek the timeline separately from advancing Animator and scripts.
+    this.composition.gotoAndStop(time);
+    this.player.engine.mainLoop(deltaTime);
   }
 
   // The returned buffer is reused by the next read on this player.

--- a/web-packages/test/unit/src/effects-core/components/lifecycle.spec.ts
+++ b/web-packages/test/unit/src/effects-core/components/lifecycle.spec.ts
@@ -473,7 +473,8 @@ describe('core/components/lifecycle', () => {
     parent.setParent(composition.sceneRoot);
     events = [];
     composition.resume();
-    composition.update(16);
+    composition.sceneTicking.update.tick(16);
+    composition.sceneTicking.lateUpdate.tick(16);
     expect(events).deep.equals(['child:update', 'timeline', 'child:late']);
   });
 
@@ -490,10 +491,13 @@ describe('core/components/lifecycle', () => {
     expect(created.root.isDuringPlay).equals(true);
     expect(events).deep.equals(['sceneRoot:awake', 'sceneRoot:start', 'sceneRoot:enable']);
     events = [];
-    created.update(16);
-    expect(events).deep.equals([]);
+    created.sceneTicking.update.tick(16);
+    created.sceneTicking.lateUpdate.tick(16);
+    expect(events).deep.equals(['sceneRoot:update', 'sceneRoot:late']);
+    events = [];
     created.resume();
-    created.update(16);
+    created.sceneTicking.update.tick(16);
+    created.sceneTicking.lateUpdate.tick(16);
     expect(events).deep.equals(['sceneRoot:update', 'sceneRoot:late']);
   });
 

--- a/web-packages/test/unit/src/effects-core/composition/composition.spec.ts
+++ b/web-packages/test/unit/src/effects-core/composition/composition.spec.ts
@@ -197,7 +197,7 @@ describe('core/composition', () => {
     expect(comp.getPaused()).equals(true);
     expect(comp.getSpeed()).equals(2);
     comp.resume();
-    comp.update(100);
+    comp.sceneTicking.update.tick(100);
     expect(comp.time).closeTo(1.5, 0.000001);
     comp.restart();
     expect(comp.time).closeTo(1.3, 0.000001);
@@ -214,7 +214,7 @@ describe('core/composition', () => {
     expect(comp.time).closeTo(0, 0.000001);
     expect(comp.isEnded).equals(false);
     expect(comp.getPaused()).equals(false);
-    comp.update(100);
+    comp.sceneTicking.update.tick(100);
     expect(comp.time).closeTo(0.1, 0.000001);
   });
 

--- a/web-packages/test/unit/src/effects-core/engine-plugin.spec.ts
+++ b/web-packages/test/unit/src/effects-core/engine-plugin.spec.ts
@@ -12,7 +12,8 @@ describe('core/engine/plugin-engine-lifetime', () => {
     const composition = new Composition(player.engine);
     const order: string[] = [];
 
-    composition.update = () => order.push('composition-update');
+    composition.sceneTicking.update.tick = () => order.push('composition-update');
+    composition.sceneTicking.lateUpdate.tick = () => order.push('composition-lateupdate');
     composition.sceneTicking.preRender.tick = () => order.push('composition-prerender');
     composition.renderContent = () => order.push('composition-render');
     player.engine.renderTargetPool.flush = () => order.push('pool-flush');
@@ -23,6 +24,7 @@ describe('core/engine/plugin-engine-lifetime', () => {
 
     expect(order).deep.equals([
       'composition-update',
+      'composition-lateupdate',
       'engine-update:16',
       'composition-prerender',
       'composition-render',

--- a/web-packages/test/unit/src/effects-core/interact/interact.spec.ts
+++ b/web-packages/test/unit/src/effects-core/interact/interact.spec.ts
@@ -20,6 +20,7 @@ describe('core/interact/item', () => {
     canvas,
     pixelRatio: 1,
     interactive: true,
+    manualRender: true,
   };
 
   before(() => {
@@ -501,9 +502,11 @@ describe('core/interact/item', () => {
     comp.play();
 
     player?.gotoAndStop(0.1);
+    player.engine.mainLoop(100);
     expect(messagePhrase).to.eql(spec.MESSAGE_ITEM_PHRASE_BEGIN, 'MESSAGE_ITEM_PHRASE_BEGIN');
 
     player?.gotoAndStop(0.3);
+    player.engine.mainLoop(200);
     expect(messagePhrase).to.eql(spec.MESSAGE_ITEM_PHRASE_END, 'MESSAGE_ITEM_PHRASE_END');
     expect(messageSpy).to.have.been.called.twice;
     comp?.dispose();

--- a/web-packages/test/unit/src/effects-core/plugins/particle/transform.spec.ts
+++ b/web-packages/test/unit/src/effects-core/plugins/particle/transform.spec.ts
@@ -148,8 +148,8 @@ describe('core/plugins/particle/transform', () => {
       { id: 2, type: '2', name: '1', transform: { position: [1, 0, 0] } },
     ]);
 
-    // @ts-expect-error
-    comp.forwardTime(1);
+    comp.gotoAndStop(1);
+    player.engine.mainLoop(1000);
     const item = comp.getItemByName('1')!;
     const itemContent = item.getComponent(ParticleSystem);
     const pos = itemContent.getPointPositionByIndex(0)!;
@@ -165,8 +165,8 @@ describe('core/plugins/particle/transform', () => {
       { type: '3', id: '1', transform: { position: [1, 0, 0], rotation: [0, 0, 90], scale: [1, 1, 1] } },
     ]);
 
-    // @ts-expect-error
-    comp.forwardTime(1);
+    comp.gotoAndStop(1);
+    player.engine.mainLoop(1000);
     const item = comp.getItemByName('1')!;
     const itemContent = item.getComponent(ParticleSystem);
     const pos = itemContent.getPointPositionByIndex(0)!;

--- a/web-packages/test/unit/src/plugin-gui/gui-editor-controls.spec.ts
+++ b/web-packages/test/unit/src/plugin-gui/gui-editor-controls.spec.ts
@@ -240,7 +240,7 @@ describe('plugin-gui/editor controls', () => {
     popup.setSize(100, 80);
     popup.popup(new math.Vector2(290, 140), source);
     expect(popup.visible).equals(true);
-    expect(popup.x).closeTo(200, 0.1);
+    expect(popup.x + popup.width).closeTo(root.width, 0.1);
     expect(popup.y).equals(70);
     expect(popup.getThemeColor('fontColor').toArray()).deep.equals([0.3, 0.4, 0.5, 1]);
     expect(popup.hasFocus()).equals(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added timeline playback controls, including configurable speed and start time.
  - Added playback completion status and end events.
  - Seeking now evaluates the timeline immediately, while enabled components continue updating with engine frames.
  - Added manual frame rendering support for scenes that need rendering without advancing timelines.

- **Changes**
  - Composition playback and lifecycle are now coordinated through scene ticking.
  - Stopping playback resets it to the configured start time.
  - Removed the need to manually call the composition update method. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->